### PR TITLE
Add an icon to tabPanel

### DIFF
--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -20,9 +20,9 @@ export class TabPanel {
   private readonly _panel: WebviewPanel;
   private webviewController: WebviewController;
 
-  private constructor(panel: WebviewPanel) {
+  private constructor(panel: WebviewPanel, context: ExtensionContext) {
     this._panel = panel;
-
+    this._panel.iconPath = Uri.joinPath(context.extensionUri, "assets", "logo.svg");
     // Set an event listener to listen for when the panel is disposed (i.e. when the user closes
     // the panel or when the panel is closed programmatically)
     this._panel.onDidDispose(() => this.dispose());
@@ -69,7 +69,7 @@ export class TabPanel {
           retainContextWhenHidden: true,
         }
       );
-      TabPanel.currentPanel = new TabPanel(panel);
+      TabPanel.currentPanel = new TabPanel(panel, context);
       context.workspaceState.update(OPEN_PANEL_ON_ACTIVATION, true);
 
       commands.executeCommand("workbench.action.lockEditorGroup");


### PR DESCRIPTION
This PR adds React native IDE logo to tabPanel.

Before: 
<img width="134" alt="Screenshot 2024-04-24 at 10 31 38" src="https://github.com/software-mansion/react-native-ide/assets/159789821/fd42d7b1-54be-4931-9bfb-53c85e1d4c7f">
After:
<img width="129" alt="Screenshot 2024-04-24 at 10 32 31" src="https://github.com/software-mansion/react-native-ide/assets/159789821/aa84dad7-d07b-41cf-be98-4a934d53dd61">
