### PR TITLE
Enable web analytics on landing & docs

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/core": "2.4.3",
     "@docusaurus/preset-classic": "2.4.3",
     "@mdx-js/react": "^1.6.22",
+    "@vercel/analytics": "^1.2.2",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/packages/docs/src/theme/Navbar/index.js
+++ b/packages/docs/src/theme/Navbar/index.js
@@ -1,10 +1,13 @@
-import React from 'react';
-import NavbarLayout from '@theme/Navbar/Layout';
-import NavbarContent from '@theme/Navbar/Content';
+import React from "react";
+import NavbarLayout from "@theme/Navbar/Layout";
+import NavbarContent from "@theme/Navbar/Content";
+import { Analytics } from "@vercel/analytics/react";
+
 export default function Navbar() {
   return (
     <NavbarLayout>
       <NavbarContent />
+      <Analytics />
     </NavbarLayout>
   );
 }

--- a/packages/docs/yarn.lock
+++ b/packages/docs/yarn.lock
@@ -2252,6 +2252,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@vercel/analytics@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.2.2.tgz#715d8f203a170c06ba36b363e03b048c03060d5d"
+  integrity sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==
+  dependencies:
+    server-only "^0.0.1"
+
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.11.5":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
@@ -6718,6 +6725,11 @@ serve-static@1.15.0:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.18.0"
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 set-function-length@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
This PR adds cookieless, anonymous analytics to our website provided by `@vercel/analytics`.