### PR TITLE
Fix click events on inspector after #123

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -20,7 +20,7 @@ export function InspectDataMenu({
   onCancel: () => void;
 }) {
   const triggerRef = useRef<HTMLDivElement>(null);
-  let filteredData = inspectStack.filter((item) => !item.hide);
+  const filteredData = inspectStack.filter((item) => !item.hide);
 
   useEffect(() => {
     const event = new MouseEvent("contextmenu", {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -328,19 +328,6 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
               className="phone-screen"
             />
 
-            {inspectStackData && (
-              <InspectDataMenu
-                inspectLocation={inspectStackData.requestLocation}
-                inspectStack={inspectStackData.stack}
-                onSelected={onInspectorItemSelected}
-                onHover={(item) => {
-                  if (item.frame) {
-                    setInspectFrame(item.frame);
-                  }
-                }}
-                onCancel={() => resetInspector()}
-              />
-            )}
             {inspectFrame && (
               <div className="phone-screen phone-inspect-overlay">
                 <div
@@ -396,6 +383,19 @@ function Preview({ isInspecting, setIsInspecting }: Props) {
             )}
           </div>
           <img src={device!.frameImage} className="phone-frame" />
+          {inspectStackData && (
+            <InspectDataMenu
+              inspectLocation={inspectStackData.requestLocation}
+              inspectStack={inspectStackData.stack}
+              onSelected={onInspectorItemSelected}
+              onHover={(item) => {
+                if (item.frame) {
+                  setInspectFrame(item.frame);
+                }
+              }}
+              onCancel={() => resetInspector()}
+            />
+          )}
         </div>
       )}
       {!showDevicePreview && !hasBuildError && (


### PR DESCRIPTION
#123 broke click events on context menu of the inspector tool because of the event handlers that have been moved to the menu parent component. Moving the menu outside of the touch enabled container fixes the problem.