### PR TITLE
Include lib/android files in built packages

### DIFF
--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -2,9 +2,9 @@
 *
 */**
 
-# Whitelist needed files
+# Allow needed files
 !dist/**
-!lib/*
-!assets/*
+!lib/**
+!assets/**
 !LICENSE.txt
 !README.md


### PR DESCRIPTION
This PR updates vscode igore files so that lib/android files are included in the packages.

Previously we had "lib/*" there which was preventing files from subdirectories inside `lib` from being packaged. Adding "**" makes all the files including subdirectories to be removed from the ignorelist.

Fixes #177 