### PR TITLE
Fix stream closing when computer sleeps

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -61,20 +61,20 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
   useEffect(() => {
     let timer: NodeJS.Timeout;
 
-    if (previewRef.current !== null && previewURL !== undefined) {
-      async function checkIfImageLoaded() {
-        try {
+    async function checkIfImageLoaded() {
+      try {
+        if (previewRef.current !== null && previewURL !== undefined) {
           // waits until image is ready to be displayed
-          await previewRef.current!.decode();
-        } catch {
-          // Stream connection was dropped
-          setPreviewRefreshKey((previousKey) => previousKey + 1);
-        } finally {
-          timer = setTimeout(checkIfImageLoaded, 2_000);
+          await previewRef.current.decode();
         }
+      } catch {
+        // Stream connection was dropped
+        setPreviewRefreshKey((previousKey) => previousKey + 1);
+      } finally {
+        timer = setTimeout(checkIfImageLoaded, 2_000);
       }
-      checkIfImageLoaded();
     }
+    checkIfImageLoaded();
 
     return () => clearTimeout(timer);
   }, [previewURL, previewRef]);


### PR DESCRIPTION
We use `<img>` tag to display MJPEG stream of simulator frames. It appears that after computer goes to sleep, connection between `<img>` and simulator server is dropped.

This change periodically tries to check if `<img>` contents is decodable and if not, remounts the image to establish a new connection.

Note: there's similar problem with Vite HMR server. It's easier to test this change by using production build.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode

Fixes #41.