### PR TITLE
Add google-site-verification tag to landing

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -69,6 +69,12 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      metadata: [
+        {
+          name: "google-site-verification",
+          content: "U0xic78Z5DjD9r0wrxOYQrLZPuSF_DZidnZeXPR4D0k",
+        },
+      ],
     }),
 };
 


### PR DESCRIPTION
This PR adds a google-site-verification tag to our docusaurus docs so Google could run indexing crawler over the page. 

There's a couple of ways of setting it but this one is the easiest.

Alternatively, we could set it up via DNS record but our devops is currently on vacation ;)