### PR TITLE
Fix ios rebuild infinite cycle when opening IDE panel

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
-        "@expo/fingerprint": "^0.5.0",
+        "@expo/fingerprint": "^0.10.3",
         "@expo/package-manager": "^1.1.2",
         "@msgpack/msgpack": "^2.8.0",
         "@radix-ui/react-alert-dialog": "^1.0.5",
@@ -911,17 +911,20 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.5.0",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.10.3.tgz",
+      "integrity": "sha512-h/BnnyloJyMSrzeXonKLE6HfiMpRg3e9m8CAv+eUaAozG9heKMG9ftHW4cfm2StDYj/rWjFc5YK6MSIX6qd+xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expo/spawn-async": "^1.5.0",
+        "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "find-up": "^5.0.0",
         "minimatch": "^3.0.4",
         "p-limit": "^3.1.0",
-        "resolve-from": "^5.0.0"
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
       },
       "bin": {
         "fingerprint": "bin/cli.js"
@@ -995,75 +998,16 @@
       }
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.5.0",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^6.0.5"
+        "cross-spawn": "^7.0.3"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/path-key": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/spawn-async/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "node": ">=12"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -7876,11 +7820,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nise": {
       "version": "6.0.0",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -373,7 +373,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",
-    "@expo/fingerprint": "^0.5.0",
+    "@expo/fingerprint": "^0.10.3",
     "@expo/package-manager": "^1.1.2",
     "@msgpack/msgpack": "^2.8.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -111,6 +111,7 @@ async function loadCachedBuild(platform: DevicePlatform, newFingerprint: string)
   const cacheInfo = getCachedBuild(platform);
   const fingerprintsMatch = cacheInfo?.fingerprint === newFingerprint;
   if (!fingerprintsMatch) {
+    Logger.info("Fingerprint mismatch, cannot use cached build.");
     return undefined;
   }
 
@@ -119,13 +120,14 @@ async function loadCachedBuild(platform: DevicePlatform, newFingerprint: string)
   try {
     const builtAppExists = fs.existsSync(appPath);
     if (!builtAppExists) {
+      Logger.info("Couldn't use cached build. App artifact not found.");
       return undefined;
     }
 
     const hash = await getAppHash(appPath);
     const hashesMatch = hash === cacheInfo.buildHash;
     if (hashesMatch) {
-      Logger.log("Using existing build.");
+      Logger.info("Using cached build.");
       return build;
     }
   } catch (e) {

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -82,12 +82,7 @@ export async function buildIos(
   cancelToken: CancelToken,
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void,
-  checkIosDependenciesInstalled: () => Promise<boolean>,
-  installPods: (
-    appRootFolder: string,
-    forceCleanBuild: boolean,
-    cancelToken: CancelToken
-  ) => Promise<void>
+  installPodsIfNeeded: () => Promise<void>
 ): Promise<IOSBuildResult> {
   const { ios: buildOptions } = getLaunchConfiguration();
 
@@ -98,10 +93,7 @@ export async function buildIos(
 
   const sourceDir = getIosSourceDir(appRootFolder);
 
-  const isPodsInstalled = await checkIosDependenciesInstalled();
-  if (!isPodsInstalled) {
-    await installPods(appRootFolder, forceCleanBuild, cancelToken);
-  }
+  await installPodsIfNeeded();
 
   const xcodeProject = await findXcodeProject(appRootFolder);
 

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -360,11 +360,7 @@ export class DependencyManager implements Disposable {
     return installed;
   }
 
-  public async installPods(
-    appRootFolder: string,
-    forceCleanBuild: boolean,
-    cancelToken: CancelToken
-  ) {
+  public async installPods(appRootFolder: string, cancelToken: CancelToken) {
     const iosDirPath = getIosSourceDir(appRootFolder);
 
     if (!iosDirPath) {
@@ -390,10 +386,6 @@ export class DependencyManager implements Disposable {
     };
 
     try {
-      if (forceCleanBuild) {
-        await cancelToken.adapt(commandInIosDir("pod deintegrate"));
-      }
-
       await cancelToken.adapt(commandInIosDir("pod install"));
     } catch (e) {
       Logger.error("Pods not installed", e);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -124,6 +124,7 @@ export class DeviceSession implements Disposable {
   }
 
   private async buildApp({ clean }: { clean: boolean }) {
+    const buildStartTime = Date.now();
     this.eventDelegate.onStateChange(StartupMessage.Building);
     this.disposableBuild = this.buildManager.startBuild(this.device.deviceInfo, {
       clean,
@@ -133,6 +134,8 @@ export class DeviceSession implements Disposable {
       }, 100),
     });
     this.maybeBuildResult = await this.disposableBuild.build;
+    const buildDurationSec = (Date.now() - buildStartTime) / 1000;
+    Logger.info(`Build completed in ${buildDurationSec.toFixed(2)}s`);
   }
 
   private async installApp({ reinstall }: { reinstall: boolean }) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -339,8 +339,7 @@ export class Project
       oldMetro.dispose();
     }
 
-    Logger.debug("Installing Node Modules");
-    const installNodeModules = this.installNodeModules();
+    const maybeInstallNodeModules = this.maybeInstallNodeModules();
 
     Logger.debug(`Launching devtools`);
     const waitForDevtools = this.devtools.start();
@@ -351,7 +350,7 @@ export class Project
       throttle((stageProgress: number) => {
         this.reportStageProgress(stageProgress, StartupMessage.WaitingForAppToLoad);
       }, 100),
-      [installNodeModules]
+      [maybeInstallNodeModules]
     );
 
     Logger.debug("Checking expo router");
@@ -493,13 +492,13 @@ export class Project
     extensionContext.workspaceState.update(PREVIEW_ZOOM_KEY, zoom);
   }
 
-  private async installNodeModules(): Promise<void> {
+  private async maybeInstallNodeModules(): Promise<void> {
     const nodeModulesStatus = await this.dependencyManager.checkNodeModulesInstalled();
 
     if (!nodeModulesStatus.installed) {
+      Logger.info("Installing node modules");
       await this.dependencyManager.installNodeModules(nodeModulesStatus.packageManager);
     }
-    Logger.debug("Node Modules installed");
   }
 
   //#region Select device

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -57,6 +57,23 @@ export function getNativeABI() {
   }
 }
 
+export enum XCODEBUILD_ARCH {
+  ARM64 = "arm64",
+  X86_64 = "x86_64",
+  I386 = "i386",
+}
+
+export function getXcodebuildArch() {
+  switch (process.arch) {
+    case "x64":
+      return XCODEBUILD_ARCH.X86_64;
+    case "ia32":
+      return XCODEBUILD_ARCH.I386;
+    default:
+      return XCODEBUILD_ARCH.ARM64;
+  }
+}
+
 export function getOldAppCachesDir() {
   return join(os.homedir(), "Library", "Caches", "com.swmansion.react-native-ide");
 }

--- a/packages/vscode-extension/src/utilities/fingerprint.ts
+++ b/packages/vscode-extension/src/utilities/fingerprint.ts
@@ -17,6 +17,6 @@ export async function generateWorkspaceFingerprint() {
   const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
     ignorePaths: IGNORE_PATHS,
   });
-  Logger.log("FINGERPRINT: ----------------", fingerprint.hash, "------------------");
+  Logger.log("New workspace fingerprint", fingerprint.hash);
   return fingerprint.hash;
 }

--- a/packages/vscode-extension/src/utilities/fingerprint.ts
+++ b/packages/vscode-extension/src/utilities/fingerprint.ts
@@ -17,6 +17,6 @@ export async function generateWorkspaceFingerprint() {
   const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
     ignorePaths: IGNORE_PATHS,
   });
-  Logger.log("New workspace fingerprint", fingerprint.hash);
+  Logger.log("Workspace fingerprint", fingerprint.hash);
   return fingerprint.hash;
 }


