### PR TITLE
Fix dropdown menus position in hierarchy. 

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from "react";
 import * as Select from "@radix-ui/react-select";
 import { DeviceInfo, Platform } from "../../common/DeviceManager";
 import "./DeviceSelect.css";
+import "./shared/Dropdown.css";
 import Tooltip from "./shared/Tooltip";
 
 interface RichSelectItemProps extends Select.SelectItemProps {
@@ -65,7 +66,7 @@ function DeviceSelect({ onValueChange, devices, value, label, disabled }: Device
       </Select.Trigger>
 
       <Select.Portal>
-        <Select.Content className="device-select-content" position="popper">
+        <Select.Content className="device-select-content dropdown-menu-content" position="popper">
           <Select.Viewport className="device-select-viewport">
             {iOSDevices.length > 0 && (
               <Select.Group>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -42,7 +42,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
           <Label>device appearance</Label>
           <form>
             <RadioGroup.Root
-              className="radio-group-root"
+              className="dropdown-menu-content  radio-group-root"
               defaultValue={deviceSettings.appearance}
               onValueChange={(value) => {
                 project.updateDeviceSettings({

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -4,6 +4,7 @@ button {
 }
 
 .dropdown-menu-content {
+  z-index: 40;
   min-width: 220px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;


### PR DESCRIPTION
This PR fixes the bug caused by overlays having high z-index and overshadowing important interface elements.  

Before: 
<img width="237" alt="Screenshot 2024-04-19 at 19 10 08" src="https://github.com/software-mansion/react-native-ide/assets/159789821/44428fd2-221e-4e6b-86e1-83d073efee47">

After: 
<img width="268" alt="Screenshot 2024-04-19 at 19 09 26" src="https://github.com/software-mansion/react-native-ide/assets/159789821/6c2bf120-79a0-4dcb-bcf0-1dee4730fea9">
