### PR TITLE
Fix for error message when reloading iOS application during build

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -371,7 +371,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
         status: "running",
         previewURL,
       });
-    } catch (e: any) {
+    } catch (e) {
       Logger.error("Couldn't start device session", e);
       if (
         this.projectState.selectedDevice === deviceInfo &&


### PR DESCRIPTION
Description: 
This is a primitive fix of a problem with reloading on iOS during build. 

Before: 
When reloading when subprocess running `xcodebuild` was active the information about that process being killed would leak and cause change in `ProjectState.status` to `buildError` despite the fact that new build was up and running. 

After: this change prevents unwanted change in status, when it is caused by previous session 

Fixes: #8 
