### PR TITLE
Explicitly limit extension to macOS

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -17,7 +17,8 @@
   ],
   "version": "0.0.10-beta",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.75.0",
+    "os": "darwin"
   },
   "extensionKind": [
     "workspace"


### PR DESCRIPTION
Not sure if "os" field is respected by VSCode marketplace, but we will add it to see if it gives users trying the extension on other OSes any pointers.