### PR TITLE
Fix android studio path after #592

### DIFF
--- a/packages/vscode-extension/src/utilities/android.ts
+++ b/packages/vscode-extension/src/utilities/android.ts
@@ -11,7 +11,7 @@ export const ANDROID_HOME =
   });
 
 const ANDROID_STUDIO_PATH = Platform.select({
-  macos: path.join("Applications", "Android Studio.app"),
+  macos: "/Applications/Android Studio.app",
   windows: path.join("C:", "Program Files", "Android", "Android Studio"),
 });
 

--- a/packages/vscode-extension/src/utilities/android.ts
+++ b/packages/vscode-extension/src/utilities/android.ts
@@ -6,14 +6,9 @@ import { Platform } from "./platform";
 export const ANDROID_HOME =
   process.env.ANDROID_HOME ??
   Platform.select({
-    macos: path.join(os.homedir(), "Library", "Android", "sdk"),
-    windows: path.join(os.homedir(), "AppData", "Local", "Android", "Sdk"),
+    macos: path.join(os.homedir(), "Library/Android/sdk"),
+    windows: path.join(os.homedir(), "AppData\\Local\\Android\\Sdk"),
   });
-
-const ANDROID_STUDIO_PATH = Platform.select({
-  macos: "/Applications/Android Studio.app",
-  windows: path.join("C:", "Program Files", "Android", "Android Studio"),
-});
 
 function findJavaHome() {
   // we first try to use environment variable and if it is not set, we then use java bundled with Android Studio
@@ -26,17 +21,24 @@ function findJavaHome() {
     return envJavaHome;
   }
 
+  const androidStudioPath = Platform.select({
+    macos: "/Applications/Android Studio.app",
+    windows: path.join(path.parse(os.homedir()).root, "Program Files\\Android\\Android Studio"),
+  });
+
   const jbrPath = Platform.select({
-    macos: path.join(ANDROID_STUDIO_PATH, "Contents", "jbr", "Contents", "Home"),
-    windows: path.join(ANDROID_STUDIO_PATH, "jbr"),
+    macos: path.join(androidStudioPath, "Contents/jbr/Contents/Home"),
+    windows: path.join(androidStudioPath, "jbr"),
   });
 
-  const jrePath = Platform.select({
-    macos: path.join(ANDROID_STUDIO_PATH, "Contents", "jre", "Contents", "Home"),
-    windows: path.join(ANDROID_STUDIO_PATH, "jre"),
-  });
+  if (fs.existsSync(jbrPath)) {
+    return jbrPath;
+  }
 
-  return fs.existsSync(jbrPath) ? jbrPath : jrePath;
+  return Platform.select({
+    macos: path.join(androidStudioPath, "Contents/jre/Contents/Home"),
+    windows: path.join(androidStudioPath, "jre"),
+  });
 }
 
 export const JAVA_HOME = findJavaHome();


### PR DESCRIPTION
In #592 we broke the Android Studio path on Mac while replacing the actual path with `path.join` calls. Apparently, `path.join` doesn't start at the file system root, but creates relative path if no lash at the start is provided.

This PR updates the logic of the code that finds java home:
1. We no longer use path.join where it doesn't make sense. Specifically given we have Platform.select we now exacly how paths are constructed on each individual system. Using path.join just makes it more difficult to process this code.
2. We move constants that doesn't need to live under global scope into findJavaHome method (specifically path for android studio)
3. We extract fs root on windows using cwd path root attribute to make it more resilient depending on the users' filesystem setup.


### Test plan
1. Make sure android builds can run on Mac (they were broken before)
2. Test on windows as well (don't have it at hand right now but we will test it later today)