### PR TITLE
Don't autofocus modal's content by default

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Modal.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/Modal.tsx
@@ -12,13 +12,20 @@ interface ModalProps {
   headerShown?: boolean;
 }
 
+function preventDefault(e: Event) {
+  e.preventDefault();
+}
+
 export default function Modal({ title, component, open, setOpen, headerShown }: ModalProps) {
   const close = () => setOpen(false);
   return (
     <Dialog.Root open={open}>
       <Dialog.Portal>
         <Dialog.Overlay className="modal-overlay" onClick={close} />
-        <Dialog.Content className="modal-content" onEscapeKeyDown={close}>
+        <Dialog.Content
+          className="modal-content"
+          onEscapeKeyDown={close}
+          onOpenAutoFocus={preventDefault}>
           {headerShown && <Dialog.Title className="modal-title">{title}</Dialog.Title>}
 
           <div className="modal-content-container">{component}</div>


### PR DESCRIPTION
|Before|After|
|-|-|
|<img src="https://github.com/software-mansion/react-native-ide/assets/12465392/d34a27f9-b10f-47ae-a4be-5c2a09947a4b" />|<img src="https://github.com/software-mansion/react-native-ide/assets/12465392/447f4ff1-af48-4e63-b917-74f807e68a56" />| 

