### PR TITLE
Android progress indication and refactor of progress logic

### DIFF
--- a/packages/vscode-extension/lib/android/initscript.gradle
+++ b/packages/vscode-extension/lib/android/initscript.gradle
@@ -6,3 +6,8 @@ gradle.allprojects { project ->
         }
     }
 }
+
+// This is a functionality that is used by BuildAndroidProgressProcessor 
+gradle.taskGraph.whenReady { graph ->
+    println "React-Native-IDE:TaskGraphSize: ${graph.allTasks.size()}"
+}

--- a/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
@@ -1,0 +1,28 @@
+import { BuildProgressProcessor } from "./BuildProgressProcessor";
+
+export class BuildAndroidProgressProcessor implements BuildProgressProcessor {
+  private completedTasks: number = 0;
+  private tasksToComplete: number = 0;
+
+  constructor(private progressListener: (newProgress: number) => void) {}
+
+  private updateProgress() {
+    if (!this.tasksToComplete) {
+      return;
+    }
+    this.progressListener(this.completedTasks / this.tasksToComplete);
+  }
+
+  processLine(line: string): void {
+    const taskGrapfSizeMatch = /React-Native-IDE:TaskGraphSize: (\d+)/m.exec(line);
+
+    if (taskGrapfSizeMatch) {
+      this.tasksToComplete += Number(taskGrapfSizeMatch[1]);
+    }
+    const taskExecutedMatch = /> Task /m.exec(line);
+    if (taskExecutedMatch) {
+      this.completedTasks++;
+      this.updateProgress();
+    }
+  }
+}

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -89,7 +89,7 @@ export class BuildManager {
     if (platform === Platform.Android) {
       const cancelToken = new CancelToken();
       return new DisposableBuildImpl(
-        this.startAndroidBuild(forceCleanBuild, cancelToken),
+        this.startAndroidBuild(forceCleanBuild, cancelToken, progressListener),
         cancelToken
       );
     } else {
@@ -127,7 +127,11 @@ export class BuildManager {
     return undefined;
   }
 
-  private async startAndroidBuild(forceCleanBuild: boolean, cancelToken: CancelToken) {
+  private async startAndroidBuild(
+    forceCleanBuild: boolean,
+    cancelToken: CancelToken,
+    progressListener: (newProgress: number) => void
+  ) {
     const newFingerprint = await generateWorkspaceFingerprint();
     if (!forceCleanBuild) {
       const buildResult = await this.loadAndroidCachedBuild(newFingerprint);
@@ -147,7 +151,8 @@ export class BuildManager {
       getAppRootFolder(),
       forceCleanBuild,
       cancelToken,
-      this.buildOutputChannel!
+      this.buildOutputChannel!,
+      progressListener
     );
     const buildResult: AndroidBuildResult = { ...build, platform: Platform.Android };
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -76,7 +76,7 @@ export interface ProjectInterface {
 
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
-  stageProgressListener(newStageProgress: number): void;
+  stageProgressListener(newStageProgress: number, stage: string): void;
 
   resumeDebugger(): Promise<void>;
   stepOverDebugger(): Promise<void>;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -215,7 +215,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
 
     Logger.debug(`Launching metro`);
     const waitForMetro = this.metro.start(forceCleanBuild, (newStageProgress: number) => {
-      this.stageProgressListener(newStageProgress);
+      this.stageProgressListener(newStageProgress, StartupMessage.WaitingForAppToLoad);
     });
   }
 
@@ -290,7 +290,10 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     await this.deviceSession?.changeDeviceSettings(settings);
     this.eventEmitter.emit("deviceSettingsChanged", this.deviceSettings);
   }
-  public async stageProgressListener(newStageProgress: number) {
+  public async stageProgressListener(newStageProgress: number, stage: string) {
+    if (stage !== this.projectState.startupMessage) {
+      return;
+    }
     if (newStageProgress < this.projectState.stageProgress) {
       return;
     }
@@ -345,7 +348,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
           deviceInfo.platform,
           forceCleanBuild,
           (newStageProgress: number) => {
-            this.stageProgressListener(newStageProgress);
+            this.stageProgressListener(newStageProgress, StartupMessage.Building);
           }
         )
       );


### PR DESCRIPTION
Before: 
There was no indication about the progress of android build. 

Now: 
Progress indicator based on number of tasks that were completed, and information about task graph. 

https://github.com/software-mansion-labs/react-native-sztudio/assets/159789821/dcde201b-b817-4ca8-926d-d3708e6f9920

Solution:
To achieve this effect I parse logs from build process to check if new tasks are being completed;
to know how many there is I added a gradle init script that logs that information. 

Additionally: 
This PR lets you define to which stage stageProgressListener belongs. 