### PR TITLE
Add a Button that opens IDE in new window. 

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -80,7 +80,7 @@ export interface ProjectInterface {
   focusDebugConsole(): Promise<void>;
   openNavigation(navigationItemID: string): Promise<void>;
   openDevMenu(): Promise<void>;
-  openNewWindow(): void;
+  movePanelToNewWindow(): void;
 
   dispatchTouch(xRatio: number, yRatio: number, type: "Up" | "Move" | "Down"): Promise<void>;
   dispatchKeyPress(keyCode: number, direction: "Up" | "Down"): Promise<void>;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -285,7 +285,7 @@ export class Project implements Disposable, MetroDelegate, ProjectInterface {
     await this.deviceSession?.openDevMenu();
   }
 
-  public openNewWindow() {
+  public movePanelToNewWindow() {
     commands.executeCommand("workbench.action.moveEditorToNewWindow");
   }
 

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -104,7 +104,7 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
                     <DropdownMenu.Item
                       className="dropdown-menu-item"
                       onSelect={() => {
-                        project.openNewWindow();
+                        project.movePanelToNewWindow();
                       }}>
                       <span className="codicon codicon-multiple-windows" />
                       New Window


### PR DESCRIPTION
This PR adds a button that opens IDE in a new window. The button will be visible only if IDE is located in a tab and not on the sidebar. 