### PR TITLE
Update deps of expo-51 project to make it work again after some library updates

### DIFF
--- a/test-apps/expo-51/package-lock.json
+++ b/test-apps/expo-51/package-lock.json
@@ -10,22 +10,22 @@
       "dependencies": {
         "@expo/vector-icons": "^14.0.0",
         "@react-navigation/native": "^6.0.2",
-        "expo": "~51.0.0-preview.8",
+        "expo": "^51.0.0-preview.14",
         "expo-constants": "~16.0.1",
         "expo-font": "~12.0.4",
         "expo-linking": "~6.3.1",
-        "expo-router": "~3.5.5",
-        "expo-splash-screen": "~0.27.2",
+        "expo-router": "^3.5.8",
+        "expo-splash-screen": "^0.27.4",
         "expo-status-bar": "~1.12.1",
-        "expo-system-ui": "~3.0.2",
+        "expo-system-ui": "^3.0.4",
         "expo-web-browser": "~13.0.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-native": "0.74.0",
+        "react-native": "^0.74.1",
         "react-native-gesture-handler": "~2.16.0",
-        "react-native-reanimated": "3.9.0-rc.1",
-        "react-native-safe-area-context": "4.10.0-rc.1",
-        "react-native-screens": "3.31.0-rc.1",
+        "react-native-reanimated": "^3.10.0",
+        "react-native-safe-area-context": "^4.10.1",
+        "react-native-screens": "^3.31.1",
         "react-native-web": "~0.19.10"
       },
       "devDependencies": {
@@ -36,7 +36,7 @@
         "jest": "^29.2.1",
         "jest-expo": "~51.0.1",
         "react-test-renderer": "18.2.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.18.7.tgz",
-      "integrity": "sha512-N16ifo8nXnsp9Z4QIgyA1tX2siq1td8ZrXc9aZ6N4l1V4B3Pz1gX9TeEu8Lc0Xz5wElgQ7zGwfRx4rw/PUivTA==",
+      "version": "0.18.8",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.18.8.tgz",
+      "integrity": "sha512-qS6nquE8rOIFDPkn/4ll28AAe7IkDFDBSC3TE02tT5Rh7JqXEMdhB41BuDBs2te45SUre506DiDdcLY7MLTLcA==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
@@ -2179,7 +2179,7 @@
         "@expo/osascript": "^2.0.31",
         "@expo/package-manager": "^1.5.0",
         "@expo/plist": "^0.1.0",
-        "@expo/prebuild-config": "7.0.1",
+        "@expo/prebuild-config": "7.0.3",
         "@expo/rudder-sdk-node": "1.1.1",
         "@expo/spawn-async": "^1.7.2",
         "@expo/xcpretty": "^4.3.0",
@@ -2370,9 +2370,9 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.3.tgz",
-      "integrity": "sha512-XZRpVGdBKS8p8JrGp9J7wX6oCGq3zwhrVMDXTXsGfZZTVJo/uX6NkXtnl/C3TlxG4Kv5kOuYBekSsnw+i3plRA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.4.tgz",
+      "integrity": "sha512-Hi+xuyNWE2LT4LVbGttHJgl9brnsdWAhEB42gWKb5+8ae86Nr/KwUBQJsJppirBYTeLjj5ZlY0glYnAkDa2jqw==",
       "dependencies": {
         "@expo/config-types": "^51.0.0-unreleased",
         "@expo/json-file": "~8.3.0",
@@ -3129,16 +3129,16 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-7.0.1.tgz",
-      "integrity": "sha512-5q1rzbINPCZzOO1uFR6dhr7NwGOO36gUs1cZO9N7n5McuejwHId0r6TIBNJlHg7vRUJDaeL9C9OTg68N7b809A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-7.0.3.tgz",
+      "integrity": "sha512-Kvxy/oQzkxwXLvAmwb+ygxuRn4xUUN2+mVJj3KDe4bRVCNyDPs7wlgdokF3twnWjzRZssUzseMkhp+yHPjAEhA==",
       "dependencies": {
         "@expo/config": "~9.0.0-beta.0",
         "@expo/config-plugins": "~8.0.0-beta.0",
         "@expo/config-types": "^51.0.0-unreleased",
         "@expo/image-utils": "^0.5.0",
         "@expo/json-file": "^8.3.0",
-        "@react-native/normalize-colors": "~0.74.81",
+        "@react-native/normalize-colors": "~0.74.83",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
         "resolve-from": "^5.0.0",
@@ -4304,18 +4304,18 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.4.tgz",
-      "integrity": "sha512-V7rt2N5JY7M4dJFgdNfR164r3hZdR/Z7V54dv85TFQHRbdwF4QrkG+GeagAU54qrkK/OU8OH3AF2+mKuiNWpGA==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.6.tgz",
+      "integrity": "sha512-IqclB7VQ84ye8Fcs89HOpOscY4284VZg2pojHNl8H0Lzd4DadXJWQoxC7zWm8v2f8eyeX2kdhxp2ETD5tceIgA==",
       "dependencies": {
-        "@react-native-community/cli-clean": "13.6.4",
-        "@react-native-community/cli-config": "13.6.4",
-        "@react-native-community/cli-debugger-ui": "13.6.4",
-        "@react-native-community/cli-doctor": "13.6.4",
-        "@react-native-community/cli-hermes": "13.6.4",
-        "@react-native-community/cli-server-api": "13.6.4",
-        "@react-native-community/cli-tools": "13.6.4",
-        "@react-native-community/cli-types": "13.6.4",
+        "@react-native-community/cli-clean": "13.6.6",
+        "@react-native-community/cli-config": "13.6.6",
+        "@react-native-community/cli-debugger-ui": "13.6.6",
+        "@react-native-community/cli-doctor": "13.6.6",
+        "@react-native-community/cli-hermes": "13.6.6",
+        "@react-native-community/cli-server-api": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
+        "@react-native-community/cli-types": "13.6.6",
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "deepmerge": "^4.3.0",
@@ -4334,11 +4334,11 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-13.6.4.tgz",
-      "integrity": "sha512-nS1BJ+2Z+aLmqePxB4AYgJ+C/bgQt02xAgSYtCUv+lneRBGhL2tHRrK8/Iolp0y+yQoUtHHf4txYi90zGXLVfw==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-13.6.6.tgz",
+      "integrity": "sha512-cBwJTwl0NyeA4nyMxbhkWZhxtILYkbU3TW3k8AXLg+iGphe0zikYMGB3T+haTvTc6alTyEFwPbimk9bGIqkjAQ==",
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2"
@@ -4486,11 +4486,11 @@
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-13.6.4.tgz",
-      "integrity": "sha512-GGK415WoTx1R9FXtfb/cTnan9JIWwSm+a5UCuFd6+suzS0oIt1Md1vCzjNh6W1CK3b43rZC2e+3ZU7Ljd7YtyQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-13.6.6.tgz",
+      "integrity": "sha512-mbG425zCKr8JZhv/j11382arezwS/70juWMsn8j2lmrGTrP1cUdW0MF15CCIFtJsqyK3Qs+FTmqttRpq81QfSg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^4.3.0",
@@ -4563,23 +4563,23 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.4.tgz",
-      "integrity": "sha512-9Gs31s6tA1kuEo69ay9qLgM3x2gsN/RI994DCUKnFSW+qSusQJyyrmfllR2mGU3Wl1W09/nYpIg87W9JPf5y4A==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.6.tgz",
+      "integrity": "sha512-Vv9u6eS4vKSDAvdhA0OiQHoA7y39fiPIgJ6biT32tN4avHDtxlc6TWZGiqv7g98SBvDWvoVAmdPLcRf3kU+c8g==",
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-13.6.4.tgz",
-      "integrity": "sha512-lWOXCISH/cHtLvO0cWTr+IPSzA54FewVOw7MoCMEvWusH+1n7c3hXTAve78mLozGQ7iuUufkHFWwKf3dzOkflQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-13.6.6.tgz",
+      "integrity": "sha512-TWZb5g6EmQe2Ua2TEWNmyaEayvlWH4GmdD9ZC+p8EpKFpB1NpDGMK6sXbpb42TDvwZg5s4TDRplK0PBEA/SVDg==",
       "dependencies": {
-        "@react-native-community/cli-config": "13.6.4",
-        "@react-native-community/cli-platform-android": "13.6.4",
-        "@react-native-community/cli-platform-apple": "13.6.4",
-        "@react-native-community/cli-platform-ios": "13.6.4",
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-config": "13.6.6",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-platform-apple": "13.6.6",
+        "@react-native-community/cli-platform-ios": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "deepmerge": "^4.3.0",
@@ -4856,12 +4856,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-13.6.4.tgz",
-      "integrity": "sha512-VIAufA/2wTccbMYBT9o+mQs9baOEpTxCiIdWeVdkPWKzIwtKsLpDZJlUqj4r4rI66mwjFyQ60PhwSzEJ2ApFeQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-13.6.6.tgz",
+      "integrity": "sha512-La5Ie+NGaRl3klei6WxKoOxmCUSGGxpOk6vU5pEGf0/O7ky+Ay0io+zXYUZqlNMi/cGpO7ZUijakBYOB/uyuFg==",
       "dependencies": {
-        "@react-native-community/cli-platform-android": "13.6.4",
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6"
       }
@@ -4931,11 +4931,11 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.4.tgz",
-      "integrity": "sha512-WhknYwIobKKCqaGCN3BzZEQHTbaZTDiGvcXzevvN867ldfaGdtbH0DVqNunbPoV1RNzeV9qKoQHFdWBkg83tpg==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.6.tgz",
+      "integrity": "sha512-/tMwkBeNxh84syiSwNlYtmUz/Ppc+HfKtdopL/5RB+fd3SV1/5/NPNjMlyLNgFKnpxvKCInQ7dnl6jGHJjeHjg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
@@ -5085,11 +5085,11 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-apple": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.4.tgz",
-      "integrity": "sha512-TLBiotdIz0veLbmvNQIdUv9fkBx7m34ANGYqr5nH7TFxdmey+Z+omoBqG/HGpvyR7d0AY+kZzzV4k+HkYHM/aQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.6.tgz",
+      "integrity": "sha512-bOmSSwoqNNT3AmCRZXEMYKz1Jf1l2F86Nhs7qBcXdY/sGiJ+Flng564LOqvdAlVLTbkgz47KjNKCS2pP4Jg0Mg==",
       "dependencies": {
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-tools": "13.6.6",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-glob": "^3.3.2",
@@ -5299,27 +5299,27 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.4.tgz",
-      "integrity": "sha512-8Dlva8RY+MY5nhWAj6V7voG3+JOEzDTJmD0FHqL+4p0srvr9v7IEVcxfw5lKBDIUNd0OMAHNevGA+cyz1J60jg==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.6.tgz",
+      "integrity": "sha512-vjDnRwhlSN5ryqKTas6/DPkxuouuyFBAqAROH4FR1cspTbn6v78JTZKDmtQy9JMMo7N5vZj1kASU5vbFep9IOQ==",
       "dependencies": {
-        "@react-native-community/cli-platform-apple": "13.6.4"
+        "@react-native-community/cli-platform-apple": "13.6.6"
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-13.6.4.tgz",
-      "integrity": "sha512-D2qSuYCFwrrUJUM0SDc9l3lEhU02yjf+9Peri/xhspzAhALnsf6Z/H7BCjddMV42g9/eY33LqiGyN5chr83a+g==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-13.6.6.tgz",
+      "integrity": "sha512-ZtCXxoFlM7oDv3iZ3wsrT3SamhtUJuIkX2WePLPlN5bcbq7zimbPm2lHyicNJtpcGQ5ymsgpUWPCNZsWQhXBqQ==",
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "13.6.4",
-        "@react-native-community/cli-tools": "13.6.4",
+        "@react-native-community/cli-debugger-ui": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
         "nocache": "^3.0.1",
         "pretty-format": "^26.6.2",
         "serve-static": "^1.13.1",
-        "ws": "^7.5.1"
+        "ws": "^6.2.2"
       }
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/@jest/types": {
@@ -5429,29 +5429,17 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-13.6.4.tgz",
-      "integrity": "sha512-N4oHLLbeTdg8opqJozjClmuTfazo1Mt+oxU7mr7m45VCsFgBqTF70Uwad289TM/3l44PP679NRMAHVYqpIRYtQ==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-13.6.6.tgz",
+      "integrity": "sha512-ptOnn4AJczY5njvbdK91k4hcYazDnGtEPrqIwEI+k/CTBHNdb27Rsm2OZ7ye6f7otLBqF8gj/hK6QzJs8CEMgw==",
       "dependencies": {
         "appdirsjs": "^1.2.4",
         "chalk": "^4.1.2",
@@ -5722,9 +5710,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "13.6.4",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-13.6.4.tgz",
-      "integrity": "sha512-NxGCNs4eYtVC8x0wj0jJ/MZLRy8C+B9l8lY8kShuAcvWTv5JXRqmXjg8uK1aA+xikPh0maq4cc/zLw1roroY/A==",
+      "version": "13.6.6",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-13.6.6.tgz",
+      "integrity": "sha512-733iaYzlmvNK7XYbnWlMjdE+2k0hlTBJW071af/xb6Bs+hbJqBP9c03FZuYH2hFFwDDntwj05bkri/P7VgSxug==",
       "dependencies": {
         "joi": "^17.2.1"
       }
@@ -5957,28 +5945,28 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.81.tgz",
-      "integrity": "sha512-ms+D6pJ6l30epm53pwnAislW79LEUHJxWfe1Cu0LWyTTBlg1OFoqXfB3eIbpe4WyH3nrlkQAh0yyk4huT2mCvw==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.83.tgz",
+      "integrity": "sha512-2vkLMVnp+YTZYTNSDIBZojSsjz8sl5PscP3j4GcV6idD8V978SZfwFlk8K0ti0BzRs11mzL0Pj17km597S/eTQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.81.tgz",
-      "integrity": "sha512-Bj6g5/xkLMBAdC6665TbD3uCKCQSmLQpGv3gyqya/ydZpv3dDmDXfkGmO4fqTwEMunzu09Sk55st2ipmuXAaAg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.83.tgz",
+      "integrity": "sha512-+S0st3t4Ro00bi9gjT1jnK8qTFOU+CwmziA7U9odKyWrCoRJrgmrvogq/Dr1YXlpFxexiGIupGut1VHxr+fxJA==",
       "dependencies": {
-        "@react-native/codegen": "0.74.81"
+        "@react-native/codegen": "0.74.83"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.81.tgz",
-      "integrity": "sha512-H80B3Y3lBBVC4x9tceTEQq/04lx01gW6ajWCcVbd7sHvGEAxfMFEZUmVZr0451Cafn02wVnDJ8psto1F+0w5lw==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.83.tgz",
+      "integrity": "sha512-KJuu3XyVh3qgyUer+rEqh9a/JoUxsDOzkJNfRpDyXiAyjDRoVch60X/Xa/NcEQ93iCVHAWs0yQ+XGNGIBCYE6g==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
@@ -6020,7 +6008,7 @@
         "@babel/plugin-transform-typescript": "^7.5.0",
         "@babel/plugin-transform-unicode-regex": "^7.0.0",
         "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.74.81",
+        "@react-native/babel-plugin-codegen": "0.74.83",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
@@ -6032,9 +6020,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.81.tgz",
-      "integrity": "sha512-hhXo4ccv2lYWaJrZDsdbRTZ5SzSOdyZ0MY6YXwf3xEFLuSunbUMu17Rz5LXemKXlpVx4KEgJ/TDc2pPVaRPZgA==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.83.tgz",
+      "integrity": "sha512-GgvgHS3Aa2J8/mp1uC/zU8HuTh8ZT5jz7a4mVMWPw7+rGyv70Ba8uOVBq6UH2Q08o617IATYc+0HfyzAfm4n0w==",
       "dependencies": {
         "@babel/parser": "^7.20.0",
         "glob": "^7.1.1",
@@ -6052,14 +6040,14 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.81.tgz",
-      "integrity": "sha512-ezPOwPxbDgrBZLJJMcXryXJXjv3VWt+Mt4jRZiEtvy6pAoi2owSH0b178T5cEZaWsxQN0BbyJ7F/xJsNiF4z0Q==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.83.tgz",
+      "integrity": "sha512-7GAFjFOg1mFSj8bnFNQS4u8u7+QtrEeflUIDVZGEfBZQ3wMNI5ycBzbBGycsZYiq00Xvoc6eKFC7kvIaqeJpUQ==",
       "dependencies": {
-        "@react-native-community/cli-server-api": "13.6.4",
-        "@react-native-community/cli-tools": "13.6.4",
-        "@react-native/dev-middleware": "0.74.81",
-        "@react-native/metro-babel-transformer": "0.74.81",
+        "@react-native-community/cli-server-api": "13.6.6",
+        "@react-native-community/cli-tools": "13.6.6",
+        "@react-native/dev-middleware": "0.74.83",
+        "@react-native/metro-babel-transformer": "0.74.83",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "metro": "^0.80.3",
@@ -6215,20 +6203,20 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.81.tgz",
-      "integrity": "sha512-HCYF1/88AfixG75558HkNh9wcvGweRaSZGBA71KoZj03umXM8XJy0/ZpacGOml2Fwiqpil72gi6uU+rypcc/vw==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.83.tgz",
+      "integrity": "sha512-RGQlVUegBRxAUF9c1ss1ssaHZh6CO+7awgtI9sDeU0PzDZY/40ImoPD5m0o0SI6nXoVzbPtcMGzU+VO590pRfA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.81.tgz",
-      "integrity": "sha512-x2IpvUJN1LJE0WmPsSfQIbQaa9xwH+2VDFOUrzuO9cbQap8rNfZpcvVNbrZgrlKbgS4LXbbsj6VSL8b6SnMKMA==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.83.tgz",
+      "integrity": "sha512-UH8iriqnf7N4Hpi20D7M2FdvSANwTVStwFCSD7VMU9agJX88Yk0D1T6Meh2RMhUu4kY2bv8sTkNRm7LmxvZqgA==",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.74.81",
+        "@react-native/debugger-frontend": "0.74.83",
         "@rnx-kit/chromium-edge-launcher": "^1.0.0",
         "chrome-launcher": "^0.15.2",
         "connect": "^3.6.5",
@@ -6282,28 +6270,28 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.81.tgz",
-      "integrity": "sha512-7YQ4TLnqfe2kplWWzBWO6k0rPSrWEbuEiRXSJNZQCtCk+t2YX985G62p/9jWm3sGLN4UTcpDXaFNTTPBvlycoQ==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.83.tgz",
+      "integrity": "sha512-Pw2BWVyOHoBuJVKxGVYF6/GSZRf6+v1Ygc+ULGz5t20N8qzRWPa2fRZWqoxsN7TkNLPsECYY8gooOl7okOcPAQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.81.tgz",
-      "integrity": "sha512-o4MiR+/kkHoeoQ/zPwt81LnTm6pqdg0wOhU7S7vIZUqzJ7YUpnpaAvF+/z7HzUOPudnavoCN0wvcZPe/AMEyCA==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.83.tgz",
+      "integrity": "sha512-/t74n8r6wFhw4JEoOj3bN71N1NDLqaawB75uKAsSjeCwIR9AfCxlzZG0etsXtOexkY9KMeZIQ7YwRPqUdNXuqw==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.81.tgz",
-      "integrity": "sha512-PVcMjj23poAK6Uemflz4MIJdEpONpjqF7JASNqqQkY6wfDdaIiZSNk8EBCWKb0t7nKqhMvtTq11DMzYJ0JFITg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.83.tgz",
+      "integrity": "sha512-hGdx5N8diu8y+GW/ED39vTZa9Jx1di2ZZ0aapbhH4egN1agIAusj5jXTccfNBwwWF93aJ5oVbRzfteZgjbutKg==",
       "dependencies": {
         "@babel/core": "^7.20.0",
-        "@react-native/babel-preset": "0.74.81",
+        "@react-native/babel-preset": "0.74.83",
         "hermes-parser": "0.19.1",
         "nullthrows": "^1.1.1"
       },
@@ -6315,14 +6303,14 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.81.tgz",
-      "integrity": "sha512-g3YvkLO7UsSWiDfYAU+gLhRHtEpUyz732lZB+N8IlLXc5MnfXHC8GKneDGY3Mh52I3gBrs20o37D5viQX9E1CA=="
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.83.tgz",
+      "integrity": "sha512-jhCY95gRDE44qYawWVvhTjTplW1g+JtKTKM3f8xYT1dJtJ8QWv+gqEtKcfmOHfDkSDaMKG0AGBaDTSK8GXLH8Q=="
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.74.81",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.81.tgz",
-      "integrity": "sha512-5jF9S10Ug2Wl+L/0+O8WmbC726sMMX8jk/1JrvDDK+0DRLMobfjLc1L26fONlVBF7lE5ctqvKZ9TlKdhPTNOZg==",
+      "version": "0.74.83",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.83.tgz",
+      "integrity": "sha512-rmaLeE34rj7py4FxTod7iMTC7BAsm+HrGA8WxYmEJeyTV7WSaxAkosKoYBz8038mOiwnG9VwA/7FrB6bEQvn1A==",
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -7364,9 +7352,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.2.tgz",
-      "integrity": "sha512-Vbe/es+J7roUkOxoyTvqc1eQnyR7bKlF7csflSOttcQuLo0O0bSZW+3rGA2rXkYtc2MBw/3Bax0Yk4acc/JUaQ==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.5.tgz",
+      "integrity": "sha512-IjqR4B7wnBU55pofLeLGjwUGrWJE1buamgzE9CYpYCNicZmJcNjXUcinQiurXCMuClF2hOff3QfZsLxnGj1UaA==",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-transform-export-namespace-from": "^7.22.11",
@@ -7374,9 +7362,9 @@
         "@babel/plugin-transform-parameters": "^7.22.15",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "~0.74.81",
+        "@react-native/babel-preset": "~0.74.83",
         "babel-plugin-react-native-web": "~0.19.10",
-        "react-refresh": "0.14.0"
+        "react-refresh": "^0.14.2"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -9106,23 +9094,23 @@
       }
     },
     "node_modules/expo": {
-      "version": "51.0.0-preview.8",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.0-preview.8.tgz",
-      "integrity": "sha512-8TDwXVjQ8mkdVIecKmy2wJaZzdRnhmk/hBYDvafcK+cl4ip6ZJCQt5DqERgvLkus0HZGWMMWd4xjRIY4FNQMIg==",
+      "version": "51.0.0-preview.14",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.0-preview.14.tgz",
+      "integrity": "sha512-QKmsAsjJRBxOINfl8ncuAzVpBh50pzJDs0I1gU089LaA1r6pJPqBy9j/jMYRR54E8ENcGPgBmIbzAmagEoEItg==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.18.7",
+        "@expo/cli": "0.18.8",
         "@expo/config": "9.0.1",
-        "@expo/config-plugins": "8.0.3",
+        "@expo/config-plugins": "8.0.4",
         "@expo/metro-config": "0.18.3",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~11.0.2",
-        "expo-asset": "~10.0.3",
+        "babel-preset-expo": "~11.0.5",
+        "expo-asset": "~10.0.6",
         "expo-file-system": "~17.0.1",
         "expo-font": "~12.0.4",
         "expo-keep-awake": "~13.0.1",
         "expo-modules-autolinking": "1.11.1",
-        "expo-modules-core": "1.12.4",
+        "expo-modules-core": "1.12.8",
         "fbemitter": "^3.0.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -9131,11 +9119,11 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-10.0.3.tgz",
-      "integrity": "sha512-J7qJRwj39md+NoLJtZyimVx348MRRQq7KCfMbEZqOA9RQOzhtX2+IY9K3EeF/1sCn1QsWaVJx4e7xFAwVshzUA==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-10.0.6.tgz",
+      "integrity": "sha512-waP73/ccn/HZNNcGM4/s3X3icKjSSbEQ9mwc6tX34oYNg+XE5WdwOuZ9wgVVFrU7wZMitq22lQXd2/O0db8bxg==",
       "dependencies": {
-        "@react-native/assets-registry": "~0.74.81",
+        "@react-native/assets-registry": "~0.74.83",
         "expo-constants": "~16.0.0",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
@@ -9304,17 +9292,17 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.12.4.tgz",
-      "integrity": "sha512-+EnwUjVUVtZ5Qo899Tptz2HJBu44owZl4jetymEmGEngQzNyFH9GDCVAz2poTAZYN9U7mo45bLbvYtlDdJ99Mg==",
+      "version": "1.12.8",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.12.8.tgz",
+      "integrity": "sha512-9v2O88JHCw21x3PuHxE6MPHdsjtTUfcixXi9vsI9KWZTSYjqjAhVz02D3zwwq8iAKvA0BMOqc/quq05cptZPVw==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
     },
     "node_modules/expo-router": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.5.5.tgz",
-      "integrity": "sha512-Z68gUp/C2LueVAANTbv2DBPFQ4AIV8bJ9fjXzi5cqwW9B72j4648eeUQl/OdFLAN/Xy0fQeJ+xo8oRgGgV+rpQ==",
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/expo-router/-/expo-router-3.5.8.tgz",
+      "integrity": "sha512-rHtf4ZU8lJBnGMsXznw8Uqol8+cTpBJfstycqYoiEub9WsGWsMn/HnatBZ7Amlm1imY9b/Ev7hLVailaogvfhQ==",
       "dependencies": {
         "@expo/metro-runtime": "3.2.1",
         "@expo/server": "^0.4.0",
@@ -9322,7 +9310,7 @@
         "@react-navigation/bottom-tabs": "~6.5.7",
         "@react-navigation/native": "~6.1.6",
         "@react-navigation/native-stack": "~6.9.12",
-        "expo-splash-screen": "0.27.2",
+        "expo-splash-screen": "0.27.4",
         "react-native-helmet-async": "2.0.4",
         "schema-utils": "^4.0.1"
       },
@@ -9404,11 +9392,11 @@
       }
     },
     "node_modules/expo-splash-screen": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.2.tgz",
-      "integrity": "sha512-XD+ym2po5dHybJ8sBCX7g09LK5xhEg7YSNgRAZkoSyYNLEuzU71SOUReWnYVrXqKZuE4eKBETC14QGdKzDuMXg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.27.4.tgz",
+      "integrity": "sha512-JwepK1FjbwiOK2nwIFanfzj9s7UXYnpTwLX8A9v7Ec3K4V28yu8HooSc9X60cftBw9UZrs8Gwj4PgTpQabBS9A==",
       "dependencies": {
-        "@expo/prebuild-config": "7.0.1"
+        "@expo/prebuild-config": "7.0.3"
       },
       "peerDependencies": {
         "expo": "*"
@@ -9420,11 +9408,11 @@
       "integrity": "sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA=="
     },
     "node_modules/expo-system-ui": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-3.0.2.tgz",
-      "integrity": "sha512-4ZV9PTY83jB0RsjyDuJdsr0PKRI43+HoZUGYgkgDK93tOn79ZuBjv3fldVBABnXx6RNRRooOzNAHDPbgo5lz8A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-3.0.4.tgz",
+      "integrity": "sha512-v1n6hBO30k9qw6RE8/au4yNoovs71ExGuXizJUlR5KSo4Ruogpb+0/2q3uRZMDIYWWCANvms8L0UOh6fQJ5TXg==",
       "dependencies": {
-        "@react-native/normalize-colors": "~0.74.81",
+        "@react-native/normalize-colors": "~0.74.83",
         "debug": "^4.3.2"
       },
       "peerDependencies": {
@@ -12965,9 +12953,9 @@
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww=="
     },
     "node_modules/joi": {
-      "version": "17.13.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.0.tgz",
-      "integrity": "sha512-9qcrTyoBmFZRNHeVP4edKqIUEgFzq7MHvTNSDuHSqkpOPtiBkgNgcmTSqmiw1kw9tdKaiddvIDv/eCJDxmqWCA==",
+      "version": "17.13.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.1.tgz",
+      "integrity": "sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -13790,9 +13778,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.8.tgz",
-      "integrity": "sha512-in7S0W11mg+RNmcXw+2d9S3zBGmCARDxIwoXJAmLUQOQoYsRP3cpGzyJtc7WOw8+FXfpgXvceD0u+PZIHXEL7g==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.9.tgz",
+      "integrity": "sha512-Bc57Xf3GO2Xe4UWQsBj/oW6YfLPABEu8jfDVDiNmJvoQW4CO34oDPuYKe4KlXzXhcuNsqOtSxpbjCRRVjhhREg==",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.20.0",
@@ -13815,18 +13803,18 @@
         "jest-worker": "^29.6.3",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.80.8",
-        "metro-cache": "0.80.8",
-        "metro-cache-key": "0.80.8",
-        "metro-config": "0.80.8",
-        "metro-core": "0.80.8",
-        "metro-file-map": "0.80.8",
-        "metro-resolver": "0.80.8",
-        "metro-runtime": "0.80.8",
-        "metro-source-map": "0.80.8",
-        "metro-symbolicate": "0.80.8",
-        "metro-transform-plugins": "0.80.8",
-        "metro-transform-worker": "0.80.8",
+        "metro-babel-transformer": "0.80.9",
+        "metro-cache": "0.80.9",
+        "metro-cache-key": "0.80.9",
+        "metro-config": "0.80.9",
+        "metro-core": "0.80.9",
+        "metro-file-map": "0.80.9",
+        "metro-resolver": "0.80.9",
+        "metro-runtime": "0.80.9",
+        "metro-source-map": "0.80.9",
+        "metro-symbolicate": "0.80.9",
+        "metro-transform-plugins": "0.80.9",
+        "metro-transform-worker": "0.80.9",
         "mime-types": "^2.1.27",
         "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -13846,9 +13834,9 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.8.tgz",
-      "integrity": "sha512-TTzNwRZb2xxyv4J/+yqgtDAP2qVqH3sahsnFu6Xv4SkLqzrivtlnyUbaeTdJ9JjtADJUEjCbgbFgUVafrXdR9Q==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.9.tgz",
+      "integrity": "sha512-d76BSm64KZam1nifRZlNJmtwIgAeZhZG3fi3K+EmPOlrR8rDtBxQHDSN3fSGeNB9CirdTyabTMQCkCup6BXFSQ==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "hermes-parser": "0.20.1",
@@ -13872,11 +13860,11 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.8.tgz",
-      "integrity": "sha512-5svz+89wSyLo7BxdiPDlwDTgcB9kwhNMfNhiBZPNQQs1vLFXxOkILwQiV5F2EwYT9DEr6OPZ0hnJkZfRQ8lDYQ==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.9.tgz",
+      "integrity": "sha512-ujEdSI43QwI+Dj2xuNax8LMo8UgKuXJEdxJkzGPU6iIx42nYa1byQ+aADv/iPh5sh5a//h5FopraW5voXSgm2w==",
       "dependencies": {
-        "metro-core": "0.80.8",
+        "metro-core": "0.80.9",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -13884,9 +13872,9 @@
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.8.tgz",
-      "integrity": "sha512-qWKzxrLsRQK5m3oH8ePecqCc+7PEhR03cJE6Z6AxAj0idi99dHOSitTmY0dclXVB9vP2tQIAE8uTd8xkYGk8fA==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.9.tgz",
+      "integrity": "sha512-hRcYGhEiWIdM87hU0fBlcGr+tHDEAT+7LYNCW89p5JhErFt/QaAkVx4fb5bW3YtXGv5BTV7AspWPERoIb99CXg==",
       "engines": {
         "node": ">=18"
       }
@@ -13906,38 +13894,38 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.8.tgz",
-      "integrity": "sha512-VGQJpfJawtwRzGzGXVUoohpIkB0iPom4DmSbAppKfumdhtLA8uVeEPp2GM61kL9hRvdbMhdWA7T+hZFDlo4mJA==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.9.tgz",
+      "integrity": "sha512-28wW7CqS3eJrunRGnsibWldqgwRP9ywBEf7kg+uzUHkSFJNKPM1K3UNSngHmH0EZjomizqQA2Zi6/y6VdZMolg==",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "jest-validate": "^29.6.3",
-        "metro": "0.80.8",
-        "metro-cache": "0.80.8",
-        "metro-core": "0.80.8",
-        "metro-runtime": "0.80.8"
+        "metro": "0.80.9",
+        "metro-cache": "0.80.9",
+        "metro-core": "0.80.9",
+        "metro-runtime": "0.80.9"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.8.tgz",
-      "integrity": "sha512-g6lud55TXeISRTleW6SHuPFZHtYrpwNqbyFIVd9j9Ofrb5IReiHp9Zl8xkAfZQp8v6ZVgyXD7c130QTsCz+vBw==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.9.tgz",
+      "integrity": "sha512-tbltWQn+XTdULkGdzHIxlxk4SdnKxttvQQV3wpqqFbHDteR4gwCyTR2RyYJvxgU7HELfHtrVbqgqAdlPByUSbg==",
       "dependencies": {
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.80.8"
+        "metro-resolver": "0.80.9"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.8.tgz",
-      "integrity": "sha512-eQXMFM9ogTfDs2POq7DT2dnG7rayZcoEgRbHPXvhUWkVwiKkro2ngcBE++ck/7A36Cj5Ljo79SOkYwHaWUDYDw==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.9.tgz",
+      "integrity": "sha512-sBUjVtQMHagItJH/wGU9sn3k2u0nrCl0CdR4SFMO1tksXLKbkigyQx4cbpcyPVOAmGTVuy3jyvBlELaGCAhplQ==",
       "dependencies": {
         "anymatch": "^3.0.3",
         "debug": "^2.2.0",
@@ -13971,9 +13959,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.8.tgz",
-      "integrity": "sha512-y8sUFjVvdeUIINDuW1sejnIjkZfEF+7SmQo0EIpYbWmwh+kq/WMj74yVaBWuqNjirmUp1YNfi3alT67wlbBWBQ==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.9.tgz",
+      "integrity": "sha512-FEeCeFbkvvPuhjixZ1FYrXtO0araTpV6UbcnGgDUpH7s7eR5FG/PiJz3TsuuPP/HwCK19cZtQydcA2QrCw446A==",
       "dependencies": {
         "terser": "^5.15.0"
       },
@@ -13982,17 +13970,17 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.8.tgz",
-      "integrity": "sha512-JdtoJkP27GGoZ2HJlEsxs+zO7jnDUCRrmwXJozTlIuzLHMRrxgIRRby9fTCbMhaxq+iA9c+wzm3iFb4NhPmLbQ==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.9.tgz",
+      "integrity": "sha512-wAPIjkN59BQN6gocVsAvvpZ1+LQkkqUaswlT++cJafE/e54GoVkMNCmrR4BsgQHr9DknZ5Um/nKueeN7kaEz9w==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.8.tgz",
-      "integrity": "sha512-2oScjfv6Yb79PelU1+p8SVrCMW9ZjgEiipxq7jMRn8mbbtWzyv3g8Mkwr+KwOoDFI/61hYPUbY8cUnu278+x1g==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.9.tgz",
+      "integrity": "sha512-8PTVIgrVcyU+X/rVCy/9yxNlvXsBCk5JwwkbAm/Dm+Abo6NBGtNjWF0M1Xo/NWCb4phamNWcD7cHdR91HhbJvg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0"
       },
@@ -14001,16 +13989,16 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.8.tgz",
-      "integrity": "sha512-+OVISBkPNxjD4eEKhblRpBf463nTMk3KMEeYS8Z4xM/z3qujGJGSsWUGRtH27+c6zElaSGtZFiDMshEb8mMKQg==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.9.tgz",
+      "integrity": "sha512-RMn+XS4VTJIwMPOUSj61xlxgBvPeY4G6s5uIn6kt6HB6A/k9ekhr65UkkDD7WzHYs3a9o869qU8tvOZvqeQzgw==",
       "dependencies": {
         "@babel/traverse": "^7.20.0",
         "@babel/types": "^7.20.0",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.80.8",
+        "metro-symbolicate": "0.80.9",
         "nullthrows": "^1.1.1",
-        "ob1": "0.80.8",
+        "ob1": "0.80.9",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -14027,12 +14015,12 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.8.tgz",
-      "integrity": "sha512-nwhYySk79jQhwjL9QmOUo4wS+/0Au9joEryDWw7uj4kz2yvw1uBjwmlql3BprQCBzRdB3fcqOP8kO8Es+vE31g==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.9.tgz",
+      "integrity": "sha512-Ykae12rdqSs98hg41RKEToojuIW85wNdmSe/eHUgMkzbvCFNVgcC0w3dKZEhSsqQOXapXRlLtHkaHLil0UD/EA==",
       "dependencies": {
         "invariant": "^2.2.4",
-        "metro-source-map": "0.80.8",
+        "metro-source-map": "0.80.9",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "through2": "^2.0.1",
@@ -14054,9 +14042,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.8.tgz",
-      "integrity": "sha512-sSu8VPL9Od7w98MftCOkQ1UDeySWbsIAS5I54rW22BVpPnI3fQ42srvqMLaJUQPjLehUanq8St6OMBCBgH/UWw==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.9.tgz",
+      "integrity": "sha512-UlDk/uc8UdfLNJhPbF3tvwajyuuygBcyp+yBuS/q0z3QSuN/EbLllY3rK8OTD9n4h00qZ/qgxGv/lMFJkwP4vg==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
@@ -14069,21 +14057,21 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.8.tgz",
-      "integrity": "sha512-+4FG3TQk3BTbNqGkFb2uCaxYTfsbuFOCKMMURbwu0ehCP8ZJuTUramkaNZoATS49NSAkRgUltgmBa4YaKZ5mqw==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.9.tgz",
+      "integrity": "sha512-c/IrzMUVnI0hSVVit4TXzt3A1GiUltGVlzCmLJWxNrBGHGrJhvgePj38+GXl1Xf4Fd4vx6qLUkKMQ3ux73bFLQ==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.0",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "metro": "0.80.8",
-        "metro-babel-transformer": "0.80.8",
-        "metro-cache": "0.80.8",
-        "metro-cache-key": "0.80.8",
-        "metro-minify-terser": "0.80.8",
-        "metro-source-map": "0.80.8",
-        "metro-transform-plugins": "0.80.8",
+        "metro": "0.80.9",
+        "metro-babel-transformer": "0.80.9",
+        "metro-cache": "0.80.9",
+        "metro-cache-key": "0.80.9",
+        "metro-minify-terser": "0.80.9",
+        "metro-source-map": "0.80.9",
+        "metro-transform-plugins": "0.80.9",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -14654,9 +14642,9 @@
       "dev": true
     },
     "node_modules/ob1": {
-      "version": "0.80.8",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.8.tgz",
-      "integrity": "sha512-QHJQk/lXMmAW8I7AIM3in1MSlwe1umR72Chhi8B7Xnq6mzjhBKkA6Fy/zAhQnGkA4S912EPCEvTij5yh+EQTAA==",
+      "version": "0.80.9",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.9.tgz",
+      "integrity": "sha512-v9yOxowkZbxWhKOaaTyLjIm1aLy4ebMNcSn4NYJKOAI/Qv+SkfEfszpLr2GIxsccmb2Y2HA9qtsqiIJ80ucpVA==",
       "engines": {
         "node": ">=18"
       }
@@ -15440,21 +15428,21 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-native": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.0.tgz",
-      "integrity": "sha512-Vpp9WPmkCm4TUH5YDxwQhqktGVon/yLpjbTgjgLqup3GglOgWagYCX3MlmK1iksIcqtyMJHMEWa+UEzJ3G9T8w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.1.tgz",
+      "integrity": "sha512-0H2XpmghwOtfPpM2LKqHIN7gxy+7G/r1hwJHKLV6uoyXGC/gCojRtoo5NqyKrWpFC8cqyT6wTYCLuG7CxEKilg==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native-community/cli": "13.6.4",
-        "@react-native-community/cli-platform-android": "13.6.4",
-        "@react-native-community/cli-platform-ios": "13.6.4",
-        "@react-native/assets-registry": "0.74.81",
-        "@react-native/codegen": "0.74.81",
-        "@react-native/community-cli-plugin": "0.74.81",
-        "@react-native/gradle-plugin": "0.74.81",
-        "@react-native/js-polyfills": "0.74.81",
-        "@react-native/normalize-colors": "0.74.81",
-        "@react-native/virtualized-lists": "0.74.81",
+        "@react-native-community/cli": "13.6.6",
+        "@react-native-community/cli-platform-android": "13.6.6",
+        "@react-native-community/cli-platform-ios": "13.6.6",
+        "@react-native/assets-registry": "0.74.83",
+        "@react-native/codegen": "0.74.83",
+        "@react-native/community-cli-plugin": "0.74.83",
+        "@react-native/gradle-plugin": "0.74.83",
+        "@react-native/js-polyfills": "0.74.83",
+        "@react-native/normalize-colors": "0.74.83",
+        "@react-native/virtualized-lists": "0.74.83",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -15528,9 +15516,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.9.0-rc.1",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.9.0-rc.1.tgz",
-      "integrity": "sha512-/u1reKR6dIlirf4CXBTtjOLCT7XybPLIPB2xRgZyswptoDLRLX2BiBJS4ec0IZkT2gBv8QwSPqoDru1J8Z8lUQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.10.0.tgz",
+      "integrity": "sha512-oiQiO+iJ8HTXTli94+Cl5R7nd+TzZf+3MYnMKWtnVDDCxFsqBgpkKO2Xp2ZhZyseXY/JDdH0//E7LlPQRRxpXg==",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
@@ -15548,18 +15536,18 @@
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "4.10.0-rc.1",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.10.0-rc.1.tgz",
-      "integrity": "sha512-DOzh3rh6TBuPcaAkRtlBjZ18E4zQfCqgtrZtzLsFJTvKSJsONIansl87rrfq5m1DxUHzryhXGP3vU1WYsGh5vg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.10.1.tgz",
+      "integrity": "sha512-w8tCuowDorUkPoWPXmhqosovBr33YsukkwYCDERZFHAxIkx6qBadYxfeoaJ91nCQKjkNzGrK5qhoNOeSIcYSpA==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
     },
     "node_modules/react-native-screens": {
-      "version": "3.31.0-rc.1",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.31.0-rc.1.tgz",
-      "integrity": "sha512-OqkQAKDUnTOMzSy22W6LnnubzqCaGiUaA9CFKOWNQ3Km76JeLEyee7L4kSgPOR7zB4uvcCCwY8aBm1pMXFpS2A==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.31.1.tgz",
+      "integrity": "sha512-8fRW362pfZ9y4rS8KY5P3DFScrmwo/vu1RrRMMx0PNHbeC9TLq0Kw1ubD83591yz64gLNHFLTVkTJmWeWCXKtQ==",
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -15729,9 +15717,9 @@
       }
     },
     "node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17300,9 +17288,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/test-apps/expo-51/package.json
+++ b/test-apps/expo-51/package.json
@@ -17,22 +17,22 @@
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
     "@react-navigation/native": "^6.0.2",
-    "expo": "~51.0.0-preview.8",
+    "expo": "^51.0.0-preview.14",
     "expo-constants": "~16.0.1",
     "expo-font": "~12.0.4",
     "expo-linking": "~6.3.1",
-    "expo-router": "~3.5.5",
-    "expo-splash-screen": "~0.27.2",
+    "expo-router": "^3.5.8",
+    "expo-splash-screen": "^0.27.4",
     "expo-status-bar": "~1.12.1",
-    "expo-system-ui": "~3.0.2",
+    "expo-system-ui": "^3.0.4",
     "expo-web-browser": "~13.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.74.0",
+    "react-native": "^0.74.1",
     "react-native-gesture-handler": "~2.16.0",
-    "react-native-reanimated": "3.9.0-rc.1",
-    "react-native-safe-area-context": "4.10.0-rc.1",
-    "react-native-screens": "3.31.0-rc.1",
+    "react-native-reanimated": "^3.10.0",
+    "react-native-safe-area-context": "^4.10.1",
+    "react-native-screens": "^3.31.1",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {
@@ -43,7 +43,7 @@
     "jest": "^29.2.1",
     "jest-expo": "~51.0.1",
     "react-test-renderer": "18.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.3.3"
   },
   "private": true
 }


### PR DESCRIPTION
Expo 51 is still in preview, recently due to some deps getting updated the current version stopped building (with or without the IDE). Updating dependencies to recommended versions of Expo 51 fixes the issue.