### PR TITLE
Rename hotReload option to reloadJs

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -65,8 +65,7 @@ export type ReloadAction =
   | "reboot" // reboots device, launch app
   | "reinstall" // force reinstall app
   | "restartProcess" // relaunch app
-  | "reloadJs" // refetch JS scripts from metro
-  | "hotReload";
+  | "reloadJs"; // refetch JS scripts from metro
 
 export type InspectDataStackItem = {
   componentName: string;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -92,7 +92,7 @@ export class DeviceSession implements Disposable {
       case "restartProcess":
         await this.launchApp();
         return true;
-      case "hotReload":
+      case "reloadJs":
         if (this.devtools.hasConnectedClient) {
           await this.metro.reload();
           return true;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -255,7 +255,7 @@ export class Project
   }
 
   private async reloadMetro() {
-    if (await this.deviceSession?.perform("hotReload")) {
+    if (await this.deviceSession?.perform("reloadJs")) {
       this.updateProjectState({ status: "running" });
     }
   }

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -15,7 +15,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
       }}
       disabled={disabled}
       options={{
-        "Hot reload": () => project.reload("hotReload"),
+        "Reload JS": () => project.reload("reloadJs"),
         "Restart app process": () => project.reload("restartProcess"),
         "Reinstall app": () => project.reload("reinstall"),
         "Clean rebuild": () => project.restart(true),


### PR DESCRIPTION
This PR renames "hot reload" option from the reload menu to "reload JS" which is a more accurate name. Hot reloading refers to the option of hot-swapping individual modules, whereas this option was doing a full bundle reload.

## Test plan
1. Test reloading JS from reload dropdown