### PR TITLE
Let restart process continue when reload JS is not possible

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -257,7 +257,9 @@ export class Project
   private async reloadMetro() {
     if (await this.deviceSession?.perform("reloadJs")) {
       this.updateProjectState({ status: "running" });
+      return true;
     }
+    return false;
   }
 
   public async goHome(homeUrl: string) {
@@ -302,7 +304,11 @@ export class Project
     }
 
     if (onlyReloadJSWhenPossible) {
-      return await this.reloadMetro();
+      // if reloading JS is possible, we try to do it first and exit in case of success
+      // otherwise we continue to restart using more invasive methods
+      if (await this.reloadMetro()) {
+        return;
+      }
     }
 
     // otherwise we try to restart the device session


### PR DESCRIPTION
Changes from #477 broke restart flow for the cases when just reloading is not possible.

Previously, when "reload" button was clicked in the UI, we were trying to do the least invasive reload method possible. For that purpose we'd first attempt to reload JS, but only if the app process is alive. Apparently, due to the changes in #477 we were no longer checking whether app is running and we'd always call reload JS and let the restarting process end there.

This turns out to be a problem for example in scenarios where we get bundle error at the app startup. As a consequence, the app process never starts, and it is not possible to reload JS even once the bundle error we're getting gets fixed.

In this PR we're restoring this mechanism:
1) we update `reloadMetro` method to forward the result from `perform` call which indicates whether the reload was successful.
2) we check the result of reloadMetro call, and in case it returns `false` we let the restart process continue execution to eventually reach code that tries to restart the app process.

## Test plan
1. Simulate bundle error at startup (e.g., add broken import)
2. Boot the app – see the error
3. Fix the error and click reload (before this change it'd get stuck in "restarting" state, now it restarts the process)
4. Later, use reloadJS when the app is loaded to make sure we don't restart the process.