### PR TITLE
Fix mjpeg img component

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -29,10 +29,11 @@ function cssPropertiesForDevice(device: DeviceProperties) {
   } as const;
 }
 
+const NO_IMAGE_DATA = "data:,";
+
 const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
   (props, ref) => {
     const { src, ...rest } = props;
-    const img = (ref as RefObject<HTMLImageElement>).current;
 
     // The below effect implements the main logic of this component. The primary
     // reason we can't just use img tag with src directly, is that with mjpeg streams
@@ -43,15 +44,16 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
     // when the src by changing first to an empty string. We also set empty src when
     // the component is unmounted.
     useEffect(() => {
+      const img = (ref as RefObject<HTMLImageElement>).current;
       if (!img) {
         return;
       }
-      img.src = "";
-      img.src = src || "";
+      img.src = NO_IMAGE_DATA;
+      img.src = src || NO_IMAGE_DATA;
       return () => {
-        img.src = "";
+        img.src = NO_IMAGE_DATA;
       };
-    }, [img]);
+    }, [ref, src]);
 
     // The sole purpose of the below effect is to periodically call `decode` on the image
     // in order to detect when the stream connection is dropped. There seem to be no better
@@ -62,6 +64,7 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
 
       let cancelled = false;
       async function checkIfImageLoaded() {
+        const img = (ref as RefObject<HTMLImageElement>).current;
         if (img?.src) {
           try {
             // waits until image is ready to be displayed
@@ -70,7 +73,7 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
             // Stream connection was dropped
             if (!cancelled) {
               const src = img.src;
-              img.src = "";
+              img.src = NO_IMAGE_DATA;
               img.src = src;
             }
           }
@@ -85,7 +88,7 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
         cancelled = true;
         clearTimeout(timer);
       };
-    }, [img]);
+    }, [ref]);
 
     return <img ref={ref} {...rest} />;
   }


### PR DESCRIPTION
This PR fixes MjpegImg component introduced in #79 

That PR despite solving the performance problems with img component introduced some minor issues that resulted in the img component misbehaving sometimes.

1) when resetting src, we'd use empty string, which would default to the page location and resulted in image loading error
2) the hooks would only update when img changes, instead of using ref and src as dependencies.

This PR:
1) uses empty data url for the case where we don't have a valid url for the preview
2) fixes dependency array for hooks