### PR TITLE
Bundle error dialog enhancements

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -328,8 +328,11 @@ export class Project
   public async reload(type: ReloadAction): Promise<boolean> {
     this.updateProjectState({ status: "starting" });
     const success = (await this.deviceSession?.perform(type)) ?? false;
-    // TODO(jgonet): Don't assume that success is always true
-    this.updateProjectState({ status: "running" });
+    if (success) {
+      this.updateProjectState({ status: "running" });
+    } else {
+      window.showErrorMessage("Failed to reload, you may try another reload option", "Dismiss");
+    }
     return success;
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -331,7 +331,7 @@ export class Project
     if (success) {
       this.updateProjectState({ status: "running" });
     } else {
-      window.showErrorMessage("Failed to reload, you may try another reload option", "Dismiss");
+      window.showErrorMessage("Failed to reload, you may try another reload option.", "Dismiss");
     }
     return success;
   }

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -85,15 +85,15 @@ function BundleErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.focusDebugConsole();
+          project.focusExtensionLogsOutput();
         }}
-        tooltip={{ label: "Open debug console", side: "bottom" }}>
-        <span className="codicon codicon-debug-console" />
+        tooltip={{ label: "Open extension logs", side: "bottom" }}>
+        <span className="codicon codicon-output" />
       </IconButton>
       <IconButton
         type="secondary"
         onClick={() => {
-          project.reload("reloadJs");
+          project.restart(false);
         }}
         tooltip={{ label: "Reload Metro", side: "bottom" }}>
         <span className="codicon codicon-refresh" />
@@ -105,7 +105,7 @@ function BundleErrorActions() {
 const bundleErrorAlert = {
   id: "bundle-error-alert",
   title: "Bundle error",
-  description: "Open application logs to find out what went wrong.",
+  description: "Open IDE logs to find out what went wrong.",
   actions: <BundleErrorActions />,
 };
 


### PR DESCRIPTION
This PR updates the error dialog we show when detecting bundle error.

Previously, we'd direct the users to app logs from that dialog. Those logs apparently never display any valuable information about bundling as they come from the app process, while bundle errors are reported by metro.

In addition, the reload button from bundle error would request JS reload, which isn't sufficient in the case when the app boots up with a bundle error.

We are therefore making the following changes:
1. We're updating the logs button from bundle error dialog to open IDE logs where metro errors are getting printed: <img width="1737" alt="image" src="https://github.com/user-attachments/assets/8078639b-3a09-41d0-bf4c-4f4d1a56c955">
2. We're changing the reload button to call `restart` – restart implementation is smart enough and will attempt to reload JS when the app process is running, otherwise it will try to restart the app process, which is also good in case when we're recovering from initial bundle error
3. We're also updating `reload` implementation to remove "TODO" added there. The TODO was about handling unsuccessful reloads. Those could happen when the user forces "reloadJS" but the app process isn't running. In such a case we shouldn't attempt another reload method as that's not what user requested. Instead we will show an error popup with message that the reload attempt wasn't successful.


### How Has This Been Tested: 
1. Delete 51-dev-client folder and checkout a fresh copy. 
2. Run the IDE on that new project and expect bundle error.
3. See that logs button opens IDE logs which shows error about missing shared files
4. Click "reload JS" button from the refresh dropdown to see new error dialog
5. Use copy-shared script to copy them and click reload
6. The app will restart and load properly
7. Add import to something that doesn't exists
8. See the bundle error again, this one on top of a running app
9. Fix error and click reload – it should only reload JS and recover immediately


