### PR TITLE
Allow app folder to be recognized by the presence of app.config.ts

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -11,7 +11,9 @@
     "workspaceContains:node_modules/react-native",
     "workspaceContains:app.json",
     "workspaceContains:metro.config.js",
-    "workspaceContains:app.config.js"
+    "workspaceContains:metro.config.ts",
+    "workspaceContains:app.config.js",
+    "workspaceContains:app.config.ts"
   ],
   "version": "0.0.7-beta",
   "engines": {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -178,12 +178,15 @@ async function findAppRootFolder() {
     return appRoot;
   }
 
-  const metroConfigUri = await findSingleFileInWorkspace("**/metro.config.js", "**/node_modules");
+  const metroConfigUri = await findSingleFileInWorkspace(
+    "**/metro.config.{js,ts}",
+    "**/node_modules"
+  );
   if (metroConfigUri) {
     return Uri.joinPath(metroConfigUri, "..").fsPath;
   }
 
-  const appConfigUri = await findSingleFileInWorkspace("**/app.config.js", "**/node_modules");
+  const appConfigUri = await findSingleFileInWorkspace("**/app.config.{js,ts}", "**/node_modules");
   if (appConfigUri) {
     return Uri.joinPath(appConfigUri, "..").fsPath;
   }
@@ -196,7 +199,7 @@ async function findAppRootFolder() {
     return Uri.joinPath(rnPackageLocation, "../../..").fsPath;
   }
 
-  // app json is often use in non react-native projects, but in worst case scenario we can use it as a fallback
+  // app json is often used in non react-native projects, but in worst case scenario we can use it as a fallback
   const appJsonUri = await findSingleFileInWorkspace("**/app.json", "**/node_modules");
   if (appJsonUri) {
     return Uri.joinPath(appJsonUri, "..").fsPath;


### PR DESCRIPTION
This fixes an issue with diagnose command not working and IDE commands not being available on projects like https://github.com/MariuzM/expo-starter

As per official expo docs https://docs.expo.dev/versions/latest/config/app/ – app.config.ts can be used instead of app.config.js or app.json. We need to consider that file for activating the extension and when looking up the app root folder.

The following changes are made here:
 - we add app.config.ts and also metro.config.ts (just in case) as triggers for extension activation events
 - we consider either js or ts extension when looking up app.config.js and metro.config.js to determine the app root folder