### PR TITLE
Fix duplicate classes in some android builds. 

### DIFF
--- a/packages/vscode-extension/lib/android/configureReactNativeOverrides.gradle
+++ b/packages/vscode-extension/lib/android/configureReactNativeOverrides.gradle
@@ -82,7 +82,7 @@ dependencies { dep ->
         attribute(shouldTransform)
     }
     artifactTypes.getByName("aar") {
-        attributes.attribute(shouldTransform, false)
+        attributes.attribute(shouldTransform, true)
     }
 }
 


### PR DESCRIPTION
Description: 
some 3rd party libraries, could cause duplication of  classes during transformation we performed in configureReactNativeOverrides. 

How to reproduce a bug? 

- run `npx react-native init your-project`
- run `npm i react-native-biometrics`
- try to run react-native-ide on android 

note that react-native-ide will believe that it is not a native change so it you will have to manually clean rebuild every time you add or remove  react-native-biometrics.


This is the reported error in build logs: 
<img width="421" alt="Screenshot 2024-05-13 at 02 38 41" src="https://github.com/software-mansion/react-native-ide/assets/159789821/23007fdf-141a-4dbd-a596-7a1c269f5a03">
