### PR TITLE
Make select content background darker in dark mode for distinction

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -377,7 +377,7 @@ body[data-vscode-theme-kind="vscode-dark"] {
   --swm-select-shadow: 0 1px 10px var(--background-dark-100);
   --swm-select-disabled: var(--navy-dark-60);
   --swm-select-disabled-background: var(--background-dark-120);
-  --swm-select-content-background: var(--background-dark-80);
+  --swm-select-content-background: var(--background-dark-100);
   --swm-select-item-disabled-background: var(--background-dark-100);
   --swm-select-item-highlighted-background: var(--background-dark-60);
 


### PR DESCRIPTION
Fixes #618 

### Screenshots

#### Before: 

<img width="575" alt="Zrzut ekranu 2024-10-14 o 09 40 03" src="https://github.com/user-attachments/assets/eb433dcc-a5ef-4dc5-9450-05379f508215">

#### After:

<img width="580" alt="Zrzut ekranu 2024-10-14 o 09 39 50" src="https://github.com/user-attachments/assets/c1a3d447-b1a7-494a-88aa-39d644c88ed8">

#### On light color scheme (no problem, no changes)

<img width="578" alt="Zrzut ekranu 2024-10-14 o 09 40 20" src="https://github.com/user-attachments/assets/5adb85b3-4ac5-4cba-b170-8c591ce39b1d">

### How Has This Been Tested: 

Tested select menus in "Manage Device" modal and "Launch Configuration" modal on both dark and light color scheme.



