### PR TITLE
docs: update development.md typo packages

### DIFF
--- a/packages/docs/docs/development.md
+++ b/packages/docs/docs/development.md
@@ -56,7 +56,7 @@ It is necessary that you open that exact folder rather than the whole repository
 You can do it by opening new window in Visual Studio Code and using `File > Open Folder` option, then select `packages/vscode-extension`, or if you have vscode's command line tool installed you can open it using command:
 
 ```sh
-code package/vscode-extension
+code packages/vscode-extension
 ```
 
 ### 5. Launch vscode development host with development version of the extension


### PR DESCRIPTION
**Description**

Found this issue when I was going through the setup found here:
https://ide.swmansion.com/docs/development

There was a typo, it should say `packages` not `package`.

**Questions**

Not sure if I have to run a command to generate the docs?