### PR TITLE
Use metro message endpoint to dispatch dev menu request

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -43,9 +43,6 @@ const RNInternals = {
     } catch (e) {}
     throw new Error("Couldn't locate LoadingView module");
   },
-  get DevMenu() {
-    return require("react-native/Libraries/NativeModules/specs/NativeDevMenu").default;
-  },
 };
 
 function getCurrentScene() {
@@ -245,12 +242,6 @@ export function PreviewAppWrapper({ children, initialProps, ..._rest }) {
     },
     [mainContainerRef]
   );
-
-  useAgentListener(devtoolsAgent, "RNIDE_iosDevMenu", (_payload) => {
-    // this native module is present only on iOS and will crash if called
-    // on Android
-    RNInternals.DevMenu.show();
-  });
 
   useAgentListener(
     devtoolsAgent,

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -175,10 +175,6 @@ export class AndroidEmulatorDevice extends DeviceBase {
     await this.changeSettings(settings);
   }
 
-  async openDevMenu() {
-    await exec(ADB_PATH, ["-s", this.serial!, "shell", "input", "keyevent", "82"]);
-  }
-
   async configureExpoDevMenu(packageName: string) {
     if (packageName === "host.exp.exponent") {
       // For expo go we are unable to change this setting as the APK is not debuggable

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -269,7 +269,7 @@ export class DeviceSession implements Disposable {
   }
 
   public async openDevMenu() {
-    this.metro.openDevMenu();
+    await this.metro.openDevMenu();
   }
 
   public startPreview(previewId: string) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -269,17 +269,7 @@ export class DeviceSession implements Disposable {
   }
 
   public async openDevMenu() {
-    // on iOS, we can load native module and dispatch dev menu show method. On
-    // Android, this native module isn't available and we need to fallback to
-    // adb to send "menu key" (code 82) to trigger code path showing the menu.
-    //
-    // We could probably unify it in the future by running metro in interactive
-    // mode and sending keys to stdin.
-    if (this.device.platform === DevicePlatform.IOS) {
-      this.devtools.send("RNIDE_iosDevMenu");
-    } else {
-      await (this.device as AndroidEmulatorDevice).openDevMenu();
-    }
+    this.metro.openDevMenu();
   }
 
   public startPreview(previewId: string) {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -8,6 +8,7 @@ import { extensionContext, getAppRootFolder } from "../utilities/extensionContex
 import { shouldUseExpoCLI } from "../utilities/expoCli";
 import { Devtools } from "./devtools";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
+import WebSocket from "ws";
 
 export interface MetroDelegate {
   onBundleError(): void;
@@ -232,6 +233,22 @@ export class Metro implements Disposable {
     const appReady = this.devtools.appReady();
     await fetch(`http://localhost:${this._port}/reload`);
     await appReady;
+  }
+
+  public async openDevMenu() {
+    // to send request to open dev menu, we route it through metro process
+    // that maintains a websocket connection with the device. Specifically,
+    // /message endpoint is used to send messages to the device, and metro proxies
+    // messages between different clients connected to that endpoint.
+    // Therefore, to send the message to the device we:
+    // 1. connect to the /message endpoint over websocket
+    // 2. send specifically formatted message to open dev menu
+    const ws = new WebSocket(`ws://localhost:${this._port}/message`);
+    await new Promise((resolve) => ws.addEventListener("open", resolve));
+    ws.send(
+      JSON.stringify({ version: 2 /* protocol version, needs to be set to 2 */, method: "devMenu" })
+    );
+    ws.close();
   }
 
   public async getDebuggerURL() {


### PR DESCRIPTION
This PR uses a different method for opening dev menu.

Previously we'd call native dev menu module, which was causing problems, specifically in expo-go where the module resolution was resulting in bundle error. Since it turned out to be easier to use the standard method that metro uses for triggering the menu than to debug the old method, I decided to rework the underlying implementation.

Now, we use metro /message endpoint that is used to proxy messages between dev tools and device. One of the messages is "devMenu" which opens the dev menu on the device side (which is what we wanted).

This PR also removes old code which was placed in the wrapper, but also for android we were using a different method that was relying on adb. The new method works on both devices, hence we don't need separate implementation and can delete both of them.

## Test plan
1. Use dev menu option on Android and iOS across all configurations we have in the repo (expo-go, react-native-75, expo-51 etc)