### PR TITLE
Use resolved react-native location for locating packager.sh

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -98,8 +98,11 @@ export class Metro implements Disposable {
     resetCache: boolean,
     metroEnv: typeof process.env
   ) {
+    const reactNativeRoot = path.dirname(
+      require.resolve("react-native", { paths: [appRootFolder] })
+    );
     return exec(
-      `${appRootFolder}/node_modules/react-native/scripts/packager.sh`,
+      `${reactNativeRoot}/scripts/packager.sh`,
       [
         ...(resetCache ? ["--reset-cache"] : []),
         "--no-interactive",


### PR DESCRIPTION
This PR updates the way we locate packager.sh script for launching metro in bare React Native projects.

Before this change, we were assuming `react-native` package is located in `node_modules` under the main app location. This doesn't need to be the case for yarn workspaces setups, where `node_modules` are placed in parent directories of the main application package. We normally take this into account when loading JS packages and use node's resolution mechanism, but we weren't doing this for locating packager.sh script as it isn't a JS package.

This change makes it so that we use node's resolution to locate `react-native` package location. Then, we find packager script relative to that location.

