### PR TITLE
Display zoom controls on floating on left

### DIFF
--- a/packages/vscode-extension/src/webview/components/ZoomControls.css
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.css
@@ -1,26 +1,22 @@
 :root {
-  --swm-zoom-select-width: 70px;
+  --swm-zoom-select-width: 50px;
   --swm-zoom-select-trigger-offset: 20px;
 }
 
 .zoom-controls {
   background-color: var(--swm-zoom-controls-background);
   border-radius: 18px;
-  min-width: 75px;
   display: flex;
-  justify-content: space-between;
-}
-
-.zoom-controls .icon-button {
-  z-index: 1;
+  flex-direction: column;
+  align-items: stretch;
 }
 
 .zoom-controls .icon-button.zoom-out-button {
-  border-radius: 18px 0 0 18px;
+  border-radius: 18px 18px 0 0;
 }
 
 .zoom-controls .icon-button.zoom-in-button {
-  border-radius: 0 18px 18px 0;
+  border-radius: 0 0 18px 18px;
 }
 
 .zoom-controls .icon-button:hover {
@@ -32,7 +28,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
@@ -42,7 +37,6 @@
   background-color: var(--swm-zoom-controls-background);
   color: var(--swm-zoom-select-trigger-text);
   user-select: none;
-  width: calc(var(--swm-zoom-select-width) - var(--swm-zoom-select-trigger-offset));
 }
 .zoom-select-trigger:hover {
   background-color: var(--swm-zoom-select-trigger-hover);
@@ -59,21 +53,22 @@
 .zoom-select-content {
   overflow: hidden;
   background-color: var(--swm-zoom-controls-background);
-  width: var(--swm-zoom-select-width);
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px;
   padding-top: 4px;
   margin-left: calc(var(--swm-zoom-select-trigger-offset) * -1 / 2);
 }
 
 .zoom-select-viewport {
-  padding: 6px;
+  display: flex;
+  flex-direction: row;
 }
 
 .zoom-dropdown-menu-content {
   min-width: var(--swm-zoom-select-width);
   background-color: var(--swm-zoom-controls-background);
-  border-radius: 6px 6px 0 0;
+  border-radius: 6px;
   padding: 4px;
+  margin-left: 5px;
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
@@ -91,6 +86,7 @@
   line-height: 1;
   display: flex;
   align-items: center;
+  flex-direction: row;
   justify-content: center;
   height: 32px;
   padding: 0 10px;

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -5,7 +5,7 @@ import "./ZoomControls.css";
 
 const ZOOM_STEP = 10;
 const DEFAULT_ZOOM_LEVEL = 100;
-const ZOOM_SELECT_NUMERIC_VALUES = [300, 200, 150, 125, 100, 75, 50, 25, 10];
+const ZOOM_SELECT_NUMERIC_VALUES = [50, 100, 150, 200, 300];
 
 export type ZoomLevelType = number | "Fit";
 
@@ -25,7 +25,7 @@ const ZoomLevelSelect = ({ zoomLevel, setZoomLevel }: ZoomControlsProps) => {
       <Select.Trigger className="zoom-select-trigger" disabled={false}>
         <Select.Value>
           <div className="zoom-select-value">
-            {typeof zoomLevel === "string" ? zoomLevel : `${Math.floor(zoomLevel)}%`}
+            {typeof zoomLevel === "string" ? zoomLevel : `${Math.floor(zoomLevel) / 100}x`}
           </div>
         </Select.Value>
       </Select.Trigger>
@@ -33,17 +33,18 @@ const ZoomLevelSelect = ({ zoomLevel, setZoomLevel }: ZoomControlsProps) => {
       <Select.Portal>
         <Select.Content
           className="zoom-select-content zoom-dropdown-menu-content"
+          side="right"
           position="popper">
           <Select.Viewport className="zoom-select-viewport">
-            {ZOOM_SELECT_NUMERIC_VALUES.map((level) => (
-              <Select.SelectItem key={level} value={level.toString()} className="zoom-select-item">
-                {level}%
-              </Select.SelectItem>
-            ))}
-            <Select.Separator className="zoom-select-item-separator" />
             <Select.SelectItem value="Fit" className="zoom-select-item">
               Fit
             </Select.SelectItem>
+            <Select.Separator className="zoom-select-item-separator" />
+            {ZOOM_SELECT_NUMERIC_VALUES.map((level) => (
+              <Select.SelectItem key={level} value={level.toString()} className="zoom-select-item">
+                {level / 100}x
+              </Select.SelectItem>
+            ))}
           </Select.Viewport>
         </Select.Content>
       </Select.Portal>

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -21,6 +21,12 @@
   margin-top: 8px;
 }
 
+.button-group-left {
+  position: absolute;
+  display: flex;
+  left: 10px;
+}
+
 .bar-spacer {
   flex: 1;
   max-height: 45px;

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -144,6 +144,9 @@ function PreviewView() {
           {devicesNotFound ? <DevicesNotFoundView /> : <VSCodeProgressRing />}
         </div>
       )}
+      <div className="button-group-left">
+        <ZoomControls zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} />
+      </div>
 
       <div className="button-group-bottom">
         <IconButton
@@ -179,8 +182,6 @@ function PreviewView() {
             />
           </IconButton>
         </DeviceSettingsDropdown>
-
-        <ZoomControls zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} />
       </div>
     </div>
   );


### PR DESCRIPTION
This PR adjust the styling of newly added zoom controls.

Now the zoom controls are displayed on the side, as the bottom bar was already filled with too many buttons.
I also adjusted the popover to display to the right and changed "100%" to 1x to make it take less space.

<img width="566" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/726445/38d83cd6-0308-4d5a-b09c-c3dd27dff1b7">
