### PR TITLE
Fix z-index of loading screen background

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -105,6 +105,6 @@
   gap: 16px;
 }
 
-.phone-content-loading-overlay {
-  background-color: var(--swm-phone-content-loading-overlay);
+.phone-content-loading-background {
+  background-color: var(--swm-phone-content-loading-background);
 }

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -315,7 +315,7 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
       )}
       {!showDevicePreview && !hasBuildError && (
         <div className="phone-content">
-          <div className="phone-sized phone-screen phone-content-loading-overlay" />
+          <div className="phone-sized phone-screen phone-content-loading-background" />
           <div className="phone-sized phone-screen phone-content-loading ">
             <PreviewLoader onRequestShowPreview={() => setShowPreviewRequested(true)} />
           </div>

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -146,7 +146,7 @@ body[data-vscode-theme-kind="vscode-light"] {
 
   /* Startup message */
   --swm-startup-message: var(--off-white);
-  --swm-phone-content-loading-overlay: rgba(0, 0, 0, 0.75);
+  --swm-phone-content-loading-background: rgba(0, 0, 0, 0.75);
 
   /* Button */
   --swm-button: var(--swm-default-text);
@@ -256,7 +256,7 @@ body[data-vscode-theme-kind="vscode-dark"] {
 
   /* Startup message */
   --swm-startup-message: var(--off-white);
-  --swm-phone-content-loading-overlay: rgba(255, 255, 255, 0.15);
+  --swm-phone-content-loading-background: rgba(255, 255, 255, 0.15);
 
   /* Button */
   --swm-button: var(--swm-default-text);


### PR DESCRIPTION
This PR fixes how loading screen interacts with other UI elements. 

Additionally to avoid similar problems in the future it changes the name of phone-content-loading-overlay to phone-content-loading-background.

Before: 
![Screenshot 2024-04-14 at 22 16 49](https://github.com/software-mansion/react-native-ide/assets/159789821/7a0aa575-7d24-4cd7-bc07-ef18cef24421)

After: 
![Screenshot 2024-04-14 at 22 16 26](https://github.com/software-mansion/react-native-ide/assets/159789821/f46c887d-9692-47b5-bb74-d8659ff4098f)
