### PR TITLE
Add info about Windows support

### DIFF
--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -18,7 +18,7 @@ React Native IDE currently supports some subset of React Native projects due to 
 We constantly work to improve this compatibility, and in case your project structure isn’t supported, feel free to open an issue.
 Below we list high-level requirements for the projects we support at the moment:
 
-- React Native IDE currently only supports development on macOS in [VS Code](https://code.visualstudio.com/) and [Cursor](https://cursor.sh/).
+- React Native IDE works with [VS Code](https://code.visualstudio.com/) and [Cursor](https://cursor.sh/) on macOS and Windows.
 - With React Native IDE you can only run iOS and Android applications. If your project supports other platforms, you should be able to use the IDE but only for launching the Android and iOS part of your project.
 - We support only recent version of React Native (0.71 onwards) as well as Expo SDK 49+
 - Brownfield-type projects are currently not supported (projects that are primarily native apps with React Native used on some screens)
@@ -28,7 +28,7 @@ As a general rule of thumb, if your project started from Expo template or React 
 ### ✨ What does it do
 
 React Native IDE is a VS Code extension that aims to streamline development of React Native and Expo applications.
-The current version supports developing on macOS for Android and iOS platforms with the current list of features available:
+The current version supports developing on macOS for Android and iOS platforms, and on Windows for Android with the current list of features available:
 
 - Managing iOS and Android simulator (for now only iPhone Pro and Pixel 7 skins are available)
 - Automatically build and launch your project (keeping track of native or javascript updates automatically)

--- a/packages/docs/src/components/Disclaimer/index.tsx
+++ b/packages/docs/src/components/Disclaimer/index.tsx
@@ -6,7 +6,7 @@ const Disclaimer = () => {
     <div className={styles.disclaimerContainer}>
       <p>
         <strong>Note: </strong>React Native IDE is not a ready product (yet). Currently it's in beta
-        stage and only supports development on macOS in VSCode and Cursor. We are hoping that
+        stage and works with VSCode and Cursor on macOS and Windows. We are hoping that
         together with the community we will be able to get there soon.
       </p>
     </div>

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -42,7 +42,7 @@ const StartScreen = () => {
         </div>
         <div className={styles.headingDisclaimer}>
           <InfoIcon className={styles.headingDisclaimerIcon} />
-          Works with VSCode 1.86+ and Cursor 0.32 on macOS
+          Works with VSCode 1.86+ and Cursor 0.32 on macOS and Windows
         </div>
       </div>
     </section>

--- a/packages/docs/src/components/Sections/FAQ/index.tsx
+++ b/packages/docs/src/components/Sections/FAQ/index.tsx
@@ -11,7 +11,7 @@ const faqs = [
   },
   {
     topic: "Can I use it on Windows or Linux?",
-    answer: "Right now, React Native IDE only supports macOS.",
+    answer: "You can use the IDE with VSCode and Cursor to develop React Native apps for Android and iOS on macOS. Since version 0.0.18 we added experimental support for Windows that is compatible with VSCode and allows for developing apps for Android. Support for Linux is not yet available.",
   },
   {
     topic: "How much does it cost?",


### PR DESCRIPTION
Just updating docs and main website in a couple of places where we mentioned macOS support only. 