### PR TITLE
Update CSP to allow replays to play in release builds

### DIFF
--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -53,6 +53,7 @@ export function generateWebviewContent(
         <meta http-equiv="Content-Security-Policy"
               content="default-src 'none';
                       img-src vscode-resource: http: https: data:;
+                      media-src vscode-resource: http: https:;
                       style-src ${webview.cspSource} 'unsafe-inline';
                       script-src 'nonce-${nonce}';
                       font-src vscode-resource: https:;" />


### PR DESCRIPTION
This PR updates CSP used for the IDE panel. This is needed for replays to work, as the built-in player streams the video over http, we need to allow for this.

The issue wasn't detected with non-release builds before as we use different CSP settings there that are much more permissive in order to allow for things like hot reload.

## Test plan

Try out replays on release build