### PR TITLE
Use bundle install before pod install when bundle is used

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -167,10 +167,14 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
     try {
       const env = getLaunchConfiguration().env;
       const shouldUseBundle = await this.shouldUseBundleCommand();
-      const process = command(shouldUseBundle ? "bundle exec pod install" : "pod install", {
-        cwd: iosDirPath,
-        env: { ...env, LANG: "en_US.UTF-8" },
-      });
+      const process = command(
+        shouldUseBundle ? "bundle install && bundle exec pod install" : "pod install",
+        {
+          shell: shouldUseBundle, // when using bundle, we need shell to run multiple commands
+          cwd: iosDirPath,
+          env: { ...env, LANG: "en_US.UTF-8" },
+        }
+      );
       lineReader(process).onLineRead((line) => buildOutputChannel.appendLine(line));
       await cancelToken.adapt(process);
     } catch (e) {


### PR DESCRIPTION
In #617 we added an option for the IDE to use bundle command instead of pods directly as it is now recommended in new react native templates and setups. However, for bundle to work properly, we need to `bundle install` first. This was missed in that PR as I was testing a project where bundle install has already run.

### How Has This Been Tested: 
1. Delete rn 75 project and checkout a fresh copy
2. Open the fresh RN 75 project with the IDE


