### PR TITLE
Change resolving extension's lib files

### DIFF
--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -50,18 +50,20 @@ function adaptMetroConfig(config) {
 
   config.watchFolders = [...(config.watchFolders || []), extensionLib];
 
+  // Handle the case when resolver is not defined in the config
+  if (!config.resolver) {
+    config.resolver = {};
+  }
+
   // This code allows us to host some files from the extension's lib folder
   // Currently used for runtime and wrapper functionalities
-  config.resolver = {
-    ...config.resolver,
-    extraNodeModules: {
-      ...config.resolver?.extraNodeModules,
-      __rnp_lib__: extensionLib,
-    },
+  config.resolver.extraNodeModules = {
+    ...config.resolver.extraNodeModules,
+    __rnp_lib__: extensionLib,
   };
 
-  // By default nodeModulesPaths are not set.
-  // This may potentially break with non-standard settings like yarn workspaces etc.
+  // This code is needed to properly resolve modules
+  // It may potentially break with non-standard settings like yarn workspaces etc.
   // TODO: figure out why setting nodeModulesPaths is needed
   config.resolver.nodeModulesPaths = [
     ...(config.resolver.nodeModulesPaths || []),


### PR DESCRIPTION
This PR changes the way extension's lib files are resolved by Metro.

Before:
We considered  resolution of extension lib files inside overridden `resolveRequest` .

After:
We get rid of overriding `resolveRequest`, now extension lib is simply added to `extraNodeModules`.

Fixes #7