### PR TITLE
Remove import of expo-router from preview.js lib file

### DIFF
--- a/packages/vscode-extension/lib/preview.js
+++ b/packages/vscode-extension/lib/preview.js
@@ -1,10 +1,3 @@
-try {
-    // Attempt to require the expo router package
-    require("expo-router/entry");
-} catch (error) {
-    console.log("The 'expo-router' package is not installed.");
-}
-
 const { AppRegistry, View } = require("react-native");
 
 global.__RNIDE_previews ||= new Map();


### PR DESCRIPTION
As spotted in #190 using preview functionality required you to have expo router installed.

This was due to an import in lib file that gets loaded when you use the preview package. The import was a legacy code that was put there when we used a different way of loading preview package. Now that it is no longer needed it can be safely removed.