### PR TITLE
Fix misaligned lines in debugger

### DIFF
--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -41,14 +41,17 @@ function adaptMetroConfig(config) {
         module.output[0].data.code = `${preludeCode};var __REACT_DEVTOOLS_PORT__=${process.env.RCT_DEVTOOLS_PORT};`;
       }
     } else if (module.path === "__env__") {
-      // this handles @expo/env plugin, which is used to expose the number of lines in the prelude. 
-      // This is used to calculate the line number offset when reporting line numbers for 
-      // console.logs, breakpoints and uncaught exceptions. The reason why this is needed, is that
+      // this handles @expo/env plugin, which is used to inject environment variables
+      // the code below instantiates a global variable __EXPO_ENV_PRELUDE_LINES__ that stores
+      // the number of lines in the prelude. This is used to calculate the line number offset
+      // when reporting line numbers from the JS runtime, breakpoints
+      // and uncaught exceptions. The reason why this is needed, is that
       // metro doesn't include __env__ prelude in the source map resulting in the source map
       // transformation getting shifted by the number of lines in the prelude.
-      const expoEnvPreludeLines = module.output[0].data.lineCount;
-      process.stdout.write(JSON.stringify({ type: "RNIDE_Expo_Env_Prelude_Lines", expoEnvPreludeLines }));
-      process.stdout.write("\n");      
+      const expoEnvCode = module.output[0].data.code;
+      if (!expoEnvCode.includes("__EXPO_ENV_PRELUDE_LINES__")) {
+        module.output[0].data.code = `${expoEnvCode};var __EXPO_ENV_PRELUDE_LINES__=${module.output[0].data.lineCount};`;
+      }
     }
     return origProcessModuleFilter(module);
   };

--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -41,16 +41,14 @@ function adaptMetroConfig(config) {
         module.output[0].data.code = `${preludeCode};var __REACT_DEVTOOLS_PORT__=${process.env.RCT_DEVTOOLS_PORT};`;
       }
     } else if (module.path === "__env__") {
-      // this handles @expo/env plugin, which is used to inject environment variables
-      // the code below instantiates a global variable __EXPO_ENV_PRELUDE_LINES__ that stores
-      // the number of lines in the prelude. This is used to calculate the line number offset
-      // when reporting line numbers from the JS runtime. The reason why this is needed, is that
+      // this handles @expo/env plugin, which is used to expose the number of lines in the prelude. 
+      // This is used to calculate the line number offset when reporting line numbers for 
+      // console.logs, breakpoints and uncaught exceptions. The reason why this is needed, is that
       // metro doesn't include __env__ prelude in the source map resulting in the source map
       // transformation getting shifted by the number of lines in the prelude.
-      const expoEnvCode = module.output[0].data.code;
-      if (!expoEnvCode.includes("__EXPO_ENV_PRELUDE_LINES__")) {
-        module.output[0].data.code = `${expoEnvCode};var __EXPO_ENV_PRELUDE_LINES__=${module.output[0].data.lineCount};`;
-      }
+      const expoEnvPreludeLines = module.output[0].data.lineCount;
+      process.stdout.write(JSON.stringify({ type: "RNIDE_Expo_Env_Prelude_Lines", expoEnvPreludeLines }));
+      process.stdout.write("\n");      
     }
     return origProcessModuleFilter(module);
   };

--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -48,7 +48,12 @@ function adaptMetroConfig(config) {
       // and uncaught exceptions. The reason why this is needed, is that
       // metro doesn't include __env__ prelude in the source map resulting in the source map
       // transformation getting shifted by the number of lines in the expo generated prelude.
-      process.stdout.write(JSON.stringify({ type: "RNIDE_expo_env_prelude_lines", lineOffset: module.output[0].data.lineCount }));
+      process.stdout.write(
+        JSON.stringify({
+          type: "RNIDE_expo_env_prelude_lines",
+          lineCount: module.output[0].data.lineCount,
+        })
+      );
       process.stdout.write("\n");
     }
     return origProcessModuleFilter(module);

