### PR TITLE
Include stack trace for unhandled promises and error logging

### DIFF
--- a/packages/vscode-extension/src/Logger.ts
+++ b/packages/vscode-extension/src/Logger.ts
@@ -24,7 +24,12 @@ const logger = {
   },
 
   error(message: string, ...args: any[]) {
-    outputChannel.error(message, ...args);
+    if (args.length > 0 && args[0] instanceof Error) {
+      const error = args[0] as Error;
+      outputChannel.error(error, message, ...args.slice(0, -1));
+    } else {
+      outputChannel.error(message, ...args);
+    }
   },
 
   openOutputPanel() {

--- a/packages/vscode-extension/src/Logger.ts
+++ b/packages/vscode-extension/src/Logger.ts
@@ -24,8 +24,8 @@ const logger = {
   },
 
   error(message: string, ...args: any[]) {
-    if (args.length > 0 && args[0] instanceof Error) {
-      const error = args[0] as Error;
+    if (args.length > 0 && args[args.length - 1] instanceof Error) {
+      const error = args[args.length - 1] as Error;
       outputChannel.error(error, message, ...args.slice(0, -1));
     } else {
       outputChannel.error(message, ...args);

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -98,12 +98,12 @@ export class DebugAdapter extends DebugSession {
     this.connection = new WebSocket(configuration.websocketAddress);
 
     this.connection.on("open", () => {
-      this.sendCDPMessage("FuseboxClient.setClientMetadata", {});
+      this.sendCDPMessage("FuseboxClient.setClientMetadata", {}).catch(); // ignore error as it will throw on old debugger and is not critical
       this.sendCDPMessage("Runtime.enable", {});
       this.sendCDPMessage("Debugger.enable", { maxScriptsCacheSize: 100000000 });
       this.sendCDPMessage("Debugger.setPauseOnExceptions", { state: "none" });
-      this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 });
-      this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] });
+      this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 }).catch(); // ignore error as it will throw on old debugger and is not critical
+      this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] }).catch(); // ignore error as it will throw on old debugger and is not critical
       this.sendCDPMessage("Runtime.runIfWaitingForDebugger", {});
       this.sendCDPMessage("Runtime.evaluate", {
         expression: "__RNIDE_onDebuggerConnected()",
@@ -123,7 +123,11 @@ export class DebugAdapter extends DebugSession {
           messagePromise.resolve(message.result);
         } else if (message.error && messagePromise?.reject) {
           Logger.warn("CDP message error received", message.error);
-          messagePromise.reject(message.error);
+          // create an error object such that we can capture stack trace and assign
+          // all object error properties as provided by CDP
+          const error = new Error();
+          Object.assign(error, message.error);
+          messagePromise.reject(error);
         }
         return;
       }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -32,7 +32,6 @@ import { Project } from "./project/project";
 import { findFilesInWorkspace, isWorkspaceRoot } from "./utilities/common";
 import { Platform } from "./utilities/platform";
 
-const BIN_MODIFICATION_DATE_KEY = "bin_modification_date";
 const OPEN_PANEL_ON_ACTIVATION = "open_panel_on_activation";
 
 function handleUncaughtErrors() {


### PR DESCRIPTION
This PR fixes the logging of errors to include stack traces in the log output.

Before this change, we'd append error as last element to log output channel, whereas VSCode API expects the error to be passed as first item. As a consequence, error would just be treated as strings and we'd only get error.message in the output.

This PR reorders the elements if error object is passed as the last item to Logger.error (we do it in a number of places throught the codebase). Error messages are then provided as the first item which makes VSCode format them properly and also display stack trace in the output.

This is particularily usecul for unhandled exception handlers where we have no clue of where a given error could be thrown.

This PR also disables expected rejections in certain CDP calls that we are making as they were polluting our log output.
We are also now wrapping CDP calls in Error objects such that we can see proper stack traces in the output.

## Test plan
1. Disable catch() calls in Adapter
2. See the unhandled exception with stack trace (there was only message before this change)