### PR TITLE
Use x icon for closing ide panel in sidepanel mode

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -34,6 +34,7 @@
         "command": "RNIDE.closePanel",
         "title": "Close IDE Panel",
         "category": "React Native IDE",
+        "icon": "$(close)",
         "enablement": "RNIDE.extensionIsActive"
       },
       {


### PR DESCRIPTION
Button for closing IDE panel in sidepanel mode would consist of text "Close IDE Panel" – this has been added for consistency with "Open IDE Panel" button that we show when IDE isn't open. However, following the same pattern here doesn't seem correct, as unlike for opening the IDE we wouldn't be able to provide a single icon that'd make it clear what's going to happen when you click it, it is also much easier to spot "Open IDE Panel" text from a gazzilion of different icons that shows up in the activity bar. To the contrary, the "x" icon has pretty clear semantics, and it is easy for the user to understand what it does especially that it is a sole icon that's present in IDE side-panel's activity bar. Therefore there is no need to pollute that activity bar with a long and unnecessary text button.