### PR TITLE
Restore expo env plugin

### DIFF
--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -40,6 +40,17 @@ function adaptMetroConfig(config) {
       if (!preludeCode.includes("__REACT_DEVTOOLS_PORT__")) {
         module.output[0].data.code = `${preludeCode};var __REACT_DEVTOOLS_PORT__=${process.env.RCT_DEVTOOLS_PORT};`;
       }
+    } else if (module.path === "__env__") {
+      // this handles @expo/env plugin, which is used to inject environment variables
+      // the code below instantiates a global variable __EXPO_ENV_PRELUDE_LINES__ that stores
+      // the number of lines in the prelude. This is used to calculate the line number offset
+      // when reporting line numbers from the JS runtime. The reason why this is needed, is that
+      // metro doesn't include __env__ prelude in the source map resulting in the source map
+      // transformation getting shifted by the number of lines in the prelude.
+      const expoEnvCode = module.output[0].data.code;
+      if (!expoEnvCode.includes("__EXPO_ENV_PRELUDE_LINES__")) {
+        module.output[0].data.code = `${expoEnvCode};var __EXPO_ENV_PRELUDE_LINES__=${module.output[0].data.lineCount};`;
+      }
     }
     return origProcessModuleFilter(module);
   };

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -21,7 +21,8 @@ function wrapConsole(consoleFunc) {
     const stack = parseErrorStack(new Error().stack);
     const expoLogIndex = stack.findIndex((frame) => frame.methodName === "__expoConsoleLog");
     const location = expoLogIndex > 0 ? stack[expoLogIndex + 1] : stack[1];
-    args.push(location.file, location.lineNumber, location.column);
+    const lineOffset = global.__EXPO_ENV_PRELUDE_LINES__ || 0;
+    args.push(location.file, location.lineNumber - lineOffset, location.column);
     return consoleFunc.apply(console, args);
   };
 }

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -137,11 +137,6 @@ export class Metro implements Disposable {
       RCT_METRO_PORT: "0",
       RCT_DEVTOOLS_PORT: this.devtools.port.toString(),
       REACT_NATIVE_IDE_LIB_PATH: libPath,
-      // we disable env plugins as they add additional lines at the top of the bundle that are not
-      // taken into account by source maps. As a result, this messes up line numbers reported by hermes
-      // and makes it hard to translate them back to original locations. Once this is fixed, we
-      // can restore this plugin.
-      EXPO_NO_CLIENT_ENV_VARS: "true",
     };
     let bundlerProcess: ChildProcess;
 


### PR DESCRIPTION
This PR re-enables expo env plugin allowing it to function.

The reason why we disabled it was that metro wasn't handling source maps correctly. This was because env plugin would add additional modules to output using customSerializer, but the serializer isn't used when generating sourcemaps, and hence the source maps were generated by skipping that module. As a consequence, all lines transformed using sourcemaps were shifted by the number of lines of the env module.

In this PR we implement a different workaround that stores the number of lines from expo env in global variable and then uses it to manually adjust reported line numbers.