### PR TITLE
Disable default context menu on windows

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -417,7 +417,7 @@ function Preview({
     // this is a fix that disables context menu on windows https://github.com/microsoft/vscode/issues/139824
     // there is an active backlog item that aims to change the behavior of context menu, so it might not be necessary
     // in the future https://github.com/microsoft/vscode/issues/225411
-    function onContextMenu(e) {
+    function onContextMenu(e: any) {
       e.stopImmediatePropagation();
     }
 
@@ -430,10 +430,10 @@ function Preview({
         setIsPressing(false);
       }
     }
-    addEventListener("blur", onBlurChange, true);
+    document.addEventListener("blur", onBlurChange, true);
     return () => {
       window.removeEventListener("contextmenu", onContextMenu);
-      removeEventListener("blur", onBlurChange, true);
+      document.removeEventListener("blur", onBlurChange, true);
     };
   }, []);
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -413,11 +413,16 @@ function Preview({
     }
   }
 
-  function onContextMenu(e: MouseEvent<HTMLDivElement>) {
-    e.preventDefault();
-  }
-
   useEffect(() => {
+    // this is a fix that disables context menu on windows https://github.com/microsoft/vscode/issues/139824
+    // there is an active backlog item that changes the bahaviour of context menu, so it might not be necessery
+    // in the future https://github.com/microsoft/vscode/issues/225411
+    function onContextMenu(e) {
+      e.stopImmediatePropagation();
+    }
+
+    window.addEventListener("contextmenu", onContextMenu, true);
+
     function onBlurChange() {
       if (!document.hasFocus()) {
         setIsPanning(false);
@@ -426,7 +431,10 @@ function Preview({
       }
     }
     addEventListener("blur", onBlurChange, true);
-    return () => removeEventListener("blur", onBlurChange, true);
+    return () => {
+      window.removeEventListener("contextmenu", onContextMenu);
+      removeEventListener("blur", onBlurChange, true);
+    };
   }, []);
 
   useEffect(() => {
@@ -505,7 +513,6 @@ function Preview({
         onMouseUp,
         onMouseEnter,
         onMouseLeave,
-        onContextMenu,
       };
 
   const resizableProps = useResizableProps({

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -415,7 +415,7 @@ function Preview({
 
   useEffect(() => {
     // this is a fix that disables context menu on windows https://github.com/microsoft/vscode/issues/139824
-    // there is an active backlog item that changes the bahaviour of context menu, so it might not be necessery
+    // there is an active backlog item that aims to change the behavior of context menu, so it might not be necessary
     // in the future https://github.com/microsoft/vscode/issues/225411
     function onContextMenu(e) {
       e.stopImmediatePropagation();


### PR DESCRIPTION
This PR disables default context menu on windows, as it clashed with right-click inspector functionality. 

Test plan: 
- open Radon IDE 
- right click inside app previe to trigger inspector 