### PR TITLE
Allow switching between different versions of Expo Go

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -238,10 +238,26 @@ export class AndroidEmulatorDevice extends DeviceBase {
         Logger.error("Error while uninstalling will be ignored", e);
       }
     }
+
+    const installApk = (allowDowngrade: boolean) => {
+      return exec(ADB_PATH, [
+        "-s",
+        this.serial!,
+        "install",
+        ...(allowDowngrade ? ["-d"] : []),
+        "-r",
+        build.apkPath,
+      ]);
+    };
     await retry(
-      () => exec(ADB_PATH, ["-s", this.serial!, "install", "-r", build.apkPath]),
+      () => installApk(false),
       2,
-      1000
+      1000,
+      // there's a chance that same emulator was used in newer version of Expo
+      // and then RN IDE was opened on older project, in which case installation
+      // will fail. We use -d flag which allows for downgrading debuggable
+      // applications (see `adb shell pm`, install command)
+      () => installApk(true)
     );
   }
 

--- a/packages/vscode-extension/src/utilities/retry.ts
+++ b/packages/vscode-extension/src/utilities/retry.ts
@@ -1,11 +1,16 @@
-export async function retry<T>(fn: () => Promise<T>, retriesLeft = 5, interval = 1000): Promise<T> {
+export async function retry<T>(
+  fn: () => Promise<T>,
+  retriesLeft = 5,
+  interval = 1000,
+  fallbackFn?: () => Promise<T>
+): Promise<T> {
   try {
     const val = await fn();
     return val;
   } catch (error) {
     if (retriesLeft) {
       await new Promise((r) => setTimeout(r, interval));
-      return retry(fn, retriesLeft - 1, interval);
+      return retry(fallbackFn ?? fn, retriesLeft - 1, interval);
     } else {
       throw error;
     }


### PR DESCRIPTION
When using RN IDE in projects that uses different Expo Go version, adb refused to install older version of Expo Go app unless `-d` flag is used. This resets app state (which shows welcome dialog, etc) so we only do it when first install fails.

## Testing

Run expo-51 project on Android, then run expo-go project. Without this patch, it will fail with the message:
```
adb: failed to install ~/.expo/android-apk-cache/Exponent-2.30.11.apk: Failure [INSTALL_FAILED_VERSION_DOWNGRADE: Downgrade detected: Update version code 239 is older than current 249]
```