### PR TITLE
Redo jsx transform workaround

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -1,6 +1,28 @@
 const ORIGINAL_TRANSFORMER_PATH = process.env.REACT_NATIVE_IDE_ORIG_BABEL_TRANSFORMER_PATH;
 
-const { requireFromAppDir } = require("./metro_helpers");
+const { requireFromAppDir, overrideModuleFromAppDir } = require("./metro_helpers");
+
+// In some configurations, React Native may pull several different version of JSX transoform plugins:
+// plugin-transform-react-jsx-self, plugin-transform-react-jsx-source, plugin-transform-react-jsx and
+// plugin-transform-react-jsx-development. For line and column numbers to be added to components, we
+// need the development version of the plugin. Apparently, it is up to the order of plugins being added
+// whether the development version would actually be allowed to produce the JSXElement node output.
+// To workaround this issue, we override require such that it always pulls in the development version.
+// Apparently, when someone has both dev and non-dev plugins on their babel config, overriding the non-dev
+// version with dev will result in an error, as the dev version has additional checks and throws an error
+// when registered more then once (which is what's going to happen if we turn non-dev into dev version).
+// In order to avoid this, we add a custom plugin that disables all jsx transform visitors that come after
+// the first one.
+const jsxDevTransformer = requireFromAppDir("@babel/plugin-transform-react-jsx/lib/development");
+overrideModuleFromAppDir("@babel/plugin-transform-react-jsx", jsxDevTransformer);
+
+function clearObject(obj) {
+  for (let prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      delete obj[prop];
+    }
+  }
+}
 
 function transformWrapper({ filename, src, plugins, ...rest }) {
   const { transform } = require(ORIGINAL_TRANSFORMER_PATH);
@@ -22,22 +44,16 @@ function transformWrapper({ filename, src, plugins, ...rest }) {
     {
       name: "disable-non-dev-jsx-transformer-exit",
       pre(state) {
-        // In some configurations, React Native may pull several different version of JSX transoform plugins:
-        // plugin-transform-react-jsx-self, plugin-transform-react-jsx-source, plugin-transform-react-jsx and
-        // plugin-transform-react-jsx-development. For line and columnt numbers to be added to components, we
-        // need the development version of the plugin to produce the JSXElement node output. Apparently,
-        // in the default configuration, non-dev version is typically added and runs before the dev version
-        // resulting in the JSXElement node being processed by the non-dev version and the latter, dev version
-        // not seeing the already transformed node. Below, we implement a workaround that deletes JSXElement
-        // visitor from jsx transform plugin, as long as development version of the plugin is also present.
-        // This way we let the development version handle transforming JSXElement nodes.
-        const hasJsxDevTransformer = state.opts.plugins.some(
-          (p) => p.key === "transform-react-jsx/development"
-        );
-        if (hasJsxDevTransformer) {
-          state.opts.plugins.forEach((plugin) => {
-            if (plugin.key === "transform-react-jsx") {
-              delete plugin.visitor.JSXElement;
+        // we disable all jsx transform visitors that come after the first one, because they will
+        // throw an error recognizing that parts of the code have already been transformed.
+        const plugins = state.opts.plugins;
+        const jsxTransformer = plugins.find((p) => p.key === "transform-react-jsx/development");
+        if (jsxTransformer) {
+          plugins.forEach((plugin) => {
+            if (plugin.key.includes("transform-react-jsx") && plugin !== jsxTransformer) {
+              // we need to clear the visitor as it is being referenced in other places, so
+              // reassigning to empty object doesn't work.
+              clearObject(plugin.visitor);
             }
           });
         }


### PR DESCRIPTION
This PR updates the approach landed in #184 

The previous version didn't work in case no dev-version of plugin is installed. Depending on React Native setup, some projects have non-dev and dev jsx-transforms together, and other have only one of them (usually non-dev version). In order to cover all scenarios, this approach re-adds module overriding.

This is an upgrade compared to the approach replaced by #184 as we keep the order of plugins.

The new approach works as follows:
 - using require override, we replace non-dev plugin with dev-plugin. So even if you only have non-dev, you'll still end up using dev plugin
 - if you have both non dev and dev version, this will turn the config to apply dev version twice. Apparently this results in an error, as dev plugin stores some metadata in babel plugin state and detects if code has already been processed. To circumvent that, we post-process plugins list and disable all jsx-transform plugins that occur after the first jsx-transform on the plugin list.