### PR DESCRIPTION
This PR fixes an issue with the IDE constantly attempting to rebuild an app for iOS on every start of the IDE (or when switching between devices).

The issue was there because of failing pods check, which was triggering pods installation on every build. This on its own wasn't enough to trigger the cycle. On top of the above, the pods install was affecting the fingerprint of the workspace by generating xcworkspace and other files. As a consequence, when caching iOS builds, we'd use a stale fingerprint from before the pods installation. Because of that, on the subsequent restarts, we'd always detect fingerprint change and try to rebuild the app which in turn would again store the build under stale fingerprint cache key.

The above issue has been resolved by the following:
1) Upgrading @expo/fingerprint library – the new version no longer detects the change as long as pod install was not making any actual changes (the previous version would check the modification date of files in pods directory I believe which remained unchanged)
2) Despite the main source being addressed by the fingerprint update, we still need to consider the scenario in which the fingerprint changes due to pods. This can happen when new dependency is added that requires autolinking. Therefore we are changing the logic such that we update the current fingerprint after pods installation (when triggered).

This PR also resolves some other build related issues:
1) We're updating xcodebuild command to use `arch` and `sdk` options instead of relying on temporary simulator created with the exact same settings. I validated that properly setting these options doesn't impact the build time and that when using `-showBuildSettings` options, the xcode generates the same settings in both cases. We want to avoid having temporary simulators as they'd sometimes appear in xcode UI.
2) We're updating some places where logging wasn't accurate. For example, we only print "Installing node_modules" when we're actually triggering the installation rather than when checking if installation is necessary and then optionally installing.
3) We're reporting build times now to logger so that we can better diagnose similar issues in the future
4) We're also adding build time reports option to xcode builds for the similar reason.


## Test plan
1) With expo-router, try running `pod install` from terminal. Then open project in IDE – this will trigger native build. Then subsequent re-opening of the project should no longer trigger build and there's no fingerprint mismatch in logs.
2) Verify the clean build times are the same with previous and new commands (for me they both take around 90seconds)





