### PR TITLE
Gracefully handle attempts of launching the ide launch configuration

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -171,16 +171,6 @@ class LaunchConfigDebugAdapterDescriptorFactory implements vscode.DebugAdapterDe
   }
 }
 
-async function findSingleFileInWorkspace(fileGlobPattern: string, excludePattern: string | null) {
-  const files = await workspace.findFiles(fileGlobPattern, excludePattern, 2);
-  if (files.length === 1) {
-    return files[0];
-  } else if (files.length > 1) {
-    Logger.error(`Found multiple ${fileGlobPattern} files in the workspace`);
-  }
-  return undefined;
-}
-
 function extensionActivated() {
   if (extensionContext.workspaceState.get(OPEN_PANEL_ON_ACTIVATION)) {
     commands.executeCommand("RNIDE.openPanel");


### PR DESCRIPTION
Since we follow standard launch config approach for project-based customization, after the user creates launch configuration it'll be shown in the run options dialog.

Some users have reported errors that they see when attempting to run this configuration.

This configuration is not meant to be run but the IDE uses it to read config from it. 

In this PR, we make it so that the error no longer appears when someone tries to run the launch config, instead we run some dummy command that exits immediately and trigger opening on the IDE panel in case it isn't launched already.