### PR TITLE
Add build and launch telemetry

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -17,6 +17,8 @@ import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
 import { DependencyManager } from "../dependency/DependencyManager";
+import { getTelemetryReporter } from "../utilities/telemetry";
+import { platform } from "os";
 
 type StartOptions = { cleanBuild: boolean };
 
@@ -100,6 +102,11 @@ export class DeviceSession implements Disposable {
   }
 
   private async launchApp() {
+    const launchReequestTime = Date.now();
+    getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
+      platform: this.device.platform,
+    });
+
     // FIXME: Windows getting stuck waiting for the promise to resolve. This
     // seems like a problem with app connecting to Metro and using embedded
     // bundle instead.
@@ -111,10 +118,30 @@ export class DeviceSession implements Disposable {
 
     Logger.debug("Will wait for app ready and for preview");
     this.eventDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
+
+    if (shouldWaitForAppLaunch) {
+      const reportWaitingStuck = setTimeout(() => {
+        Logger.info("App is taking very long to boot up, it might be stuck");
+        getTelemetryReporter().sendTelemetryEvent("app:launch:waiting-stuck", {
+          platform: this.device.platform,
+        });
+      }, 30000);
+      waitForAppReady.then(() => clearTimeout(reportWaitingStuck));
+    }
+
     const [previewUrl] = await Promise.all([this.device.startPreview(), waitForAppReady]);
     Logger.debug("App and preview ready, moving on...");
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
     await this.startDebugger();
+
+    const launchDurationSec = (Date.now() - launchReequestTime) / 1000;
+    Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");
+    getTelemetryReporter().sendTelemetryEvent(
+      "app:launch:completed",
+      { platform: this.device.platform },
+      { durationSec: launchDurationSec }
+    );
+
     return previewUrl;
   }
 
@@ -135,7 +162,14 @@ export class DeviceSession implements Disposable {
     });
     this.maybeBuildResult = await this.disposableBuild.build;
     const buildDurationSec = (Date.now() - buildStartTime) / 1000;
-    Logger.info(`Build completed in ${buildDurationSec.toFixed(2)}s`);
+    Logger.info("Build completed in", buildDurationSec.toFixed(2), "sec.");
+    getTelemetryReporter().sendTelemetryEvent(
+      "build:completed",
+      {
+        platform: this.device.platform,
+      },
+      { durationSec: buildDurationSec }
+    );
   }
 
   private async installApp({ reinstall }: { reinstall: boolean }) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -101,7 +101,7 @@ export class DeviceSession implements Disposable {
   }
 
   private async launchApp() {
-    const launchReequestTime = Date.now();
+    const launchRequestTime = Date.now();
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
       platform: this.device.platform,
     });
@@ -133,7 +133,7 @@ export class DeviceSession implements Disposable {
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
     await this.startDebugger();
 
-    const launchDurationSec = (Date.now() - launchReequestTime) / 1000;
+    const launchDurationSec = (Date.now() - launchRequestTime) / 1000;
     Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");
     getTelemetryReporter().sendTelemetryEvent(
       "app:launch:completed",

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -18,7 +18,6 @@ import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
-import { platform } from "os";
 
 type StartOptions = { cleanBuild: boolean };
 


### PR DESCRIPTION
This PR adds more loggind and telemetry around build and launch process.

Building and launching the app is one of the most fragile element of the IDE pipeline and we get numerous reports around that. While there are a few known issues around it that we are fixing and investigating. I figured it'd be good to also add telemetry around that such that we can track how it works for a larger group of people and also be able to detect regressions.

## Test plan

Just run the example app with clean build and make sure nothing breaks.