### PR TITLE
Persist preview zoom state

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -19,6 +19,7 @@ export type ProjectState = {
   stageProgress?: number;
   previewURL: string | undefined;
   selectedDevice: DeviceInfo | undefined;
+  previewZoom: number | "Fit" | undefined; // Preview specific. Consider extracting to different location if we store more preview state
 };
 
 // important: order of values in this enum matters
@@ -87,6 +88,7 @@ export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
   restart(forceCleanBuild: boolean): Promise<void>;
   selectDevice(deviceInfo: DeviceInfo): Promise<void>;
+  updatePreviewZoomLevel(zoom: number | "Fit"): Promise<void>;
 
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -112,10 +112,10 @@ type Props = {
   isInspecting: boolean;
   setIsInspecting: (isInspecting: boolean) => void;
   zoomLevel: ZoomLevelType;
-  setZoomLevel: (zoomLevel: ZoomLevelType) => void;
+  onZoomChanged: (zoomLevel: ZoomLevelType) => void;
 };
 
-function Preview({ isInspecting, setIsInspecting, zoomLevel, setZoomLevel }: Props) {
+function Preview({ isInspecting, setIsInspecting, zoomLevel, onZoomChanged }: Props) {
   const wrapperDivRef = useRef<HTMLDivElement>(null);
   const [isPressing, setIsPressing] = useState(false);
   const previewRef = useRef<HTMLImageElement>(null);
@@ -322,7 +322,7 @@ function Preview({ isInspecting, setIsInspecting, zoomLevel, setZoomLevel }: Pro
   const resizableProps = useResizableProps({
     wrapperDivRef,
     zoomLevel,
-    setZoomLevel,
+    setZoomLevel: onZoomChanged,
   });
 
   return (

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -11,13 +11,13 @@ export type ZoomLevelType = number | "Fit";
 
 type ZoomControlsProps = {
   zoomLevel: ZoomLevelType;
-  setZoomLevel: React.Dispatch<React.SetStateAction<ZoomLevelType>>;
+  onZoomChanged: (zoom: ZoomLevelType) => void;
 };
 
-const ZoomLevelSelect = ({ zoomLevel, setZoomLevel }: ZoomControlsProps) => {
+const ZoomLevelSelect = ({ zoomLevel, onZoomChanged }: ZoomControlsProps) => {
   const onValueChange = useCallback(
-    (e: string) => setZoomLevel(Number(e) || (e as ZoomLevelType)),
-    [setZoomLevel]
+    (e: string) => onZoomChanged(Number(e) || (e as ZoomLevelType)),
+    [onZoomChanged]
   );
 
   return (
@@ -52,26 +52,19 @@ const ZoomLevelSelect = ({ zoomLevel, setZoomLevel }: ZoomControlsProps) => {
   );
 };
 
-function ZoomControls({ zoomLevel, setZoomLevel }: ZoomControlsProps) {
-  const handleZoom = useCallback(
-    (shouldIncrease: boolean) => {
-      setZoomLevel((currentZoomLevel: ZoomLevelType) => {
-        const resolvedCurrentZoomLevel =
-          typeof currentZoomLevel === "string" ? DEFAULT_ZOOM_LEVEL : currentZoomLevel;
-        const newZoomLevel = resolvedCurrentZoomLevel + (shouldIncrease ? ZOOM_STEP : -ZOOM_STEP);
+function ZoomControls({ zoomLevel, onZoomChanged }: ZoomControlsProps) {
+  function handleZoom(shouldIncrease: boolean) {
+    const currentZoomLevel = zoomLevel;
+    const resolvedCurrentZoomLevel =
+      typeof currentZoomLevel === "string" ? DEFAULT_ZOOM_LEVEL : currentZoomLevel;
+    const newZoomLevel = resolvedCurrentZoomLevel + (shouldIncrease ? ZOOM_STEP : -ZOOM_STEP);
 
-        if (newZoomLevel < ZOOM_STEP) {
-          return currentZoomLevel;
-        }
-
-        return newZoomLevel;
-      });
-    },
-    [setZoomLevel]
-  );
-
-  const handleZoomIn = useCallback(() => handleZoom(true), [handleZoom]);
-  const handleZoomOut = useCallback(() => handleZoom(false), [handleZoom]);
+    if (newZoomLevel < ZOOM_STEP) {
+      onZoomChanged(currentZoomLevel);
+    } else {
+      onZoomChanged(newZoomLevel);
+    }
+  }
 
   return (
     <div className="zoom-controls">
@@ -81,17 +74,17 @@ function ZoomControls({ zoomLevel, setZoomLevel }: ZoomControlsProps) {
           label: "Zoom out",
           side: "top",
         }}
-        onClick={handleZoomOut}>
+        onClick={() => handleZoom(false)}>
         <span className="codicon codicon-zoom-out" />
       </IconButton>
-      <ZoomLevelSelect zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} />
+      <ZoomLevelSelect zoomLevel={zoomLevel} onZoomChanged={onZoomChanged} />
       <IconButton
         className="zoom-in-button"
         tooltip={{
           label: "Zoom in",
           side: "top",
         }}
-        onClick={handleZoomIn}>
+        onClick={() => handleZoom(true)}>
         <span className="codicon codicon-zoom-in" />
       </IconButton>
     </div>

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -15,6 +15,7 @@ const ProjectContext = createContext<ProjectContextProps>({
     status: "starting",
     previewURL: undefined,
     selectedDevice: undefined,
+    previewZoom: undefined,
   },
   deviceSettings: { appearance: "dark", contentSize: "normal" },
   project,
@@ -25,6 +26,7 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     status: "starting",
     previewURL: undefined,
     selectedDevice: undefined,
+    previewZoom: undefined,
   });
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings>({
     appearance: "dark",

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, Dispatch, SetStateAction } from "react";
 import { vscode } from "../utilities/vscode";
 import Preview from "../components/Preview";
 import IconButton from "../components/shared/IconButton";
@@ -20,13 +20,20 @@ import ZoomControls, { ZoomLevelType } from "../components/ZoomControls";
 import { useDiagnosticAlert } from "../hooks/useDiagnosticAlert";
 
 function PreviewView() {
+  const { projectState, project } = useProject();
+
   const [isInspecting, setIsInspecting] = useState(false);
-  const [zoomLevel, setZoomLevel] = useState<ZoomLevelType>("Fit");
+  const zoomLevel = projectState.previewZoom ?? "Fit";
+  const onZoomChanged = useCallback(
+    (zoom: ZoomLevelType) => {
+      project.updatePreviewZoomLevel(zoom);
+    },
+    [project]
+  );
   const [isFollowing, setIsFollowing] = useState(false);
   const [logCounter, setLogCounter] = useState(0);
 
   const { devices, finishedInitialLoad } = useDevices();
-  const { projectState, project } = useProject();
 
   const selectedDevice = projectState?.selectedDevice;
   const devicesNotFound = projectState !== undefined && devices.length === 0;
@@ -140,7 +147,7 @@ function PreviewView() {
           isInspecting={isInspecting}
           setIsInspecting={setIsInspecting}
           zoomLevel={zoomLevel}
-          setZoomLevel={setZoomLevel}
+          onZoomChanged={onZoomChanged}
         />
       ) : (
         <div className="missing-device-filler">
@@ -148,7 +155,7 @@ function PreviewView() {
         </div>
       )}
       <div className="button-group-left">
-        <ZoomControls zoomLevel={zoomLevel} setZoomLevel={setZoomLevel} />
+        <ZoomControls zoomLevel={zoomLevel} onZoomChanged={onZoomChanged} />
       </div>
 
       <div className="button-group-bottom">


### PR DESCRIPTION
We use VSC extension context for storage. It doesn't fully belong to project state but it's easier for now. We can extract the preview state to other location after we decide to store more preview-specific state.

Tested by using plus and minus and predefined zoom multiplier values.