### PR TITLE
Restart app process on Android when launching app

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -292,6 +292,10 @@ export class AndroidEmulatorDevice extends DeviceBase {
     if (build.platform !== DevicePlatform.Android) {
       throw new Error("Invalid platform");
     }
+    // terminate the app before launching, otherwise launch commands won't actually start the process which
+    // may be in a bad state
+    await exec(ADB_PATH, ["-s", this.serial!, "shell", "am", "force-stop", build.packageName]);
+
     const deepLinkChoice =
       build.packageName === EXPO_GO_PACKAGE_NAME ? "expo-go" : "expo-dev-client";
     const expoDeeplink = await fetchExpoLaunchDeeplink(metroPort, "android", deepLinkChoice);


### PR DESCRIPTION
This PR fixes the recovery mechanism when bundle error occurs. Previously, when bundle error happened on Android, we attempted to restart the process by using `launchApp` code path. This, however, would only try to launch the app process, while it may already be in a bad state. Launching it again using deeplink wouldn't recover the process, and similarly to how we do this on iOS, we should terminate the process prior to launching via deeplink or with the `monkey` adb command.

Along with this PR we are enhancing the logging for the case when app gets stuck. I'd often search for stream URL to diagnose, and now it gets printed along the "stuck" message.

### How Has This Been Tested: 
1. Open project dev-client project with JS errors, see bundle error when it launches
2. Fix errors and try reloading
3. It should now fully recover, before it'd get stuck on loading as the unrelying process wouldn't restart and wouldn't know that it should attempted a reload.


