### PR TITLE
Fix ios scheme detection

### DIFF
--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -101,12 +101,13 @@ function buildProject(
 }
 
 async function findXcodeScheme(xcodeProject: IOSProjectInfo) {
-  const basename = path.basename(xcodeProject.workspaceLocation || xcodeProject.xcodeprojLocation);
+  const basename = xcodeProject.workspaceLocation
+    ? path.basename(xcodeProject.workspaceLocation, ".xcworkspace")
+    : path.basename(xcodeProject.xcodeprojLocation, ".xcodeproj");
 
   // we try to search for the scheme name under .xcodeproj/xcshareddata/xcschemes
   const schemeFiles = await workspace.findFiles(
-    xcodeProject.xcodeprojLocation,
-    "**/xcshareddata/xcschemes/*.xcscheme"
+    new RelativePattern(xcodeProject.xcodeprojLocation, "**/xcshareddata/xcschemes/*.xcscheme")
   );
   if (schemeFiles.length === 1) {
     return path.basename(schemeFiles[0].fsPath, ".xcscheme");


### PR DESCRIPTION
#90 introduced a regression due to improper use of basename function. Because no extension was provided, basename would contain .xcworkspace extension breaking iOS builds. On top of that, there was another bug related to xcscheme search making it so that instead of including scheme files we were excluding them.

This PR fixes the two above issues. We now pass an extension when using basename and also use RelativePattern when searching for xcscheme files.