### PR TITLE
Reset urlList when project resets

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import IconButton from "./shared/IconButton";
-import { ProjectInterface } from "../../common/Project";
+import { ProjectInterface, ProjectState } from "../../common/Project";
 import UrlSelect from "./UrlSelect";
 
 interface UrlBarProps {
@@ -20,8 +20,15 @@ function UrlBar({ project, disabled }: UrlBarProps) {
       ]);
     }
     project.addListener("navigationChanged", handleNavigationChanged);
+    const handleProjectReset = (e: ProjectState) =>{
+      if(e.status === 'starting'){
+        setUrlList([]);
+      }
+    };
+    project.addListener('projectStateChanged', handleProjectReset);
     return () => {
       project.removeListener("navigationChanged", handleNavigationChanged);
+      project.removeListener('projectStateChanged', handleProjectReset);
     };
   }, []);
 


### PR DESCRIPTION
I see a bug related to the fact that after restarting an app (click restart the app  btn) the navigationHistory is empty but the UrlBar persists w/ old urls and then navigation does not work - zero action after clicking through. Should the state inside UrlBar be cleared, or should the navigationHistory persist?

<img width="1506" alt="Screenshot 2024-05-04 at 19 56 55" src="https://github.com/software-mansion/react-native-ide/assets/77052270/213f6955-6911-46d0-ba1f-8c89bd4ba3c5">
<img width="465" alt="Screenshot 2024-05-04 at 20 01 08" src="https://github.com/software-mansion/react-native-ide/assets/77052270/c1d3f168-da44-4eac-8638-a9710e3c68b9">




