### PR TITLE
Implement jsx transform workaround that doesn't affect order of plugins

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -10,9 +10,9 @@ function transformWrapper({ filename, src, plugins, ...rest }) {
     // expo-router v2 and v3 integration
     const { version } = requireFromAppDir("expo-router/package.json");
     if (version.startsWith("2.")) {
-      // src = `${src};require("__RNIDE_lib__/expo_router_v2_plugin.js");`;
+      src = `${src};require("__RNIDE_lib__/expo_router_v2_plugin.js");`;
     } else if (version.startsWith("3.")) {
-      // src = `${src};require("__RNIDE_lib__/expo_router_plugin.js");`;
+      src = `${src};require("__RNIDE_lib__/expo_router_plugin.js");`;
     }
   } else if (filename.endsWith("node_modules/react-native-ide/index.js")) {
     src = `${src};preview = require("__RNIDE_lib__/preview.js").preview;`;


### PR DESCRIPTION
This PR fixes an issue with setups that rely on particular order of JSX transform plugin relative to other plugins.

Before, we'd add dev version of jsx-transform plugin at the beginning of the plugins section and disable all other variants of jsx plugin. However, some setups, specifically apps that use nativewind, rely on a particular order of jsx transforms for plugin hoisting.

After digging into the code of jsx transform plugin, I noticed, that across different React Native setups, the dev plugin is already added, it is just not producing output. The reason for that is that there JSXElement nodes are transformed by the non-dev version of the plugin that is typically registered earlier. As a consequence JSXElement visitor never runs in the dev version.

The workaround this PR implements removes JSXElement visitor from non-dev version in case the dev version of jsx transform plugin is present. This is done using a custom plugin that runs before all other plugins, and we also use `pre` callback to make sure it runs early enough.
