### PR TITLE
Disable node modules checks

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyChecker.ts
+++ b/packages/vscode-extension/src/dependency/DependencyChecker.ts
@@ -44,10 +44,6 @@ export class DependencyChecker implements Disposable {
             Logger.debug("Received checkCocoaPodsInstalled command.");
             this.checkCocoaPodsInstalled();
             return;
-          case "checkNodeModulesInstalled":
-            Logger.debug("Received checkNodeModulesInstalled command.");
-            this.checkNodeModulesInstalled();
-            return;
           case "checkPodsInstalled":
             Logger.debug("Received checkPodsInstalled command.");
             this.checkPodsInstalled();
@@ -73,24 +69,6 @@ export class DependencyChecker implements Disposable {
       },
     });
     Logger.debug("Nodejs installed: ", installed);
-    return installed;
-  }
-
-  public async checkNodeModulesInstalled() {
-    const installed = await checkIfCLIInstalled(`npm list --json`, {
-      cwd: getAppRootFolder(),
-    });
-
-    const errorMessage = "Node modules are not installed.";
-    this.webview.postMessage({
-      command: "isNodeModulesInstalled",
-      data: {
-        installed,
-        info: "Whether JavaScript packages are installed.",
-        error: installed ? undefined : errorMessage,
-      },
-    });
-    Logger.debug("Node modules installed: ", installed);
     return installed;
   }
 
@@ -151,17 +129,13 @@ export class DependencyChecker implements Disposable {
 
   public async checkPodsInstalled() {
     const installed = await checkIosDependenciesInstalled();
-    const nodeModulesInstalled = await this.checkNodeModulesInstalled();
     const errorMessage = "iOS dependencies are not installed.";
-    const extraInfoMessage = nodeModulesInstalled
-      ? ""
-      : "  Node modules need to be installed first.";
 
     this.webview.postMessage({
       command: "isPodsInstalled",
       data: {
         installed,
-        info: `Whether iOS dependencies are installed.${extraInfoMessage}`,
+        info: `Whether iOS dependencies are installed.`,
         error: installed ? undefined : errorMessage,
       },
     });

--- a/packages/vscode-extension/src/dependency/DependencyInstaller.ts
+++ b/packages/vscode-extension/src/dependency/DependencyInstaller.ts
@@ -1,6 +1,5 @@
 import { Webview, Disposable } from "vscode";
 import { Logger } from "../Logger";
-import { installNodeModulesAsync, resolvePackageManager } from "../utilities/packageManager";
 import { DependencyChecker } from "./DependencyChecker";
 import { command } from "../utilities/subprocess";
 import { getIosSourceDir } from "../builders/buildIOS";
@@ -33,10 +32,6 @@ export class DependencyInstaller implements Disposable {
         const command = message.command;
 
         switch (command) {
-          case "installNodeModules":
-            Logger.debug("Received installNodeModules command.");
-            this.installNodeModules();
-            return;
           case "installPods":
             Logger.debug("Received installPods command.");
             this.installPods();
@@ -46,20 +41,6 @@ export class DependencyInstaller implements Disposable {
       undefined,
       this.disposables
     );
-  }
-
-  public async installNodeModules() {
-    const packageManager = await resolvePackageManager();
-    Logger.debug(`Installing node modules using ${packageManager}`);
-    this.webview.postMessage({
-      command: "installingNodeModules",
-    });
-
-    await installNodeModulesAsync(packageManager);
-    Logger.debug("Finished installing node modules!");
-    await this.dependencyChecker.checkNodeModulesInstalled();
-    // after installing node modules, we need to run checkPodsInstalled function to determine if pods can be installed (they can't be installed if node modules are not present)
-    await this.dependencyChecker.checkPodsInstalled();
   }
 
   public async installPods() {

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -44,16 +44,3 @@ export function isPackageManagerAvailable(manager: PackageManagerName): boolean 
   } catch {}
   return false;
 }
-
-export async function installNodeModulesAsync(packageManager: PackageManagerName) {
-  const options = { cwd: getAppRootFolder() };
-  if (packageManager === "yarn") {
-    await new PackageManager.YarnPackageManager(options).installAsync();
-  } else if (packageManager === "pnpm") {
-    await new PackageManager.PnpmPackageManager(options).installAsync();
-  } else if (packageManager === "bun") {
-    await new PackageManager.BunPackageManager(options).installAsync();
-  } else {
-    await new PackageManager.NpmPackageManager(options).installAsync();
-  }
-}

--- a/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
+++ b/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
@@ -31,23 +31,6 @@ function DiagnosticView() {
 
       <Label>Project related</Label>
       <DiagnosticItem
-        label="Node modules installed"
-        item={dependencies.NodeModules}
-        action={
-          <IconButton
-            tooltip={{ label: "Fix", side: "bottom" }}
-            type="secondary"
-            size="small"
-            onClick={() => {
-              vscode.postMessage({
-                command: "installNodeModules",
-              });
-            }}>
-            <span className="codicon codicon-wand" />
-          </IconButton>
-        }
-      />
-      <DiagnosticItem
         label="Pods installed"
         item={dependencies.Pods}
         action={


### PR DESCRIPTION
This PR removes code responsible for node_modules checks.

These checks have been buggy and caused many projects to report issues while not giving a lot of value. Specifically, yarn-base projects would occasionally fail the check (maybe due to packages that were incompatible with node). On the other hand, we couldn't use project-specific package manager to perform this check because for example yarn wouldn't report a problem even when node_modules folder didn't exist (see #14)

We may want to revisit this in the future but it'd need to provide some additional values such as:
1) verifying if node_modules are in sync with current package.json and lock files – the old implementation only checked the existence of node_modules
2) the command should be fast, such that we can perform this verification at different moments, for example when we suspect someone should re-run install command (i.e. they checkout a different branch with changes to lockfiles)