### PR TITLE
Adjust Progress Processorss

### DIFF
--- a/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
@@ -10,6 +10,8 @@ export class BuildAndroidProgressProcessor implements BuildProgressProcessor {
     if (!this.tasksToComplete) {
       return;
     }
+    // the 0.999 max value is here to prevent situations in which users see 100% indiction,
+    // but the build process is still takeing a couple more seconds.
     this.progressListener(Math.min(0.999, this.completedTasks / this.tasksToComplete));
   }
 

--- a/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildAndroidProgressProcessor.ts
@@ -10,7 +10,7 @@ export class BuildAndroidProgressProcessor implements BuildProgressProcessor {
     if (!this.tasksToComplete) {
       return;
     }
-    this.progressListener(Math.min(1, this.completedTasks / this.tasksToComplete));
+    this.progressListener(Math.min(0.999, this.completedTasks / this.tasksToComplete));
   }
 
   processLine(line: string): void {

--- a/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
@@ -65,7 +65,7 @@ export class BuildIOSProgressProcessor implements BuildProgressProcessor {
     if (!this.tasksToComplete) {
       return;
     }
-    this.progressListener(Math.min(1, this.completedTasks / this.tasksToComplete));
+    this.progressListener(Math.min(0.999, this.completedTasks / this.tasksToComplete));
   }
 
   async processLine(line: string) {

--- a/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
@@ -65,6 +65,8 @@ export class BuildIOSProgressProcessor implements BuildProgressProcessor {
     if (!this.tasksToComplete) {
       return;
     }
+    // the 0.999 max value is here to prevent situations in which users see 100% indiction,
+    // but the build process is still takeing a couple more seconds.
     this.progressListener(Math.min(0.999, this.completedTasks / this.tasksToComplete));
   }
 


### PR DESCRIPTION
This PR changes the maximum progress for iOS and android build from 1 to 0.999 to avoid situations in which users are send 100% for prolonged  periods of time. 

### How Has This Been Tested: 

- run clean build in any test app



