### PR TITLE
Reset img src manually to avoid hanging connections

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -56,7 +56,7 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
       return () => {
         img.src = "";
       };
-    }, [img, ref]);
+    }, [img]);
 
     // The sole purpose of the below effect is to periodically call `decode` on the image
     // in order to detect when the stream connection is dropped. There seem to be no better


### PR DESCRIPTION
This PR implements a workaround for an issue with img tag not dropping connection on unmount.

This issue was the main culprit behind #69 and resolves that problem. The reason why it was causing stuttering after several reloads, was that upon each of thereloads we would remount img component. As a consequence, chromium would keep multiple connections to stream server active, each one continuing to be decoded, which resulted in stuttering.

The main fix is to handle src attribute of img element manually. This way we can remember to reset it when the component is unmounted. In this PR we extracted this logic to a new component called `MjpegImg` which implements this logic, and we also moved the logic responsible for detecting connection drops to this new component.