### PR TITLE
Fix infinite loop for device selection when device is already in use

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -211,7 +211,10 @@ export class Project
       // wait for the new device to be added to the list:
       const listener = async (newDevices: DeviceInfo[]) => {
         this.deviceManager.removeListener("devicesChanged", listener);
-        if (isEqual(newDevices, devices)) {
+        if (this.projectState.selectedDevice) {
+          // device was selected in the meantime, we don't need to do anything
+          return;
+        } else if (isEqual(newDevices, devices)) {
           // list is the same, we register listener to wait for the next change
           this.deviceManager.addListener("devicesChanged", listener);
         } else {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -207,17 +207,20 @@ export class Project
       this.updateProjectState({
         selectedDevice: undefined,
       });
-      // because devices might be outdated after xcode installation change we list them again
-      const newDeviceList = await this.deviceManager.listAllDevices();
-      if (!isEqual(newDeviceList, devices)) {
-        selectInitialDevice(newDeviceList);
-      } else {
-        const listener = async (newDevices: DeviceInfo[]) => {
-          this.deviceManager.removeListener("devicesChanged", listener);
+      // when we reach this place, it means there's no device that we can select, we
+      // wait for the new device to be added to the list:
+      const listener = async (newDevices: DeviceInfo[]) => {
+        this.deviceManager.removeListener("devicesChanged", listener);
+        if (isEqual(newDevices, devices)) {
+          // list is the same, we register listener to wait for the next change
+          this.deviceManager.addListener("devicesChanged", listener);
+        } else {
           selectInitialDevice(newDevices);
-        };
-        this.deviceManager.addListener("devicesChanged", listener);
-      }
+        }
+      };
+
+      // we trigger initial listener call with the most up to date list of devices
+      listener(await this.deviceManager.listAllDevices());
 
       return false;
     };


### PR DESCRIPTION
This PR fixes an issue with infinite loop we'd fall into with initial device selection that caused "This device is already used..." warning appearing every second.

The problem would occur, when the previously selected device was being used in some other window. The root cause of the problem was that the 'devicesChanged' event can be triggered regardless of whether the device list actually updates, but at any point we trigger the code that loads the devices list. As a consequence `selectInitialDevice` would fall into a loop as it was requesting to load the device, and then setup a listener that'd call `selectInitialDevice` again.

While this issue isn't specific for the case where device is in use, and the infinite loop would still be spinning in case the initial device fails to be selected (for example, when there are no devices on the list). However, it surfaced because for the case when device is used elsewhere we display a warning dialog which would start popping up every second in this case.

The fix is for the listener to validate whether the device change event actually provides us with an updated list of devices. If not, we ignore such event and wait for next one instead of trying to re-select the device from the same set of devices.

This PR also fixes another issue with `selectInitialDevice` logic that would, in some cases result in initial device being selected even after the user select the device on their own. This would occur in case when we can't select the initial device (for example because it is in use), user selects a device manually, and later on they create a new device. In such case the listener would still be active and once new device is selected it'd grab that new device. The fix for this issue is to return from the listener if we see that device is already selected.

## Test plan

1. Open separate vscode window with Radon IDE installed, select device that we previously used in our test project
2. Launch extension with the test project
3. You should only get the error that "device is already used" once instead of getting them every second

