### PR TITLE
Change reload IDE button's behavior

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -71,7 +71,6 @@ export interface ProjectEventListener<T> {
 export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
   restart(forceCleanBuild: boolean): Promise<void>;
-  reloadWebview(): Promise<void>;
   selectDevice(deviceInfo: DeviceInfo): Promise<void>;
 
   getDeviceSettings(): Promise<DeviceSettings>;

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -122,9 +122,6 @@ export class DebugAdapter extends DebugSession {
             const sourceMap = JSON.parse(decodedData);
             const consumer = await new SourceMapConsumer(sourceMap);
             this.sourceMaps.push([message.params.url, message.params.scriptId, consumer]);
-            this.sourceMaps.forEach(([url, id, consumer]) => {
-              console.log("PORT URL", url, id, consumer);
-            });
             this.updateBreakpointsInSource(message.params.url, consumer);
           }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -375,11 +375,6 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     }
   }
 
-  public async reloadWebview() {
-    Logger.debug("Reloading webview");
-    commands.executeCommand("workbench.action.webview.reloadWebviewAction");
-  }
-
   private removeDeviceListener = async (devices: DeviceInfo) => {
     await this.trySelectingInitialDevice();
   };

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -20,8 +20,7 @@ function Actions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          // FIXME: this should also clean-up the backend of the extension and not only reload the webview
-          project.reloadWebview();
+          project.restart(true);
         }}
         tooltip={{ label: "Reload IDE", side: "bottom" }}>
         <span className="codicon codicon-refresh" />

--- a/packages/vscode-extension/src/webview/hooks/useDiagnosticAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useDiagnosticAlert.tsx
@@ -25,7 +25,7 @@ function Actions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.reloadWebview();
+          project.restart(false);
         }}
         tooltip={{ label: "Reload IDE", side: "bottom" }}>
         <span className="codicon codicon-refresh" />


### PR DESCRIPTION
This PR changes reload IDE button's behavior. Now it triggers project restart (with clean build enabled) instead of just reloading the webview. `reloadWebview` method has been removed, as it is not used anymore.

Resolves #9 