### PR TITLE
Add more specific description to a log

### DIFF
--- a/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
@@ -57,7 +57,7 @@ export class BuildIOSProgressProcessor implements BuildProgressProcessor {
       }
       this.tasksToComplete = tasksToComplete;
     } catch (err: any) {
-      Logger.warn(err);
+      Logger.warn(`Build iOS progress processor: ${err}`);
     }
   }
 


### PR DESCRIPTION
This PR makes it more clear where the log informing a user about missing iOS build manifest is coming from.

Relates to:  #158