### PR TITLE
Fix apk path for default build variant

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -38,7 +38,7 @@ async function extractPackageName(artifactPath: string, cancelToken: CancelToken
 
 function getApkPath(appRootFolder: string, productFlavor: string, buildType: string) {
   const androidSourceDir = getAndroidSourceDir(appRootFolder);
-  const apkFile = ["app", productFlavor, buildType].join("-") + ".apk";
+  const apkFile = ["app", productFlavor, buildType].filter(Boolean).join("-") + ".apk";
   return path.join(androidSourceDir, RELATIVE_APK_DIR, productFlavor, buildType, apkFile);
 }
 


### PR DESCRIPTION
Fix for https://github.com/software-mansion/react-native-ide/pull/222. Product flavor is not set by default and it was giving a wrong .apk path if an empty string not filtered out. 