### PR TITLE
Enable optiojn to retain webview state for side-panel mode

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -76,7 +76,8 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     window.registerWebviewViewProvider(
       SidePanelViewProvider.viewType,
-      new SidePanelViewProvider(context)
+      new SidePanelViewProvider(context),
+      { webviewOptions: { retainContextWhenHidden: true } }
     )
   );
   context.subscriptions.push(commands.registerCommand("RNIDE.openPanel", showIDEPanel));


### PR DESCRIPTION
This option makes it so that when switching between different panels in side panel (i.e. file explorer <> IDE), the IDE wouldn't reset its webview state.