--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -42,16 +42,14 @@ function adaptMetroConfig(config) {
       }
     } else if (module.path === "__env__") {
       // this handles @expo/env plugin, which is used to inject environment variables
-      // the code below instantiates a global variable __EXPO_ENV_PRELUDE_LINES__ that stores
-      // the number of lines in the prelude. This is used to calculate the line number offset
+      // the code below exposes the number of lines in the prelude.
+      // This is used to calculate the line number offset
       // when reporting line numbers from the JS runtime, breakpoints
       // and uncaught exceptions. The reason why this is needed, is that
       // metro doesn't include __env__ prelude in the source map resulting in the source map
-      // transformation getting shifted by the number of lines in the prelude.
-      const expoEnvCode = module.output[0].data.code;
-      if (!expoEnvCode.includes("__EXPO_ENV_PRELUDE_LINES__")) {
-        module.output[0].data.code = `${expoEnvCode};var __EXPO_ENV_PRELUDE_LINES__=${module.output[0].data.lineCount};`;
-      }
+      // transformation getting shifted by the number of lines in the expo generated prelude.
+      process.stdout.write(JSON.stringify({ type: "RNIDE_expo_env_prelude_lines", lineOffset: module.output[0].data.lineCount }));
+      process.stdout.write("\n");
     }
     return origProcessModuleFilter(module);
   };

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -25,8 +25,7 @@ function wrapConsole(consoleFunc) {
     const stack = parseErrorStack(new Error().stack);
     const expoLogIndex = stack.findIndex((frame) => frame.methodName === "__expoConsoleLog");
     const location = expoLogIndex > 0 ? stack[expoLogIndex + 1] : stack[1];
-    const lineOffset = global.__EXPO_ENV_PRELUDE_LINES__ || 0;
-    args.push(lineOffset, location.file, location.lineNumber, location.column);
+    args.push(location.file, location.lineNumber, location.column);
     return consoleFunc.apply(console, args);
   };
 }

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -26,7 +26,7 @@ function wrapConsole(consoleFunc) {
     const expoLogIndex = stack.findIndex((frame) => frame.methodName === "__expoConsoleLog");
     const location = expoLogIndex > 0 ? stack[expoLogIndex + 1] : stack[1];
     const lineOffset = global.__EXPO_ENV_PRELUDE_LINES__ || 0;
-    args.push(location.file, location.lineNumber - lineOffset, location.column);
+    args.push(lineOffset, location.file, location.lineNumber, location.column);
     return consoleFunc.apply(console, args);
   };
 }

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -143,7 +143,7 @@ export async function buildAndroid(
     ),
   ];
   // configureReactNativeOverrides init script is only necessary for RN versions older then 0.74.0 see comments in configureReactNativeOverrides.gradle for more details
