### PR TITLE
Allow using extension only on macOS

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -64,6 +64,11 @@ export function deactivate(context: ExtensionContext): undefined {
 export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
 
+  if (process.platform !== "darwin") {
+    window.showErrorMessage("React Native IDE works only on macOS.", "Dismiss");
+    return;
+  }
+
   setExtensionContext(context);
   if (context.extensionMode === ExtensionMode.Development) {
     enableDevModeLogging();


### PR DESCRIPTION
Due to the fact that VSCode marketplace doesn't allow for entirely disabling extension on specified platforms (it fallbacks to previous version that was universal) we need to check in runtime for platform we're running on.