### PR TITLE
Forward stderr lines to output channels used for iOS/Android builds

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -96,7 +96,7 @@ export async function buildAndroid(
   );
   const buildAndroidProgressProcessor = new BuildAndroidProgressProcessor(progressListener);
   outputChannel.clear();
-  lineReader(buildProcess).onLineRead((line) => {
+  lineReader(buildProcess, true).onLineRead((line) => {
     outputChannel.appendLine(line);
     buildAndroidProgressProcessor.processLine(line);
   });

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -1,10 +1,10 @@
-import { RelativePattern, workspace, Uri, window, OutputChannel } from "vscode";
+import { RelativePattern, workspace, Uri, OutputChannel } from "vscode";
 import { exec, lineReader } from "../utilities/subprocess";
 import { Logger } from "../Logger";
 import path from "path";
 import { checkIosDependenciesInstalled } from "../dependency/DependencyChecker";
 import { installIOSDependencies } from "../dependency/DependencyInstaller";
-import { CancelToken, IOSBuildResult } from "./BuildManager";
+import { CancelToken } from "./BuildManager";
 import { BuildIOSProgressProcessor } from "./BuildIOSProgressProcessor";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import {
@@ -185,7 +185,7 @@ export async function buildIos(
 
     const buildIOSProgressProcessor = new BuildIOSProgressProcessor(progressListener);
     outputChannel.clear();
-    lineReader(process).onLineRead((line) => {
+    lineReader(process, true).onLineRead((line) => {
       outputChannel.appendLine(line);
       buildIOSProgressProcessor.processLine(line);
       // Xcode can sometimes escape `=` with a backslash or put the value in quotes

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -8,18 +8,26 @@ export type ChildProcess = ExecaChildProcess<string>;
  * When using this methid, the subprocess should be started with buffer: false option
  * as there's no need for allocating memory for the output that's going to be very long.
  */
-export function lineReader(childProcess: ExecaChildProcess<string>) {
+export function lineReader(childProcess: ExecaChildProcess<string>, includeStderr = false) {
   const input = childProcess.stdout;
   if (!input) {
     throw new Error("Child process has no stdout");
   }
-  const reader = readline.createInterface({
+  const stdoutReader = readline.createInterface({
     input,
     terminal: false,
   });
+  let stderrReader = null;
+  if (includeStderr && childProcess.stderr) {
+    stderrReader = readline.createInterface({
+      input: childProcess.stderr!,
+      terminal: false,
+    });
+  }
   return {
     onLineRead: (callback: (line: string) => void) => {
-      reader.on("line", callback);
+      stdoutReader.on("line", callback);
+      stderrReader?.on("line", callback);
     },
   };
 }


### PR DESCRIPTION
This PR fixes an issue where error messages printed to stderr from ios or Android builds weren't included in the build output channels. The reason was that we'd only listen for lines from stdout. This PR adds an option for line reader to also include lines from stderr and we now use this option for xcodebuild and gradle processes.