### PR TITLE
Yet another attempt at solving jsx babel transform overwrites

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -7,24 +7,52 @@ const { requireFromAppDir, overrideModuleFromAppDir } = require("./metro_helpers
 // plugin-transform-react-jsx-development. For line and column numbers to be added to components, we
 // need the development version of the plugin. Apparently, it is up to the order of plugins being added
 // whether the development version would actually be allowed to produce the JSXElement node output.
-// To workaround this issue, we override require such that it always pulls in the development version.
-// Apparently, when someone has both dev and non-dev plugins on their babel config, overriding the non-dev
-// version with dev will result in an error, as the dev version has additional checks and throws an error
-// when registered more then once (which is what's going to happen if we turn non-dev into dev version).
-// In order to avoid this, we add a custom plugin that disables all jsx transform visitors that come after
-// the first one.
+//
+// Since babel doesn't have goo extension points, as the plugin system relies on directly requiring plugin
+// modules, the only option to intercept that process is by overriding require. This, however isn't ideal
+// as we don't know which plugins are loaded and in what order.
+//
+// In addition to that, there are some extra constraints that make this even harder. Specifically, the development
+// version of JSX transform plugin (plugin-transform-react-jsx-development) has a check that throws an error
+// when plugin-transform-jsx-source or plugin-transform-jsx-self run on the same source files, or in case it is registered
+// more than once. Also, some libraries, like nativewind, rely on specific order of JSX transform to happen. Because of
+// that we take the following approach:
+// 1) we disable plugin-transform-jsx-source and plugin-transform-jsx-self plugins entirely as they are deprecated and
+// don't provide any value except from interfering with JSX dev plugin
+// 2) we replace non-dev version (plugin-transform-jsx) with dev version (plugin-transform-jsx-development) to ensure that
+// the JSX transformation runs at the right time.
+// 3) we keep a flag to know if the non-dev version was used (and replaced by dev version), and if it was, we disable
+// further requires of the dev version to avoid it being installed the second time.
+//
+// The downside of the current approach is if the dev version is used first and the non-dev version is listed later,
+// we will end up replacing the non-dev version and as a result we will run the dev version twice which will result in
+// an error. In practice we haven't yet encountered such a setup.
 const jsxDevTransformer = requireFromAppDir("@babel/plugin-transform-react-jsx/lib/development");
-overrideModuleFromAppDir("@babel/plugin-transform-react-jsx", jsxDevTransformer);
-
-function clearObject(obj) {
-  for (let prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      delete obj[prop];
-    }
+let nonJSXDevTransformUsed = false;
+overrideModuleFromAppDir("@babel/plugin-transform-react-jsx", (...args) => {
+  nonJSXDevTransformUsed = true;
+  return jsxDevTransformer.default(...args);
+});
+overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-development", (...args) => {
+  if (nonJSXDevTransformUsed) {
+    return {
+      name: "rnide-disabled-jsx-dev-transform",
+      visitor: {},
+    };
+  } else {
+    return jsxDevTransformer.default(...args);
   }
-}
+});
+overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-source", {
+  name: "rnide-disabled-jsx-source-transform",
+  visitor: {},
+});
+overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-self", {
+  name: "rnide-disabled-jsx-self-transform",
+  visitor: {},
+});
 
-function transformWrapper({ filename, src, plugins, ...rest }) {
+function transformWrapper({ filename, src, ...rest }) {
   const { transform } = require(ORIGINAL_TRANSFORMER_PATH);
   if (filename.endsWith("node_modules/react-native/Libraries/Core/InitializeCore.js")) {
     src = `${src};require("__RNIDE_lib__/runtime.js");`;
@@ -40,29 +68,7 @@ function transformWrapper({ filename, src, plugins, ...rest }) {
     src = `${src};preview = require("__RNIDE_lib__/preview.js").preview;`;
   }
 
-  const newPlugins = [
-    {
-      name: "disable-non-dev-jsx-transformer-exit",
-      pre(state) {
-        // we disable all jsx transform visitors that come after the first one, because they will
-        // throw an error recognizing that parts of the code have already been transformed.
-        const plugins = state.opts.plugins;
-        const jsxTransformer = plugins.find((p) => p.key === "transform-react-jsx/development");
-        if (jsxTransformer) {
-          plugins.forEach((plugin) => {
-            if (plugin.key.includes("transform-react-jsx") && plugin !== jsxTransformer) {
-              // we need to clear the visitor as it is being referenced in other places, so
-              // reassigning to empty object doesn't work.
-              clearObject(plugin.visitor);
-            }
-          });
-        }
-      },
-    },
-    ...plugins,
-  ];
-
-  return transform({ filename, src, plugins: newPlugins, ...rest });
+  return transform({ filename, src, ...rest });
 }
 
 module.exports = { transform: transformWrapper };


### PR DESCRIPTION
Fixes #198 

This is another approach at resolving the complexity of enabling development JSX transforms.

As noted in #198 the old approach would sometimes produce an error that the development transform throws when other instance of dev JSX transform run, or when some of jsx-self or jsx-source transforms are run on the same file along with the jsx dev version.

The problem in the repro provided in #198 was due to the use of quite popular react-native-svg-transformer which doesn't forward `plugins` attribute to the upstream transformer. I proposed a fix for this issue in that repo https://github.com/kristerkari/react-native-svg-transformer/pull/354 however, it isn't practical to wait for a fix there and hence the PR implements another workaround that doesn't depend on the `plugins` attribute of the transformer.

The new approach relies on additional flag that is turned on when non-dev version of the plugin is loaded. What we try to achieve is that only jsx-dev transform is listed as plugin, and other varians (non-dev, -self, and -source) versions are all turned off. Since we can't hijack the plugins list, the only option is to use require overwrites. Furthermore, we need to consider the case when someone has a proper setup where only dev transform is listed and others are not. If we were to only overwrite non-deb with dev version, that wouldn't suffice for this particular case.

What we now do is:
1) disable -self and -source transforms entirely (read inline comment for details on why we can do it)
2) replace non-dev JSX transform with dev version, and also use a flag to mark when this replaced non-dev version is used
3) replace dev JSX transform with extra logic that checks for the flag that marks whether non-dev version is used. If it is used, we return an empty transform. Otherwise, we just return the dev transform as it means that non-dev isn't registered.

As stated in the inline comment, this approach would break if someone has dev transform registered before non-dev. Apparently, I don't see a better way to move forward with this approach and I'd hope that the current solution would cover the majority of setups.


