### PR TITLE
Diagnostics modal - Fix pods installed endless load

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyInstaller.ts
+++ b/packages/vscode-extension/src/dependency/DependencyInstaller.ts
@@ -67,11 +67,11 @@ export class DependencyInstaller implements Disposable {
     this.webview.postMessage({
       command: "installingPods",
     });
-    try{
+    try {
       await installIOSDependencies(getAppRootFolder(), false);
       Logger.debug("Finished installing pods!");
-    }catch (error){
-      Logger.error("", error);
+    } catch (error) {
+      Logger.error("Install Pods:", error);
     }
     await this.dependencyChecker.checkPodsInstalled();
   }


### PR DESCRIPTION
Before: 
When an error occurred during pods installation diagnostics modal would indicate that installation is in progress endlessly. 

https://github.com/software-mansion/react-native-ide/assets/159789821/14bbdd28-2be0-4ca9-b049-ac36028f3b55

After: 
Error forces new dependency check.

https://github.com/software-mansion/react-native-ide/assets/159789821/9e574055-2aae-4dac-b96a-a4137878981c

Fixes: #39 