-  if (semver.lt(await getReactNativeVersion(), "0.74.0")) {
+  if (semver.lt(getReactNativeVersion(), "0.74.0")) {
     gradleArgs.push(
       "--init-script", // configureReactNativeOverrides init script is used to patch React Android project, see comments in configureReactNativeOverrides.gradle for more details
       path.join(

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -164,7 +164,12 @@ export class DebugAdapter extends DebugSession {
             // more over offset should only be applied to the main bundle sourcemap as other files
             // (generated during reload) do not contain the prelude causing the issue
             const shouldApplyOffset = semver.lte(getReactNativeVersion(), "0.76.0");
-            Logger.debug("Expo prelude lines were detected and an offset was set to:", lineOffset);
+            if (lineOffset && shouldApplyOffset) {
+              Logger.debug(
+                "Expo prelude lines were detected and an offset was set to:",
+                lineOffset
+              );
+            }
 
             this.sourceMaps.push([
               message.params.url,

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -154,12 +154,13 @@ export class DebugAdapter extends DebugSession {
             const sourceMap = JSON.parse(decodedData);
             const consumer = await new SourceMapConsumer(sourceMap);
 
-            // This line is here because of a problem with sourcemaps for expo projects that was addressed in
-            // this PR https://github.com/expo/expo/pull/29463, unfortunately it still requires changes to
-            // metro that were attempted here https://github.com/facebook/metro/pull/1284 we should monitor
-            // the situation in upcoming versions and if the changes are still not added bump the version below.
-            // more over offset should only be applied to the main bundle sourcemap as other files (generated during reload)
-            // do not contain the prelude causing the issue
+            // This line is here because of a problem with sourcemaps for expo projects,
+            // that was addressed in this PR https://github.com/expo/expo/pull/29463,
+            // unfortunately it still requires changes to metro that were attempted here
+            // https://github.com/facebook/metro/pull/1284 we should monitor the situation
+            // in upcoming versions and if the changes are still not added bump the version below.
+            // more over offset should only be applied to the main bundle sourcemap as other files
+            // (generated during reload) do not contain the prelude causing the issue
             const shouldApplyOffset =
               semver.lte(getReactNativeVersion(), "0.76.0") && this.sourceMaps.length === 0;
             this.sourceMaps.push([

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -161,8 +161,6 @@ export class DebugAdapter extends DebugSession {
             // unfortunately it still requires changes to metro that were attempted here
             // https://github.com/facebook/metro/pull/1284 we should monitor the situation
             // in upcoming versions and if the changes are still not added bump the version below.
-            // more over offset should only be applied to the main bundle sourcemap as other files
-            // (generated during reload) do not contain the prelude causing the issue
             const shouldApplyOffset = semver.lte(getReactNativeVersion(), "0.76.0");
             if (lineOffset && shouldApplyOffset) {
               Logger.debug(

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -154,8 +154,8 @@ export class DebugAdapter extends DebugSession {
             const sourceMap = JSON.parse(decodedData);
             const consumer = await new SourceMapConsumer(sourceMap);
 
-            // This is a heuristic that checks if the source map should contain __env__
-            // module that is added by expo, but not reported in the source map
+            // We detect when a source map for the entire bundle is loaded by checking
+            // if __env__ module is present in the sources.
             const isFileWithOffset = sourceMap.sources.includes("__prelude__");
 
             // When using expo <${PUT_VERSION_HERE}, source maps skip the prelude module which is 

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -163,8 +163,7 @@ export class DebugAdapter extends DebugSession {
             // in upcoming versions and if the changes are still not added bump the version below.
             // more over offset should only be applied to the main bundle sourcemap as other files
             // (generated during reload) do not contain the prelude causing the issue
-            const shouldApplyOffset =
-              semver.lte(getReactNativeVersion(), "0.76.0") && this.sourceMaps.length === 0;
+            const shouldApplyOffset = semver.lte(getReactNativeVersion(), "0.76.0");
             Logger.debug("Expo prelude lines were detected and an offset was set to:", lineOffset);
 
             this.sourceMaps.push([

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -158,11 +158,11 @@ export class DebugAdapter extends DebugSession {
             // module that is added by expo, but not reported in the source map
             const isFileWithOffset = sourceMap.sources.includes("__prelude__");
 
-            // This line is here because of a problem with sourcemaps for expo projects,
-            // that was addressed in this PR https://github.com/expo/expo/pull/29463,
-            // unfortunately it still requires changes to metro that were attempted here
-            // https://github.com/facebook/metro/pull/1284 we should monitor the situation
-            // in upcoming versions and if the changes are still not added bump the version below.
+            // When using expo <${PUT_VERSION_HERE}, source maps skip the prelude module which is 
+            // included in the main bundle at the start. As a result, all lines in the main bundle are shifted by
+            // the amount of lines the prelude file adds. To offset this, we use the lineOffset parameter that we pass
+            // to the source maps list that is used later on to correct line numbers when translating from generated
+            // to the original positions.
             const shouldApplyOffset =
               semver.lte(getReactNativeVersion(), "0.76.0") && isFileWithOffset;
             if (this.lineOffset !== 0 && shouldApplyOffset) {

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -163,7 +163,7 @@ export class DebugAdapter extends DebugSession {
             // expoPreludeLineCount which reflects the number of lines in __env__ module to offset the line numbers in the source map.
             const bundleContainsExpoPrelude = sourceMap.sources.includes("__env__");
             let lineOffset = 0;
-            if (isMainBundle && !bundleContainsExpoPrelude) {
+            if (isMainBundle && !bundleContainsExpoPrelude && this.expoPreludeLineCount > 0) {
               Logger.debug(
                 "Expo prelude lines were detected and an offset was set to:",
                 this.expoPreludeLineCount

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -56,6 +56,7 @@ export class DebugSession implements Disposable {
         websocketAddress: websocketAddress,
         absoluteProjectPath: getAppRootFolder(),
         projectPathAlias: this.metro.isUsingNewDebugger ? "/[metro-project]" : undefined,
+        lineOffset: this.metro.initialBundleLineOffset,
       },
       {
         suppressDebugStatusbar: true,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -56,7 +56,6 @@ export class DebugSession implements Disposable {
         websocketAddress: websocketAddress,
         absoluteProjectPath: getAppRootFolder(),
         projectPathAlias: this.metro.isUsingNewDebugger ? "/[metro-project]" : undefined,
-        lineOffset: this.metro.initialBundleLineOffset,
       },
       {
         suppressDebugStatusbar: true,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -56,7 +56,7 @@ export class DebugSession implements Disposable {
         websocketAddress: websocketAddress,
         absoluteProjectPath: getAppRootFolder(),
         projectPathAlias: this.metro.isUsingNewDebugger ? "/[metro-project]" : undefined,
-        lineOffset: this.metro.expoPreludeLineOffset,
+        expoPreludeLineCount: this.metro.expoPreludeLineCount,
       },
       {
         suppressDebugStatusbar: true,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -56,6 +56,7 @@ export class DebugSession implements Disposable {
         websocketAddress: websocketAddress,
         absoluteProjectPath: getAppRootFolder(),
         projectPathAlias: this.metro.isUsingNewDebugger ? "/[metro-project]" : undefined,
+        lineOffset: this.metro.expoPreludeLineOffset,
       },
       {
         suppressDebugStatusbar: true,

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -46,7 +46,7 @@ type MetroEvent =
       transformedFileCount: number;
       totalFileCount: number;
     }
-  | { type: "RNIDE_expo_env_prelude_lines"; lineOffset: number }
+  | { type: "RNIDE_expo_env_prelude_lines"; lineCount: number }
   | {
       type: "RNIDE_initialize_done";
       port: number;
@@ -67,7 +67,7 @@ export class Metro implements Disposable {
   private _port = 0;
   private startPromise: Promise<void> | undefined;
   private usesNewDebugger?: Boolean;
-  private _expoPreludeLineOffset: number = 0;
+  private _expoPreludeLineCount = 0;
 
   constructor(private readonly devtools: Devtools, private readonly delegate: MetroDelegate) {}
 
@@ -82,8 +82,8 @@ export class Metro implements Disposable {
     return this._port;
   }
 
-  public get expoPreludeLineOffset() {
-    return this._expoPreludeLineOffset;
+  public get expoPreludeLineCount() {
+    return this._expoPreludeLineCount;
   }
 
   public dispose() {
@@ -214,8 +214,8 @@ export class Metro implements Disposable {
 
           switch (event.type) {
             case "RNIDE_expo_env_prelude_lines":
-              this._expoPreludeLineOffset = event.lineOffset;
-              Logger.debug("Expo prelude line offset was set to: ", this._expoPreludeLineOffset);
+              this._expoPreludeLineCount = event.lineCount;
+              Logger.debug("Expo prelude line offset was set to: ", this._expoPreludeLineCount);
               break;
             case "RNIDE_initialize_done":
               this._port = event.port;

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -46,6 +46,7 @@ type MetroEvent =
       transformedFileCount: number;
       totalFileCount: number;
     }
+  | { type: "RNIDE_expo_env_prelude_lines"; lineOffset: number }
   | {
       type: "RNIDE_initialize_done";
       port: number;
@@ -66,6 +67,7 @@ export class Metro implements Disposable {
   private _port = 0;
   private startPromise: Promise<void> | undefined;
   private usesNewDebugger?: Boolean;
+  private _expoPreludeLineOffset: number = 0;
 
   constructor(private readonly devtools: Devtools, private readonly delegate: MetroDelegate) {}
 
@@ -78,6 +80,10 @@ export class Metro implements Disposable {
 
   public get port() {
     return this._port;
+  }
+
+  public get expoPreludeLineOffset() {
+    return this._expoPreludeLineOffset;
   }
 
   public dispose() {
@@ -207,6 +213,10 @@ export class Metro implements Disposable {
           }
 
           switch (event.type) {
+            case "RNIDE_expo_env_prelude_lines":
+              this._expoPreludeLineOffset = event.lineOffset;
+              Logger.debug("Expo prelude line offset was set to: ", this._expoPreludeLineOffset);
+              break;
             case "RNIDE_initialize_done":
               this._port = event.port;
               Logger.info(`Metro started on port ${this._port}`);

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -47,10 +47,6 @@ type MetroEvent =
       totalFileCount: number;
     }
   | {
-      type: "RNIDE_Expo_Env_Prelude_Lines";
-      expoEnvPreludeLines: number;
-    }
-  | {
       type: "RNIDE_initialize_done";
       port: number;
     }
@@ -68,7 +64,6 @@ type MetroEvent =
 export class Metro implements Disposable {
   private subprocess?: ChildProcess;
   private _port = 0;
-  private _initialBundleLineOffset = 0;
   private startPromise: Promise<void> | undefined;
   private usesNewDebugger?: Boolean;
 
@@ -83,10 +78,6 @@ export class Metro implements Disposable {
 
   public get port() {
     return this._port;
-  }
-
-  public get initialBundleLineOffset() {
-    return this._initialBundleLineOffset;
   }
 
   public dispose() {
@@ -216,12 +207,6 @@ export class Metro implements Disposable {
           }
 
           switch (event.type) {
-            case "RNIDE_Expo_Env_Prelude_Lines":
-              this._initialBundleLineOffset = event.expoEnvPreludeLines;
-              Logger.debug(
-                `Metro initial bundle offset is set to ${this._initialBundleLineOffset}`
-              );
-              break;
             case "RNIDE_initialize_done":
               this._port = event.port;
               Logger.info(`Metro started on port ${this._port}`);

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -47,6 +47,10 @@ type MetroEvent =
       totalFileCount: number;
     }
   | {
+      type: "RNIDE_Expo_Env_Prelude_Lines";
+      expoEnvPreludeLines: number;
+    }
+  | {
       type: "RNIDE_initialize_done";
       port: number;
     }
@@ -64,6 +68,7 @@ type MetroEvent =
 export class Metro implements Disposable {
   private subprocess?: ChildProcess;
   private _port = 0;
+  private _initialBundleLineOffset = 0;
   private startPromise: Promise<void> | undefined;
   private usesNewDebugger?: Boolean;
 
@@ -78,6 +83,10 @@ export class Metro implements Disposable {
 
   public get port() {
     return this._port;
+  }
+
+  public get initialBundleLineOffset() {
+    return this._initialBundleLineOffset;
   }
 
   public dispose() {
@@ -207,6 +216,12 @@ export class Metro implements Disposable {
           }
 
           switch (event.type) {
+            case "RNIDE_Expo_Env_Prelude_Lines":
+              this._initialBundleLineOffset = event.expoEnvPreludeLines;
+              Logger.debug(
+                `Metro initial bundle offset is set to ${this._initialBundleLineOffset}`
+              );
+              break;
             case "RNIDE_initialize_done":
               this._port = event.port;
               Logger.info(`Metro started on port ${this._port}`);

--- a/packages/vscode-extension/src/utilities/reactNative.ts
+++ b/packages/vscode-extension/src/utilities/reactNative.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { getAppRootFolder } from "./extensionContext";
 
-export async function getReactNativeVersion() {
+export function getReactNativeVersion() {
   const workspacePath = getAppRootFolder();
   const reactNativeRoot = path.dirname(require.resolve("react-native", { paths: [workspacePath] }));
   const packageJsonPath = path.join(reactNativeRoot, "package.json");


### PR DESCRIPTION
This PR fixes a problem with debugger on expo projects, caused by prelude lines added to the entry bundle file added by expo. The solution is t0 add the required offset to the prelude causing the problem and scanning for it when receiving source map in the debuger.

It is possible that the changes will no longer be needed in future versions of react native as the expo team tries to correct source map generation to include extra lines, for more information read those PRs:
- [expo side ](https://github.com/expo/expo/pull/29463)
- [metro side](https://github.com/facebook/metro/pull/1284)

This is why we add version check before adding lineOffset to initial source map.

### How Has This Been Tested: 
- open expo project and set a breakpoint, before the changes it would trigger 2 lines above the place it's been set. 
- save any change in the file containing breakpoint and make sure it still works.
- check if links to files generated next to console logs are pointing in to the correct place, again both before and after making changes to the file.
- check if error position indicator (when uncaught exception  is raised) points to the correct position. 


### Additional changes: 
This PR also fixes a minor mistake with `getReactNativeVersion` utility that does not need to be async and as it is used, we make it synchronous as part of this PR.


