### PR TITLE
Adjustment for hero image

### DIFF
--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -11,8 +11,10 @@ const StartScreen = () => {
   return (
     <>
       <section className={styles.hero}>
-        <div className={styles.heroImageWrapper}>
-          <img className={styles.heroImage} src={useBaseUrl("/img/hero.png")} draggable={false} />
+        <div className={styles.heroImageContainer}>
+          <div className={styles.heroImageWrapper}>
+            <img className={styles.heroImage} src={useBaseUrl("/img/hero.png")} draggable={false} />
+          </div>
         </div>
         <div className={styles.heading}>
           <div>

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -35,6 +35,10 @@
   margin: 0;
 }
 
+.heroImageContainer {
+  position: relative;
+}
+
 .heroImageWrapper {
   border-radius: 2rem;
   border-color: var(--swm-green-light-100);
@@ -42,13 +46,15 @@
   border-style: solid;
   position: absolute;
   transform: translateX(70%) translateY(30px);
+  width: 1088px;
 }
 .heroImage {
   border-color: #000;
   border-width: 0.5rem;
   border-style: solid;
   border-radius: 1rem;
-  max-height: 700px;
+  width: 100%;
+  height: auto;
   margin-bottom: -10px;
 }
 
@@ -85,7 +91,7 @@
 
 @media (max-width: 1900px) {
   .heroImageWrapper {
-    transform: translateX(55%);
+    transform: translateX(55%) translateY(5%);
   }
 }
 
@@ -106,6 +112,7 @@
   }
 
   .heroImageWrapper {
+    width: auto;
     position: static;
     margin-top: 4rem;
     border-width: 1rem;


### PR DESCRIPTION
Fix overflowing hero image on IDE landing page.

Before:
<img width="566" alt="image" src="https://github.com/software-mansion-labs/react-native-ide/assets/59940332/0908e84d-654f-4b79-bb0e-00621f42973e">

After:
<img width="561" alt="image" src="https://github.com/software-mansion-labs/react-native-ide/assets/59940332/3533a80a-7977-49ad-b519-ec7ed23b914d">

