### PR TITLE
Fix wrong logic when deciding to wait for app ready

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -42,8 +42,7 @@ export class DeviceSession implements Disposable {
   ) {
     const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
     const waitForAppReady = shouldWaitForAppLaunch
-      ? Promise.resolve()
-      : new Promise<void>((res) => {
+      ? new Promise<void>((res) => {
           const listener = (event: string, payload: any) => {
             if (event === "RNIDE_appReady") {
               this.devtools?.removeListener(listener);
@@ -51,7 +50,8 @@ export class DeviceSession implements Disposable {
             }
           };
           this.devtools?.addListener(listener);
-        });
+        })
+      : Promise.resolve();
 
     progressCallback(StartupMessage.BootingDevice);
     await this.device.bootDevice();


### PR DESCRIPTION
This PR fixes a bug when we'd use reverse condition to check whether we should wait for app ready or not. Now after it is fixed when shouldWaitForAppReady is true we use the promise that waits for an event. Otherwise, we use a resolved promise.