### PR TITLE
Use cli.js to launch packager

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -102,8 +102,10 @@ export class Metro implements Disposable {
       require.resolve("react-native", { paths: [appRootFolder] })
     );
     return exec(
-      `${reactNativeRoot}/scripts/packager.sh`,
+      `node`,
       [
+        `${reactNativeRoot}/cli.js`,
+        "start",
         ...(resetCache ? ["--reset-cache"] : []),
         "--no-interactive",
         "--port",


### PR DESCRIPTION
This PR is an attempt to address issues some users report when launching packager.sh. Due to different setup discrepancies the packager.sh script may not launch metro correctly. We try to get a layer deeper by launching cli.js directly (this is the script that packager.sh calls into).

I'm not sure if this will help resolve issue for some of the users, but it doesn't hurt to try. 