### PR TITLE
Use unique ids for call and callback ids to avoid duped calls when weboew reloads

### DIFF
--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -15,8 +15,8 @@ export class WebviewController implements Disposable {
   public readonly project: Project;
   public readonly workspaceConfig: WorkspaceConfigController;
   private disposables: Disposable[] = [];
-  private idToCallback: Map<number, WeakRef<any>> = new Map();
-  private idToCallbackFinalizationRegistry = new FinalizationRegistry((callbackId: number) => {
+  private idToCallback: Map<string, WeakRef<any>> = new Map();
+  private idToCallbackFinalizationRegistry = new FinalizationRegistry((callbackId: string) => {
     this.idToCallback.delete(callbackId);
     this.webview.postMessage({
       command: "cleanupCallback",


### PR DESCRIPTION
This PR solves an issue where listeners registered from webview would accumulate over webview reloads.

The problem was due to the fact, we can't unregister listeners when webview reloads or when it's moved to new window. As a result, listeners are kept on the extension side and triggered sent to the new context after webview reloads. Since call and callback ids always start from 1, we have a collision of ids and those listeners trigger some actions in the new webview.
