### PR TITLE
Don't crash when sourceMapURL is empty

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -121,7 +121,7 @@ export class DebugAdapter extends DebugSession {
         case "Debugger.scriptParsed":
           const sourceMapURL = message.params.sourceMapURL;
 
-          if (sourceMapURL.startsWith("data:")) {
+          if (sourceMapURL?.startsWith("data:")) {
             const base64Data = sourceMapURL.split(",")[1];
             const decodedData = Buffer.from(base64Data, "base64").toString("utf-8");
             const sourceMap = JSON.parse(decodedData);


### PR DESCRIPTION
This PR fixes an uncaught exception error that was thrown in expo go projects due to the sourceMapURL being empty in some of the debug protocol calls.