### PR TITLE
Remove hardcoded sys images paths and use newest image for quick device creation

### DIFF
--- a/packages/vscode-extension/src/common/DeviceManager.ts
+++ b/packages/vscode-extension/src/common/DeviceManager.ts
@@ -36,6 +36,7 @@ export type IOSRuntimeInfo = {
   platform: "iOS" | "tvOS" | "watchOS";
   identifier: string;
   name: string;
+  version: string;
   supportedDeviceTypes: IOSDeviceTypeInfo[];
 };
 


### PR DESCRIPTION
This PR removes hardcoded system image paths that were used when user had no simulators created.

As a result, the buttons "Create iPhone" or "Create Android" would do nothing, because we wouldn't be able to find the exact image that was hardcoded.

Now, instead of exepecting some particular image, we select the newest available image both for iOS and Android.

We also change text on the buttons such that we no longer show the exact name of the device. It wasn't helpful to name the device and on some some resolutions it the spinner that appears on the button was causing the longer text to be misplaced.