### PR TITLE
fix: optional expo router import

### DIFF
--- a/packages/vscode-extension/lib/preview.js
+++ b/packages/vscode-extension/lib/preview.js
@@ -1,4 +1,10 @@
-require("expo-router/entry");
+try {
+    // Attempt to require the expo router package
+    require("expo-router/entry");
+} catch (error) {
+    console.log("The 'expo-router' package is not installed.");
+}
+
 const { AppRegistry, View } = require("react-native");
 
 global.__RNIDE_previews ||= new Map();


### PR DESCRIPTION
importing preview from `react-native-ide` will result in error if `expo-router` is not installed.

```
2024-05-02 00:10:04.776 [error] Unable to resolve module expo-router/entry from /Users/matin.zadeh.dolatabad@schibsted.com/.vscode/extensions/swmansion.react-native-ide-0.0.9-beta/lib/preview.js: expo-router/entry could not be found within the project or in these directories:
  ../../node_modules
  node_modules
  ../../node_modules
> 1 | require("expo-router/entry");
    |          ^
  2 | const { AppRegistry, View } = require("react-native");
  3 |
  4 | global.__RNIDE_previews ||= new Map();
2024-05-02 00:10:04.781 [error] [Error: undefined Unable to resolve module expo-router/entry from /Users/matin.zadeh.dolatabad@schibsted.com/.vscode/extensions/swmansion.react-native-ide-0.0.9-beta/lib/preview.js: expo-router/entry could not be found within the project or in these directories:
  ../../node_modules
  node_modules
  ../../node_modules
> 1 | require("expo-router/entry");
    |          ^
  2 | const { AppRegistry, View } = require("react-native");
  3 |
  4 | global.__RNIDE_previews ||= new Map();]
```

Before:

![image](https://github.com/software-mansion/react-native-ide/assets/24797481/e2bf7091-8fb2-464b-bb89-481498d19aba)


After:

<img width="1840" alt="Screenshot 2024-05-02 at 00 14 12" src="https://github.com/software-mansion/react-native-ide/assets/24797481/d7397862-fdb9-48ee-901f-49c227d1ab5b">
