### PR TITLE
Disable mouse input on a frame.

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -19,6 +19,16 @@
   min-width: var(--min-width);
 }
 
+.touchable-area {
+  position: absolute;
+  width: var(--phone-screen-width);
+  height: var(--phone-screen-height);
+  top: var(--phone-top);
+  left: var(--phone-left);
+  background-color: transparent;
+  z-index: 2;
+}
+
 .phone-screen {
   position: absolute;
   width: var(--phone-screen-width);

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -243,7 +243,8 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
       tabIndex={0} // allows keyboard events to be captured
       ref={wrapperDivRef}>
       {!isStarting && !hasBuildError && (
-        <div className="phone-content" {...touchHandlers}>
+        <div className="phone-content">
+        {/*<div className="touchable-area" {...touchHandlers}></div>*/}
           <MjpegImg
             src={previewURL}
             ref={previewRef}
@@ -252,6 +253,7 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
             }}
             className="phone-screen"
           />
+          
           {inspectFrame && (
             <div className="phone-screen phone-inspect-overlay">
               <div


### PR DESCRIPTION
This PR make touchHandlers Warp around phone screen instead of the whole phone-content (which includes a frame).
This disables the possibility for a user to interact with the application by clicking on a phone frame.

Fixes: #72 