### PR TITLE
Better names for launch config properties

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -125,24 +125,42 @@
           "typescriptreact"
         ],
         "configurationAttributes": {
-          "preview": {
+          "launch": {
             "required": [],
             "properties": {
-              "iOS:scheme": {
-                "type": "string",
-                "description": "Scheme name (from xcode project) the IDE will use for iOS builds, defaults to workspace file name."
+              "ios": {
+                "description": "Provides a way to customize Xcode builds for iOS",
+                "type": "object",
+                "properties": {
+                  "scheme": {
+                    "type": "string",
+                    "description": "Scheme name (from xcode project) the IDE will use for iOS builds, defaults to xcworkspace base file name."
+                  },
+                  "configuration": {
+                    "type": "string",
+                    "description": "Build configuration name (from xcode project) the IDE will use for iOS builds, defaults to \"Debug\"."
+                  }
+                }
               },
-              "iOS:configuration": {
-                "type": "string",
-                "description": "Build configuration name (from xcode project) the IDE will use for iOS builds, defaults to \"Debug\"."
+              "android": {
+                "description": "Provides a way to customize Gradle builds for Android",
+                "type": "object",
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "description": "Android's build variant used when building with Gradle, defaults to \"debug\"."
+                  }
+                }
               },
-              "Android:variant": {
-                "type": "string",
-                "description": "Android's build variant used when building with Gradle, defaults to \"debug\"."
-              },
-              "Preview:waitForAppLaunch": {
-                "type": "boolean",
-                "description": "Defaults to `true`, this should only be set to `false` for brownfield setups when React Native components aren't rendered immediately after the app launches."
+              "preview": {
+                "description": "Custommize the behavior of device preview",
+                "type": "object",
+                "properties": {
+                  "waitForAppLaunch": {
+                    "type": "boolean",
+                    "description": "Defaults to `true`, this should only be set to `false` for brownfield setups when React Native components aren't rendered immediately after the app launches."
+                  }
+                }
               }
             }
           }
@@ -152,8 +170,12 @@
             "type": "react-native-ide",
             "request": "launch",
             "name": "React Native IDE panel",
-            "iOS:mode": "Debug",
-            "Android:variant": "debug"
+            "ios": {
+              "configuration": "Debug"
+            },
+            "android": {
+              "variant": "debug"
+            }
           }
         ]
       }

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -66,7 +66,7 @@ export async function buildAndroid(
     "lint",
     `-PreactNativeArchitectures=${cpuArchitecture}`,
     ...(forceCleanBuild ? ["clean"] : []),
-    makeBuildTaskName(buildOptions["Android:variant"] || "debug"),
+    makeBuildTaskName(buildOptions.android?.variant || "debug"),
     "--init-script", // init script is used to patch React Android project, see comments in configureReactNativeOverrides.gradle for more details
     path.join(extensionContext.extensionPath, "lib", "android", "initscript.gradle"),
   ];

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -148,7 +148,7 @@ export async function buildIos(
   );
 
   const buildOptions = getLaunchConfiguration();
-  const scheme = buildOptions["iOS:scheme"] || (await findXcodeScheme(xcodeProject));
+  const scheme = buildOptions.ios?.scheme || (await findXcodeScheme(xcodeProject));
   Logger.debug(`Xcode build will use "${scheme}" scheme`);
 
   const buildProcess = cancelToken.adapt(
@@ -156,7 +156,7 @@ export async function buildIos(
       xcodeProject,
       sourceDir,
       scheme,
-      buildOptions["iOS:configuration"] || "Debug",
+      buildOptions?.ios?.configuration || "Debug",
       forceCleanBuild
     )
   );

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -107,7 +107,7 @@ export class WebviewController implements Disposable {
             this.webview.postMessage({
               command: "callback",
               callbackId,
-              options,
+              args: options,
             });
           };
         } else {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -40,13 +40,14 @@ export class DeviceSession implements Disposable {
     previewReadyCallback: PreviewReadyCallback,
     progressCallback: ProgressCallback
   ) {
-    const shouldWaitForAppLaunch = getLaunchConfiguration()["Preview:waitForAppLaunch"];
+    const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
     const waitForAppReady = shouldWaitForAppLaunch
       ? Promise.resolve()
       : new Promise<void>((res) => {
           const listener = (event: string, payload: any) => {
             if (event === "RNIDE_appReady") {
               this.devtools?.removeListener(listener);
+              res();
             }
           };
           this.devtools?.addListener(listener);

--- a/packages/vscode-extension/src/utilities/launchConfiguration.ts
+++ b/packages/vscode-extension/src/utilities/launchConfiguration.ts
@@ -1,10 +1,22 @@
 import { workspace } from "vscode";
 
 export type LaunchConfigurationOptions = {
-  "iOS:scheme": string | undefined;
-  "iOS:configuration": string | undefined;
-  "Android:variant": string | undefined;
-  "Preview:waitForAppLaunch": boolean | undefined;
+  ios:
+    | {
+        scheme: string | undefined;
+        configuration: string | undefined;
+      }
+    | undefined;
+  android:
+    | {
+        variant: string | undefined;
+      }
+    | undefined;
+  preview:
+    | {
+        waitForAppLaunch: boolean | undefined;
+      }
+    | undefined;
 };
 
 export function getLaunchConfiguration(): LaunchConfigurationOptions {


### PR DESCRIPTION
This PR renames launch configuration properties introduced in #90 

It turns out you can use nested objects for launch configuration which looks much better.

We are renaming fields like "iOS:scheme" to nested structure `ios: { scheme: "Debug" }}`

This PR also fixes issue introduced in #87 where variables used as object keys were renamed in WebviewController.ts