### PR TITLE
Fix inspector highlight on mouse move

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -161,13 +161,13 @@ export function PreviewAppWrapper({ children, ...rest }) {
                         : undefined;
                     });
                 })
-              );
+              ).then((stack) => stack.filter(Boolean));
             }
             stackPromise.then((stack) => {
               agent._bridge.send("RNIDE_inspectData", {
                 id: payload.id,
                 frame: scaledFrame,
-                stack: stack.filter((item) => item),
+                stack: stack,
               });
             });
           }


### PR DESCRIPTION
In #113 we introduced a regression that broke inspector highlight when hovering.

The problem was due to the fact that we'd call `stack.filter` in `wrapper.ts` and when hovering, we never ask for the stack to be populated. As a result we've been calling filter on undefined stack which resulted in the callback never returning with the frame data.

This PR fixes the issue and moves the code that filters non-empty stack items to the code branch that runs only when stack is requested.