### PR TITLE
Fix debug overlay

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -119,7 +119,7 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
   const isStarting =
     hasBundleError || hasIncrementalBundleError || debugException
       ? false
-      : projectState?.status === "starting";
+      : !projectState || projectState.status === "starting";
   const showDevicePreview =
     projectState?.previewURL && (showPreviewRequested || (!isStarting && !hasBuildError));
 
@@ -239,8 +239,6 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
         onMouseUp,
         onMouseLeave,
       };
-
-  console.log("DSS", { showDevicePreview, ps: projectState?.status, hasBuildError });
 
   return (
     <div


### PR DESCRIPTION
This PR fixes issue introduced in #93 where we'd not display device preview in debug pause state.