### PR TITLE
Fix Inspector right click 

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -1,6 +1,5 @@
-import * as ContextMenu from "@radix-ui/react-context-menu";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { InspectDataStackItem } from "../../common/Project";
-import { useEffect, useRef } from "react";
 
 import "./InspectDataMenu.css";
 
@@ -19,43 +18,37 @@ export function InspectDataMenu({
   onHover: OnSelectedCallback;
   onCancel: () => void;
 }) {
-  const triggerRef = useRef<HTMLDivElement>(null);
   const filteredData = inspectStack.filter((item) => !item.hide);
 
-  useEffect(() => {
-    const event = new MouseEvent("contextmenu", {
-      bubbles: true,
-      cancelable: true,
-      clientX: inspectLocation.x, // X position
-      clientY: inspectLocation.y, // Y position
-    });
-
-    triggerRef.current?.dispatchEvent(event);
-  }, []);
-
   return (
-    <ContextMenu.Root
-      onOpenChange={(open) => {
-        if (!open) onCancel();
-      }}>
-      <ContextMenu.Trigger ref={triggerRef} />
-      <ContextMenu.Portal>
-        <ContextMenu.Content className="context-menu-content">
-          {filteredData.map((item) => {
-            // extract file name from path:
-            const fileName = item.source.fileName.split("/").pop();
-            return (
-              <ContextMenu.Item
-                className="context-menu-item"
-                onSelect={() => onSelected(item)}
-                onMouseEnter={() => onHover(item)}>
-                <code>{`<${item.componentName}>`}</code>
-                <div className="right-slot">{`${fileName}:${item.source.line0Based + 1}`}</div>
-              </ContextMenu.Item>
-            );
-          })}
-        </ContextMenu.Content>
-      </ContextMenu.Portal>
-    </ContextMenu.Root>
+    <div style={{ right: inspectLocation.x, top: inspectLocation.y, position: "absolute" }}>
+      <DropdownMenu.Root
+        defaultOpen={true}
+        open={true}
+        onOpenChange={(open) => {
+          if (!open) onCancel();
+        }}>
+        {" "}
+        1
+        <DropdownMenu.Trigger />
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content className="context-menu-content">
+            {filteredData.map((item) => {
+              // extract file name from path:
+              const fileName = item.source.fileName.split("/").pop();
+              return (
+                <DropdownMenu.Item
+                  className="context-menu-item"
+                  onSelect={() => onSelected(item)}
+                  onMouseEnter={() => onHover(item)}>
+                  <code>{`<${item.componentName}>`}</code>
+                  <div className="right-slot">{`${fileName}:${item.source.line0Based + 1}`}</div>
+                </DropdownMenu.Item>
+              );
+            })}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
   );
 }


### PR DESCRIPTION
This PR fixes the behavior of right click when using inspector tool, it removes the old `ContexMenu` in favor of `DropdownMenu`, which is more appropriate as it does not require `contextmenu` event to be activated, which since #608  is disabled. 

### How Has This Been Tested: 

- run any test application and use right click to inspect a component
- use inspector button and right click while it is active


