### PR TITLE
Improve error recovery after metro process terminates

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -20,6 +20,11 @@ global.__RNIDE_onDebuggerConnected = function () {
   global.__fbDisableExceptionsManager = true;
 };
 
+// We add log this trace to diagnose issues with loading runtime in the IDE
+// It is necessary that this call is before we override console methods, otherwise
+// this message would be visible in the debug console panel for the IDE users.
+console.log("__RNIDE_INTERNAL: react-native-ide runtime loaded");
+
 function wrapConsole(consoleFunc) {
   return function (...args) {
     const stack = parseErrorStack(new Error().stack);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -11,8 +11,6 @@ import {
   StartupMessage,
   TouchPoint,
 } from "../common/Project";
-import { DevicePlatform } from "../common/DeviceManager";
-import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
@@ -94,8 +92,12 @@ export class DeviceSession implements Disposable {
         return true;
       case "reloadJs":
         if (this.devtools.hasConnectedClient) {
-          await this.metro.reload();
-          return true;
+          try {
+            await this.metro.reload();
+            return true;
+          } catch (e) {
+            Logger.error("Failed to reload JS", e);
+          }
         }
         return false;
     }
@@ -138,6 +140,7 @@ export class DeviceSession implements Disposable {
     }
 
     await Promise.all([
+      this.metro.ready(),
       this.device.startPreview().then((url) => (previewURL = url)),
       waitForAppReady,
     ]);

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -100,6 +100,18 @@ export class Metro implements Disposable {
       throw new Error("metro already started");
     }
     this.startPromise = this.startInternal(resetCache, progressListener, dependencies);
+    this.startPromise.then(() => {
+      // start promise is used to indicate that metro has started, however, sometimes
+      // the metro process may exit, in which case we need to update the promise to
+      // indicate an error.
+      this.subprocess
+        ?.catch(() => {
+          // ignore the error, we are only interested in the process exit
+        })
+        ?.then(() => {
+          this.startPromise = Promise.reject(new Error("Metro process exited"));
+        });
+    });
     return this.startPromise;
   }
 


### PR DESCRIPTION
Under some (yet uncertain) circumstances, metro process may be terminated. This causes the restart functionality to stop working and the only recovery option was clean rebuild or restarting the IDE tab.

The reason was that we had a `ready` call in metro, that would always use a single promise instance that is created when metro starts. When the startup was successful, the promise resolves and future call to `ready` would always be successful. This logic wouldn't consider the case when the process starts up fine but terminates later on. As a consequence, we'd always assume the metro process is healthy which resulted in the app being stuck in "waiting for app to load" state.

After fixing the above logic, by resetting the startup promise to reject once the metro process is terminated. I found some further flaws in the resetting logic.
1. When we call `selectDevice` from the restart flow. This codepath would never check for metro health assuming it is past this step and that metro should be always ready.
2. Even if restarting the app process would fail because of metro, we'd still only call `selectDevice` as an ultimate fallback in the reset flow. This way, we'd never end up restarting metro.

This PR fixes the following things:
1. When metro process is terminated, the startup promise is updated to always reject, this way, future attempts of waiting for metro will fail and allow for different recovery mechanism to activate
2. When selectDevice is called, along with waiting for devtools, or device preview, we also do metro.ready check which determines metro's process status
3. Finally, in `restart` call, we are reshuffling the calls, such that if any of the happy-path restart mechanisms fails, we always go into fallback that restarts all subprocesses and only then starts up the device. Before, we'd only restart the device which wasn't enough to recover from certain types of errors (i.e. when metro has died).

BTW: we are also adding a log statement in runtime that would help us diagnose problems where runtime couldn't be loaded.

This fixes an issue I encountered when testing the app. While the app was running, the metro process got terminated for unknown reason. This doesn't seem to happen very often but we should still have a more resilient mechanism for recovering from errors like that when the user clicks "restart" button.

Fixes # (issue)

### How Has This Been Tested: 
1. Boot up any test project
2. After it is started, use "Process Explorer" from VSCode cmd+P menu to terminate metro process
3. Click "restart" – before this change, the app would end up in "waiting for device to load" and we wouldn't be able to recover using "restart" button. Now "restarting" will spin up new metro instance and boot normally.


