### PR TITLE
Fix app loading error when AppRegistry.setWrapperComponentProvider is used

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -45,3 +45,25 @@ global.__RNIDE_register_navigation_plugin = function (name, plugin) {
 AppRegistry.setWrapperComponentProvider((appParameters) => {
   return require("__RNIDE_lib__/wrapper.js").PreviewAppWrapper;
 });
+
+// Some apps may use AppRegistry.setWrapperComponentProvider to provide a custom wrapper component.
+// Apparenlty, this method only supports one provided per app. In order for this to work, we
+// overwrite the method to wrap the custom wrapper component with the app wrapper that IDE uses
+// from the wrapper.js file.
+const origSetWrapperComponentProvider = AppRegistry.setWrapperComponentProvider;
+AppRegistry.setWrapperComponentProvider = (provider) => {
+  console.info("RNIDE: The app is using a custom wrapper component provider");
+  origSetWrapperComponentProvider((appParameters) => {
+    const RNIDEAppWrapper = require("__RNIDE_lib__/wrapper.js").PreviewAppWrapper;
+    const CustomWrapper = provider(appParameters);
+    function WrapperComponent(props) {
+      const { children, ...rest } = props;
+      return (
+        <RNIDEAppWrapper {...rest}>
+          <CustomWrapper {...rest}>{children}</CustomWrapper>
+        </RNIDEAppWrapper>
+      );
+    }
+    return WrapperComponent;
+  });
+};


### PR DESCRIPTION
This PRs allows apps to use `AppRegistry.setWrapperComponentProvider` API.

The IDE "runtime" uses wrapper component API to provide a top-level component that is responsible for setting up communication between app and the IDE (debugger / inspector / routing). This API is not considered "public" but, apparently, there are some third party libraries (as mentioned in #544) that also rely on this API, which only support a single wrapper component.

As a consequence of the above, those libraries would override the IDE's runtime wrapper breaking the communication channel and causing the app to be stuck on the loading phase.

In this PR, we are providing an override for `setWrapperComponentProvider` method, that provides a wrapper component that renders both the IDE runtime wrapper and the custom wrapper provided with the method call.

Fixes #544

Note, that there are other possible issues causing the app getting stuck on the loading phase that we are also tracking. This PR only fixes the issue rooted in the use of `AppRegistry.setWrapperComponentProvider` API.

### How Has This Been Tested: 
1. Use `AppRegistry.setWrapperComponentProvider` in main JS file in one of the projects. Make the wrapper render thick red border to make sure the wrapper is being rendered.
2. Before this change, the app would get stuck on loading phase, now it loads properly.
3. Make sure the fast refresh works
4. (Apparently there is some issue when attempting to fast-refresh the wrapper component itself)


