### PR TITLE
Use build configuration from launch configuration for getBuildPath command

### DIFF
--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -181,7 +181,14 @@ export async function buildIos(
     throw new Error(`Couldn't find "PLATFORM_NAME" in xcodebuild output`);
   }
 
-  const appPath = await getBuildPath(xcodeProject, sourceDir, platformName, scheme, cancelToken);
+  const appPath = await getBuildPath(
+    xcodeProject,
+    sourceDir,
+    platformName,
+    scheme,
+    buildOptions?.ios?.configuration || "Debug",
+    cancelToken
+  );
 
   const bundleID = await getBundleID(appPath);
 
@@ -216,6 +223,7 @@ async function getBuildPath(
   projectDir: string,
   platformName: string,
   scheme: string,
+  configuration: string,
   cancelToken: CancelToken
 ) {
   const buildSettings = await cancelToken.adapt(
@@ -229,7 +237,7 @@ async function getBuildPath(
         "-sdk",
         platformName,
         "-configuration",
-        "Debug",
+        configuration,
         "-showBuildSettings",
         "-json",
       ],


### PR DESCRIPTION
This PR fixes hardcoded Debug configuration in getBuildPath method. Afters #96 we can configure ios scheme and configuration in launch json. However, the configuration was only used for build command but not for the command retrieving the build artifact.