### PR TITLE
Change navbar to a reusable component

### DIFF
--- a/packages/docs/src/components/Hero/LandingBackground/index.tsx
+++ b/packages/docs/src/components/Hero/LandingBackground/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import HeroElipse from "@site/src/components/Hero/HeroElipse";
+import styles from "./styles.module.css";
+
+const LandingBackground = () => {
+  return (
+    <div className={styles.heroBackground}>
+      {ExecutionEnvironment.canUseViewport && <HeroElipse />}
+    </div>
+  );
+};
+
+export default LandingBackground;

--- a/packages/docs/src/components/Hero/LandingBackground/styles.module.css
+++ b/packages/docs/src/components/Hero/LandingBackground/styles.module.css
@@ -1,0 +1,12 @@
+.heroBackground {
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  background-color: var(--swm-white);
+  width: 100%;
+  height: 130vh;
+  min-height: 70vw;
+  overflow: hidden;
+  z-index: -20;
+}

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -5,7 +5,8 @@ import Hero from "@site/src/components/Hero/StartScreen";
 import LearnMoreHero from "@site/src/components/LearnMore/LearnMoreHero";
 import LearnMoreFooter from "@site/src/components/LearnMore/LearnMoreFooter";
 import Installation from "@site/src/components/Sections/Installation";
-import FooterBackground from "../components/FooterBackground";
+import LandingBackground from "@site/src/components/Hero/LandingBackground";
+import FooterBackground from "@site/src/components/FooterBackground";
 import Overview from "@site/src/components/Sections/Overview";
 import FAQ from "@site/src/components/Sections/FAQ";
 
@@ -14,6 +15,7 @@ import styles from "./index.module.css";
 export default function Home(): JSX.Element {
   return (
     <Layout description="A better developer experience for React Native developers.">
+      <LandingBackground />
       <div className={styles.preventfulContainer}>
         <div className={styles.container}>
           <Hero />

--- a/packages/docs/src/theme/Navbar/Layout/index.js
+++ b/packages/docs/src/theme/Navbar/Layout/index.js
@@ -2,12 +2,9 @@ import React from "react";
 import clsx from "clsx";
 import { useThemeConfig } from "@docusaurus/theme-common";
 import { useHideableNavbar, useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
-import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { translate } from "@docusaurus/Translate";
 import NavbarMobileSidebar from "@theme/Navbar/MobileSidebar";
 
-import HeroElipse from "@site/src/components/Hero/HeroElipse";
-import usePageType from "@site/src/hooks/usePageType";
 import styles from "./styles.module.css";
 
 function NavbarBackdrop(props) {
@@ -20,25 +17,15 @@ function NavbarBackdrop(props) {
   );
 }
 
-const LandingBackground = () => {
-  return (
-    <div className={styles.heroBackground}>
-      {ExecutionEnvironment.canUseViewport && <HeroElipse />}
-    </div>
-  );
-};
-
 export default function NavbarLayout({ children }) {
   const {
     navbar: { hideOnScroll, style },
   } = useThemeConfig();
   const mobileSidebar = useNavbarMobileSidebar();
   const { navbarRef, isNavbarVisible } = useHideableNavbar(hideOnScroll);
-  const { isLanding } = usePageType();
 
   return (
     <div>
-      {isLanding && <LandingBackground />}
       <nav
         ref={navbarRef}
         aria-label={translate({

--- a/packages/docs/src/theme/Navbar/Layout/styles.module.css
+++ b/packages/docs/src/theme/Navbar/Layout/styles.module.css
@@ -12,16 +12,3 @@
   padding-top: 2rem;
   padding: 0 1.25rem 0 1.5rem;
 }
-
-.heroBackground {
-  position: absolute;
-  top: 0;
-  right: 0;
-
-  background-color: var(--swm-white);
-  width: 100%;
-  height: 130vh;
-  min-height: 70vw;
-  overflow: hidden;
-  z-index: -20;
-}


### PR DESCRIPTION
In order to use navbar and footer theme components from `@swmansion/t-rex-ui`, we need to rewrite current navbar to be more simplified. 

To achieve that we moved landing background `<HeroElipse />` from Navbar to separate component.

<img width="1558" alt="image" src="https://github.com/software-mansion/react-native-ide/assets/59940332/b5c16925-7cb5-4614-b1e4-e1abbac5c76d">
