### PR TITLE
Fix inspector secondary functionality overflowing into regular view. 

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -191,6 +191,7 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
   function resetInspector() {
     setInspectFrame(null);
     setInspectStackData(null);
+    setIsInspecting(false);
   }
 
   function onMouseMove(e: MouseEvent<HTMLDivElement>) {
@@ -207,13 +208,18 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
     wrapperDivRef.current!.focus();
 
     if (isInspecting) {
-      sendInspect(e, e.button === 2 ? "RightButtonDown" : "Down", true);
-      setIsInspecting(false);
+      if (e.button === 2) {
+        sendInspect(e, "RightButtonDown", true);
+      } else {
+        sendInspect(e, "Down", true);
+        setIsInspecting(false);
+      }
     } else if (inspectFrame) {
       // if element is highlighted, we clear it here and ignore first click (don't send it to device)
       resetInspector();
     } else if (e.button === 2) {
       sendInspect(e, "RightButtonDown", true);
+      setIsInspecting(true);
     } else {
       setIsPressing(true);
       sendTouch(e, "Down");


### PR DESCRIPTION
Problems this PR solves a problem with inspector context menu not opening files. 

Before: 

https://github.com/software-mansion/react-native-ide/assets/159789821/27bc8f0c-b055-49ef-be93-75a157ce5df7

After:


https://github.com/software-mansion/react-native-ide/assets/159789821/5030f310-74e7-434b-9467-e24b7e181f4e





