### PR TITLE
Change WorkspaceSettings if they exist. 

### DIFF
--- a/packages/vscode-extension/src/common/WorkspaceConfig.ts
+++ b/packages/vscode-extension/src/common/WorkspaceConfig.ts
@@ -15,8 +15,8 @@ export interface WorkspaceConfigEventListener<T> {
 
 export interface WorkspaceConfig {
   getConfig(): Promise<WorkspaceConfigProps>;
-  // updateUserLevel method can take any of the keys from WorkspaceConfigProps and appropriate value:
-  updateUserLevel<K extends keyof WorkspaceConfigProps>(
+  // update method can take any of the keys from WorkspaceConfigProps and appropriate value:
+  update<K extends keyof WorkspaceConfigProps>(
     key: K,
     value: WorkspaceConfigProps[K]
   ): Promise<void>;

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -37,12 +37,13 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
     return this.config;
   }
 
-  async updateUserLevel<K extends keyof WorkspaceConfigProps>(
-    key: K,
-    value: WorkspaceConfigProps[K]
-  ) {
+  async update<K extends keyof WorkspaceConfigProps>(key: K, value: WorkspaceConfigProps[K]) {
     const configuration = workspace.getConfiguration("ReactNativeIDE");
-    await configuration.update(key as string, value, true);
+    if (configuration.inspect(key as string)?.workspaceValue) {
+      await configuration.update(key as string, value, false);
+    } else {
+      await configuration.update(key as string, value, true);
+    }
   }
 
   async addListener<K extends keyof WorkspaceConfigEventMap>(

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -15,7 +15,7 @@ interface SettingsDropdownProps {
 }
 
 function SettingsDropdown({ project, children, disabled }: SettingsDropdownProps) {
-  const { panelLocation, updateUserLevel } = useWorkspaceConfig();
+  const { panelLocation, update } = useWorkspaceConfig();
   const { openModal } = useModal();
   return (
     <DropdownMenu.Root>
@@ -55,14 +55,14 @@ function SettingsDropdown({ project, children, disabled }: SettingsDropdownProps
                 alignOffset={-5}>
                 <DropdownMenu.Item
                   className="dropdown-menu-item"
-                  onSelect={() => updateUserLevel("panelLocation", "tab")}>
+                  onSelect={() => update("panelLocation", "tab")}>
                   <span className="codicon codicon-layout-centered" />
                   Editor tab
                   {panelLocation === "tab" && <span className="codicon codicon-check right-slot" />}
                 </DropdownMenu.Item>
                 <DropdownMenu.Item
                   className="dropdown-menu-item"
-                  onSelect={() => updateUserLevel("panelLocation", "side-panel")}>
+                  onSelect={() => update("panelLocation", "side-panel")}>
                   <span className="codicon codicon-layout-sidebar-right" />
                   Side panel
                   {panelLocation === "side-panel" && (
@@ -72,7 +72,7 @@ function SettingsDropdown({ project, children, disabled }: SettingsDropdownProps
                 <DropdownMenu.Item
                   className="dropdown-menu-item"
                   onSelect={() => {
-                    updateUserLevel("panelLocation", "secondary-side-panel");
+                    update("panelLocation", "secondary-side-panel");
                     openModal(
                       "Drag and drop to secondary side panel",
                       <div>

--- a/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
@@ -12,16 +12,13 @@ import { WorkspaceConfig, WorkspaceConfigProps } from "../../common/WorkspaceCon
 const workspaceConfig = makeProxy<WorkspaceConfig>("WorkspaceConfig");
 
 type WorkspaceConfigContextType = WorkspaceConfigProps & {
-  updateUserLevel: <K extends keyof WorkspaceConfigProps>(
-    key: K,
-    value: WorkspaceConfigProps[K]
-  ) => void;
+  update: <K extends keyof WorkspaceConfigProps>(key: K, value: WorkspaceConfigProps[K]) => void;
 };
 
 const WorkspaceConfigContext = createContext<WorkspaceConfigContextType>({
   panelLocation: "tab",
   relativeAppLocation: "",
-  updateUserLevel: () => {},
+  update: () => {},
 });
 
 export default function WorkspaceConfigProvider({ children }: PropsWithChildren) {
@@ -39,7 +36,7 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
     };
   }, []);
 
-  const updateUserLevel = useCallback(
+  const update = useCallback(
     <K extends keyof WorkspaceConfigProps>(
       key: K,
       value: WorkspaceConfigProps[K],
@@ -47,13 +44,13 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
     ) => {
       const newState = { ...config, [key]: value };
       setConfig(newState);
-      workspaceConfig.updateUserLevel(key, value);
+      workspaceConfig.update(key, value);
     },
     [config, setConfig]
   );
 
   return (
-    <WorkspaceConfigContext.Provider value={{ ...config, updateUserLevel }}>
+    <WorkspaceConfigContext.Provider value={{ ...config, update }}>
       {children}
     </WorkspaceConfigContext.Provider>
   );


### PR DESCRIPTION
Before: 

changing a location of the IDE would not work from our settings dropdown menu if a User had workspace specific configuration. 

After: 

If a User has workspace specific configuration this is the one we are changing.