### PR TITLE
Metro progress refactor

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyChecker.ts
+++ b/packages/vscode-extension/src/dependency/DependencyChecker.ts
@@ -169,7 +169,9 @@ export class DependencyChecker implements Disposable {
     const installed = await checkIosDependenciesInstalled();
     const nodeModulesInstalled = await this.checkNodeModulesInstalled();
     const errorMessage = "iOS dependencies are not installed.";
-    const extraInfoMessage = nodeModulesInstalled ? "" : "  Node modules need to be installed first.";
+    const extraInfoMessage = nodeModulesInstalled
+      ? ""
+      : "  Node modules need to be installed first.";
 
     this.webview.postMessage({
       command: "isPodsInstalled",

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -71,11 +71,11 @@ export class Metro implements Disposable {
     await this.startPromise;
   }
 
-  public async start(resetCache: boolean) {
+  public async start(resetCache: boolean, progressListener: (newStageProgress: number) => void) {
     if (this.startPromise) {
       throw new Error("metro already started");
     }
-    this.startPromise = this.startInternal(resetCache);
+    this.startPromise = this.startInternal(resetCache, progressListener);
     return this.startPromise;
   }
 
@@ -118,7 +118,10 @@ export class Metro implements Disposable {
     );
   }
 
-  public async startInternal(resetCache: boolean) {
+  public async startInternal(
+    resetCache: boolean,
+    progressListener: (newStageProgress: number) => void
+  ) {
     let appRootFolder = getAppRootFolder();
     await this.devtools.ready();
 
@@ -165,9 +168,7 @@ export class Metro implements Disposable {
           if (event.type === "bundle_transform_progressed") {
             // Because totalFileCount grows as bundle_transform progresses at the begining there are a few logs that indicate 100% progress thats why we ignore them
             if (event.totalFileCount > 10) {
-              Project.currentProject!.stageProgressListener(
-                event.transformedFileCount / event.totalFileCount
-              );
+              progressListener(event.transformedFileCount / event.totalFileCount);
             }
           } else if (event.type === "client_log" && event.level === "error") {
             Logger.error(stripAnsi(event.data[0]));

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -214,7 +214,9 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     });
 
     Logger.debug(`Launching metro`);
-    const waitForMetro = this.metro.start(forceCleanBuild);
+    const waitForMetro = this.metro.start(forceCleanBuild, (newStageProgress: number) => {
+      this.stageProgressListener(newStageProgress);
+    });
   }
 
   public async dispatchTouch(xRatio: number, yRatio: number, type: "Up" | "Move" | "Down") {
@@ -342,7 +344,9 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
         this.buildManager.startBuild(
           deviceInfo.platform,
           forceCleanBuild,
-          this.stageProgressListener.bind(this)
+          (newStageProgress: number) => {
+            this.stageProgressListener(newStageProgress);
+          }
         )
       );
       this.deviceSession = newDeviceSession;


### PR DESCRIPTION
Before:

metro was updating stage progres by looking up Project singleton instance and calling Project.currentProject!.updateStageProgress

After:

updateStageProgress was renamed to more appropriate stageProgressListener
stageProgressListener is passed as an argument to metro.start