### PR TITLE
Rephrase error messages for platform folder checks

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -121,7 +121,7 @@ export async function buildAndroid(
 
   if (!(await dependencyManager.isInstalled("android"))) {
     throw new Error(
-      "Android directory does not exist, configure build source in launch configuration or use expo prebuild to generate the directory"
+      '"android" directory does not exist, configure build source in launch configuration or use expo prebuild to generate the directory'
     );
   }
 

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -352,5 +352,5 @@ async function areNativeDirectoriesOptional(): Promise<boolean> {
   const isExpoGo = await isExpoGoProject();
   const launchConfiguration = getLaunchConfiguration();
 
-  return isExpoGo && !!launchConfiguration.eas && !!launchConfiguration.customBuild;
+  return isExpoGo || !!launchConfiguration.eas || !!launchConfiguration.customBuild;
 }

--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -225,13 +225,13 @@ export function dependencyDescription(dependency: Dependency) {
       };
     case "ios":
       return {
-        info: "Whether ios directory exists in the project",
-        error: "Ios directory does not exist in root directory",
+        info: 'Whether "ios" directory exists in the project',
+        error: '"ios" directory does not exist in the main application directory',
       };
     case "android":
       return {
-        info: "Whether android directory exists in the project",
-        error: "Android directory does not exist in root directory",
+        info: 'Whether "android" directory exists in the project',
+        error: '"android" directory does not exist in the main application directory',
       };
     case "expo":
       return {


### PR DESCRIPTION
#605 introduced new platform folder checks. Apparenly also introduced a small error that got fixed in #607 but while testing this I figured the error messages weren't clear + we were using some weird constructs like "Ios"