### PR TITLE
Fix Diagnostic view pod installation. 

### DIFF
--- a/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
+++ b/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
@@ -35,6 +35,9 @@ function DiagnosticView() {
         item={dependencies.Pods}
         action={
           <IconButton
+            // TODO: support checking if Node Modules are installed and instaling them,
+            // For now this condition is always true to allow usage of "Pods install" functionality.
+            disabled={!dependencies.NodeModules?.installed || true}
             tooltip={{
               label: "Fix",
               side: "bottom",


### PR DESCRIPTION
This PR fixes the problem with "install pods" button in diagnostic view, because after #66 there was no check for node modules, `!dependencies.NodeModules?.installed` was always undefined.

Before: 
<img width="526" alt="Screenshot 2024-04-08 at 20 47 30" src="https://github.com/software-mansion/react-native-ide/assets/159789821/9b8a3484-3dbd-4d9d-b9c4-754f1c9b055e">

After:

https://github.com/software-mansion/react-native-ide/assets/159789821/b64a8bb7-46d1-4c69-adec-e7daa628e223

Fixes: #88 