### PR TITLE
Show unsupported platforms error message

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -17,8 +17,7 @@
   ],
   "version": "0.0.20",
   "engines": {
-    "vscode": "^1.75.0",
-    "os": "darwin"
+    "vscode": "^1.75.0"
   },
   "extensionKind": [
     "workspace"

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -108,7 +108,7 @@ export class DeviceManager implements DeviceManagerInterface {
 
     let shouldLoadSimulators = Platform.OS === "macos";
 
-    if (!(await checkXcodeExists())) {
+    if (shouldLoadSimulators && !(await checkXcodeExists())) {
       shouldLoadSimulators = false;
       Logger.debug("Couldn't list iOS simulators as XCode installation wasn't found");
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -63,6 +63,11 @@ export function deactivate(context: ExtensionContext): undefined {
 export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
 
+  if (Platform.OS !== "macos" && Platform.OS !== "windows") {
+    window.showErrorMessage("Radon IDE works only on macOS and Windows.", "Dismiss");
+    return;
+  }
+
   setExtensionContext(context);
   if (context.extensionMode === ExtensionMode.Development) {
     enableDevModeLogging();

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -63,11 +63,6 @@ export function deactivate(context: ExtensionContext): undefined {
 export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
 
-  if (Platform.OS !== "macos" && Platform.OS !== "windows") {
-    window.showErrorMessage("Radon IDE works only on macOS and Windows.", "Dismiss");
-    return;
-  }
-
   setExtensionContext(context);
   if (context.extensionMode === ExtensionMode.Development) {
     enableDevModeLogging();

--- a/packages/vscode-extension/src/utilities/platform.ts
+++ b/packages/vscode-extension/src/utilities/platform.ts
@@ -1,7 +1,6 @@
 import os from "os";
-import { window } from "vscode";
 
-const OS: "macos" | "windows" = (() => {
+const OS: "macos" | "windows" | "unsupported" = (() => {
   const platform = os.platform();
   switch (platform) {
     case "darwin":
@@ -9,14 +8,14 @@ const OS: "macos" | "windows" = (() => {
     case "win32":
       return "windows";
     default:
-      window.showErrorMessage("Radon IDE works only on macOS and Windows.", "Dismiss");
-      throw new Error("Unsupported platform");
+      return "unsupported";
   }
 })();
 export const Platform = {
   OS,
   select: <R, T>(obj: { macos: R; windows: T }) => {
-    return obj[Platform.OS];
+    // we assume that the 'unsupported' OS type will never occur here
+    return Platform.OS !== "unsupported" ? obj[Platform.OS] : obj["macos"];
   },
 };
 

--- a/packages/vscode-extension/src/utilities/platform.ts
+++ b/packages/vscode-extension/src/utilities/platform.ts
@@ -1,4 +1,5 @@
 import os from "os";
+import { window } from "vscode";
 
 const OS: "macos" | "windows" = (() => {
   const platform = os.platform();
@@ -8,6 +9,7 @@ const OS: "macos" | "windows" = (() => {
     case "win32":
       return "windows";
     default:
+      window.showErrorMessage("Radon IDE works only on macOS and Windows.", "Dismiss");
       throw new Error("Unsupported platform");
   }
 })();


### PR DESCRIPTION
This PR fixes fixes issue where error messages for unsupported platforms were not displayed and prevents Xcode errors from appearing on Windows by ensuring the checkXcodeExists function is only executed on macOS.

Previously, an error related to the OS const in `platform.ts` was always thrown before the check in `extension.ts`. This change ensures the verification process happens correctly.

Fixes #620 

### How Has This Been Tested: 
- run extension on currently unsupported platform (linux)
- run extension and check the logs for any errors caused by xcrun on Windows

![image](https://github.com/user-attachments/assets/e509d0c1-ea0d-41da-bd01-3bee60c44989)
