### PR TITLE
Close inspector with escape key

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.jsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.jsx
@@ -43,7 +43,7 @@ function PreviewView() {
 
   useEffect(() => {
     const disableInspectorOnEscape = (event) => {
-      if (event.key === "Escape" && isInspecing) {
+      if (event.key === "Escape") {
         setIsInspecting(false);
       }
     };
@@ -52,7 +52,7 @@ function PreviewView() {
     return () => {
       document.removeEventListener("keydown", disableInspectorOnEscape, false);
     };
-  }, [isInspecing, setIsInspecting]);
+  }, []);
 
   const handleDeviceDropdownChange = async (value) => {
     if (value === "manage") {


### PR DESCRIPTION
This PR makes it possible to abort using the inspector with an escape key.