### PR TITLE
Remove broken package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,9 @@ yarn-error.log
 **/fastlane/screenshots
 **/fastlane/test_output
 
+# VSCode
+.vscode
+
 # Bundle artifact
 *.jsbundle
 

--- a/test-apps/expo/pokemon-app/package-lock.json
+++ b/test-apps/expo/pokemon-app/package-lock.json
@@ -11,7 +11,6 @@
         "@expo/metro-runtime": "~3.1.3",
         "@gorhom/bottom-sheet": "^4.6.0",
         "@react-native-async-storage/async-storage": "^1.21.0",
-        "@react-native-community/art": "^1.2.0",
         "@react-navigation/bottom-tabs": "^6.5.12",
         "@react-navigation/native-stack": "^6.9.18",
         "axios": "^1.6.7",
@@ -3805,21 +3804,6 @@
         "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
-    "node_modules/@react-native-community/art": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/art/-/art-1.2.0.tgz",
-      "integrity": "sha512-a+ZcRGl/BzLa89yi33Mbn5SHavsEXqKUMdbfLf3U8MDLElndPqUetoJyGkv63+BcPO49UMWiQRP1YUz6/zfJ+A==",
-      "deprecated": "If you need a similar package, please consider using react-native-svg or @shopify/react-native-skia",
-      "dependencies": {
-        "art": "^0.10.3",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/@react-native-community/cli": {
       "version": "12.3.6",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-12.3.6.tgz",
@@ -6806,14 +6790,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/art": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/art/-/art-0.10.3.tgz",
-      "integrity": "sha512-HXwbdofRTiJT6qZX/FnchtldzJjS3vkLJxQilc3Xj+ma2MXjY4UAyQ0ls1XZYVnDvVIBiFZbC6QsvtW86TD6tQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/asap": {

--- a/test-apps/expo/pokemon-app/package.json
+++ b/test-apps/expo/pokemon-app/package.json
@@ -16,7 +16,6 @@
     "@expo/metro-runtime": "~3.1.3",
     "@gorhom/bottom-sheet": "^4.6.0",
     "@react-native-async-storage/async-storage": "^1.21.0",
-    "@react-native-community/art": "^1.2.0",
     "@react-navigation/bottom-tabs": "^6.5.12",
     "@react-navigation/native-stack": "^6.9.18",
     "axios": "^1.6.7",


### PR DESCRIPTION
This prevented android from building with the error:
```
> Task :react-native-community_art:compileDebugJavaWithJavac FAILED
/Users/jgonet/Documents/dev/react-native-ide/test-apps/expo/pokemon-app/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java:25: error: cannot find symbol
import static com.facebook.react.common.ArrayUtils.copyArray;
                                       ^
  symbol:   class ArrayUtils
  location: package com.facebook.react.common
/Users/jgonet/Documents/dev/react-native-ide/test-apps/expo/pokemon-app/node_modules/@react-native-community/art/android/src/main/java/com/reactnativecommunity/art/ARTShapeShadowNode.java:25: error: static import only from classes and interfaces
import static com.facebook.react.common.ArrayUtils.copyArray;
```