### PR TITLE
Correct positioning of InspectDataMenu

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -85,14 +85,19 @@ export type InspectDataStackItem = {
   frame: Frame;
 };
 
-export type TouchPoint = {
-  xRatio: number;
-  yRatio: number;
+export type InspectStackData = {
+  requestLocation: { x: number; y: number };
+  stack: InspectDataStackItem[];
 };
 
 export type InspectData = {
   stack: InspectDataStackItem[] | undefined;
   frame: Frame;
+};
+
+export type TouchPoint = {
+  xRatio: number;
+  yRatio: number;
 };
 
 export interface ProjectEventMap {

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.css
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.css
@@ -1,4 +1,4 @@
-.context-menu-content {
+.dropdown-menu-content {
   min-width: 50px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;
@@ -10,21 +10,21 @@
   max-width: calc(var(--radix-dropdown-menu-content-available-width) - 10px);
 }
 
-.context-menu-content code {
+.dropdown-menu-content code {
   font-family: monospace;
   font-size: clamp(5px, 5vw, 12px);
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.context-menu-label {
+.dropdown-menu-label {
     font-size: 12px;
     line-height: 25px;
     padding-left: 5px;
     color: var(--swm-secondary-text);
   }
 
-.context-menu-item {
+.dropdown-menu-item {
   font-size: clamp(4px, 4vw, 12px);
   line-height: 1;
   color: var(--swm-default-text);
@@ -41,18 +41,18 @@
   margin: 1px 0;
 }
 
-.context-menu-item[data-disabled] {
+.dropdown-menu-item[data-disabled] {
   color: var(--swm-disabled-text);
   pointer-events: none;
 }
 
-.context-menu-item[data-highlighted] {
+.dropdown-menu-item[data-highlighted] {
   background-color: var(--swm-dropdown-item-highlighted);
   color: var(--swm-default-text);
   overflow-wrap: anywhere;
 }
 
-.context-menu-item .right-slot {
+.dropdown-menu-item .right-slot {
   color: var(--swm-device-select-rich-item-subtitle);
   font-size: 90%;
   margin-left: auto;

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.css
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.css
@@ -17,6 +17,13 @@
   text-overflow: ellipsis;
 }
 
+.context-menu-label {
+    font-size: 12px;
+    line-height: 25px;
+    padding-left: 5px;
+    color: var(--swm-secondary-text);
+  }
+
 .context-menu-item {
   font-size: clamp(4px, 4vw, 12px);
   line-height: 1;

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -33,12 +33,13 @@ export function InspectDataMenu({
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
           <DropdownMenu.Content className="context-menu-content">
-            {filteredData.map((item) => {
+            {filteredData.map((item, index) => {
               // extract file name from path:
               const fileName = item.source.fileName.split("/").pop();
               return (
                 <DropdownMenu.Item
                   className="context-menu-item"
+                  key={index}
                   onSelect={() => onSelected(item)}
                   onMouseEnter={() => onHover(item)}>
                   <code>{`<${item.componentName}>`}</code>

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -1,23 +1,36 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { InspectDataStackItem } from "../../common/Project";
-
+import { Frame, InspectDataStackItem } from "../../common/Project";
+import { DeviceProperties } from "../utilities/consts";
 import "./InspectDataMenu.css";
 
 type OnSelectedCallback = (item: InspectDataStackItem) => void;
 
-export function InspectDataMenu({
-  inspectLocation,
-  inspectStack,
-  onSelected,
-  onHover,
-  onCancel,
-}: {
+type InspectDataMenuProps = {
   inspectLocation: { x: number; y: number };
   inspectStack: InspectDataStackItem[];
+  device?: DeviceProperties;
+  frame: Frame | null;
   onSelected: OnSelectedCallback;
   onHover: OnSelectedCallback;
   onCancel: () => void;
-}) {
+};
+
+export function InspectDataMenu({
+  inspectLocation,
+  inspectStack,
+  device,
+  frame,
+  onSelected,
+  onHover,
+  onCancel,
+}: InspectDataMenuProps) {
+  const displayDimensions = device && frame;
+  let topComponentWidth, topComponentHeight;
+  if (displayDimensions) {
+    topComponentWidth = parseFloat((frame.width * device.screenWidth).toFixed(2));
+    topComponentHeight = parseFloat((frame.height * device.screenHeight).toFixed(2));
+  }
+
   const filteredData = inspectStack.filter((item) => !item.hide);
 
   return (
@@ -33,6 +46,11 @@ export function InspectDataMenu({
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
           <DropdownMenu.Content className="context-menu-content">
+            {displayDimensions && (
+              <DropdownMenu.Label>
+                Dimensions: {topComponentWidth} × {topComponentHeight}
+              </DropdownMenu.Label>
+            )}
             {filteredData.map((item, index) => {
               // extract file name from path:
               const fileName = item.source.fileName.split("/").pop();

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -24,12 +24,17 @@ export function InspectDataMenu({
   onHover,
   onCancel,
 }: InspectDataMenuProps) {
-  const displayDimensions = device && frame;
-  let topComponentWidth, topComponentHeight;
-  if (displayDimensions) {
-    topComponentWidth = parseFloat((frame.width * device.screenWidth).toFixed(2));
-    topComponentHeight = parseFloat((frame.height * device.screenHeight).toFixed(2));
-  }
+  const displayDimensionsText = (() => {
+    if (device && frame) {
+      const topComponentWidth = parseFloat((frame.width * device.screenWidth).toFixed(2));
+      const topComponentHeight = parseFloat((frame.height * device.screenHeight).toFixed(2));
+
+      if (topComponentWidth && topComponentHeight) {
+        return `Dimensions: ${topComponentWidth} × ${topComponentHeight}`;
+      }
+    }
+    return "Dimensions: -";
+  })();
 
   const filteredData = inspectStack.filter((item) => !item.hide);
 
@@ -46,11 +51,9 @@ export function InspectDataMenu({
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
           <DropdownMenu.Content className="context-menu-content">
-            {displayDimensions && (
-              <DropdownMenu.Label>
-                Dimensions: {topComponentWidth} × {topComponentHeight}
-              </DropdownMenu.Label>
-            )}
+            <DropdownMenu.Label className="context-menu-label">
+              {displayDimensionsText}
+            </DropdownMenu.Label>
             {filteredData.map((item, index) => {
               // extract file name from path:
               const fileName = item.source.fileName.split("/").pop();

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -21,7 +21,7 @@ export function InspectDataMenu({
   const filteredData = inspectStack.filter((item) => !item.hide);
 
   return (
-    <div style={{ right: inspectLocation.x, top: inspectLocation.y, position: "absolute" }}>
+    <div style={{ left: inspectLocation.x, top: inspectLocation.y, position: "absolute" }}>
       <DropdownMenu.Root
         defaultOpen={true}
         open={true}

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -26,10 +26,10 @@ export function InspectDataMenu({
         defaultOpen={true}
         open={true}
         onOpenChange={(open) => {
-          if (!open) onCancel();
+          if (!open) {
+            onCancel();
+          }
         }}>
-        {" "}
-        1
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
           <DropdownMenu.Content className="context-menu-content">

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -50,8 +50,8 @@ export function InspectDataMenu({
         }}>
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
-          <DropdownMenu.Content className="context-menu-content">
-            <DropdownMenu.Label className="context-menu-label">
+          <DropdownMenu.Content className="dropdown-menu-content">
+            <DropdownMenu.Label className="dropdown-menu-label">
               {displayDimensionsText}
             </DropdownMenu.Label>
             {filteredData.map((item, index) => {
@@ -59,7 +59,7 @@ export function InspectDataMenu({
               const fileName = item.source.fileName.split("/").pop();
               return (
                 <DropdownMenu.Item
-                  className="context-menu-item"
+                  className="dropdown-menu-item"
                   key={index}
                   onSelect={() => onSelected(item)}
                   onMouseEnter={() => onHover(item)}>

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -578,7 +578,7 @@ function Preview({
                   </div>
                 )}
 
-                {inspectFrame && (
+                {!replayData && inspectFrame && (
                   <div className="phone-screen phone-inspect-overlay">
                     <div
                       className="inspect-area"
@@ -638,7 +638,7 @@ function Preview({
                 )}
               </div>
               <DeviceFrame device={device} isFrameDisabled={isFrameDisabled} />
-              {inspectStackData && (
+              {!replayData && inspectStackData && (
                 <InspectDataMenu
                   inspectLocation={inspectStackData.requestLocation}
                   inspectStack={inspectStackData.stack}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -94,9 +94,9 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
           } catch {
             // Stream connection was dropped
             if (!cancelled) {
-              const src = img.src;
+              const tempSrc = img.src;
               img.src = NO_IMAGE_DATA;
-              img.src = src;
+              img.src = tempSrc;
             }
           }
         }

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -14,12 +14,17 @@ import PreviewLoader from "./PreviewLoader";
 import { useBuildErrorAlert, useBundleErrorAlert } from "../hooks/useBuildErrorAlert";
 import Debugger from "./Debugger";
 import { useNativeRebuildAlert } from "../hooks/useNativeRebuildAlert";
-import { Frame, InspectDataStackItem, RecordingData, ZoomLevelType } from "../../common/Project";
-import { InspectDataMenu } from "./InspectDataMenu";
+import {
+  Frame,
+  InspectDataStackItem,
+  RecordingData,
+  ZoomLevelType,
+  InspectStackData,
+} from "../../common/Project";
 import { useResizableProps } from "../hooks/useResizableProps";
 import ZoomControls from "./ZoomControls";
 import { throttle } from "../../utilities/throttle";
-import { Platform, useUtils } from "../providers/UtilsProvider";
+import { Platform } from "../providers/UtilsProvider";
 import { useWorkspaceConfig } from "../providers/WorkspaceConfigProvider";
 import DimensionsBox from "./DimensionsBox";
 import ReplayUI from "./ReplayUI";
@@ -172,14 +177,12 @@ function ButtonGroupLeft({ children }: ButtonGroupLeftProps) {
   );
 }
 
-type InspectStackData = {
-  requestLocation: { x: number; y: number };
-  stack: InspectDataStackItem[];
-};
-
 type Props = {
   isInspecting: boolean;
-  setIsInspecting: (isInspecting: boolean) => void;
+  inspectFrame: Frame | null;
+  setInspectFrame: (inspectFrame: Frame | null) => void;
+  setInspectStackData: (inspectStackData: InspectStackData | null) => void;
+  onInspectorItemSelected: (item: InspectDataStackItem) => void;
   isPressing: boolean;
   setIsPressing: (isPressing: boolean) => void;
   zoomLevel: ZoomLevelType;
@@ -205,7 +208,10 @@ function calculateMirroredTouchPosition(touchPoint: Point, anchorPoint: Point) {
 
 function Preview({
   isInspecting,
-  setIsInspecting,
+  inspectFrame,
+  setInspectFrame,
+  setInspectStackData,
+  onInspectorItemSelected,
   isPressing,
   setIsPressing,
   zoomLevel,
@@ -222,8 +228,7 @@ function Preview({
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
 
   const workspace = useWorkspaceConfig();
-  const { projectState, project, deviceSettings } = useProject();
-  const { openFileAt } = useUtils();
+  const { projectState, project } = useProject();
 
   const isFrameDisabled = workspace.showDeviceFrame === false;
 
@@ -249,9 +254,6 @@ function Preview({
   useBundleErrorAlert(hasBundleError || hasIncrementalBundleError);
 
   const openRebuildAlert = useNativeRebuildAlert();
-
-  const [inspectFrame, setInspectFrame] = useState<Frame | null>(null);
-  const [inspectStackData, setInspectStackData] = useState<InspectStackData | null>(null);
 
   function getTouchPosition(event: MouseEvent<HTMLDivElement>) {
     const imgRect = previewRef.current!.getBoundingClientRect();
@@ -292,11 +294,6 @@ function Preview({
     );
   }
 
-  function onInspectorItemSelected(item: InspectDataStackItem) {
-    openFileAt(item.source.fileName, item.source.line0Based, item.source.column0Based);
-    setIsInspecting(false);
-  }
-
   function sendInspectUnthrottled(
     event: MouseEvent<HTMLDivElement>,
     type: MouseMove | "Leave" | "RightButtonDown"
@@ -304,11 +301,7 @@ function Preview({
     if (type === "Leave") {
       return;
     }
-    const imgRect = previewRef.current!.getBoundingClientRect();
-    const x = (event.clientX - imgRect.left) / imgRect.width;
-    const y = (event.clientY - imgRect.top) / imgRect.height;
-    const clampedX = clamp(x, 0, 1);
-    const clampedY = clamp(y, 0, 1);
+    const { x: clampedX, y: clampedY } = getTouchPosition(event);
     const requestStack = type === "Down" || type === "RightButtonDown";
     const showInspectStackModal = type === "RightButtonDown";
     project.inspectElementAt(clampedX, clampedY, requestStack, (inspectData) => {
@@ -638,19 +631,6 @@ function Preview({
                 )}
               </div>
               <DeviceFrame device={device} isFrameDisabled={isFrameDisabled} />
-              {!replayData && inspectStackData && (
-                <InspectDataMenu
-                  inspectLocation={inspectStackData.requestLocation}
-                  inspectStack={inspectStackData.stack}
-                  onSelected={onInspectorItemSelected}
-                  onHover={(item) => {
-                    if (item.frame) {
-                      setInspectFrame(item.frame);
-                    }
-                  }}
-                  onCancel={() => resetInspector()}
-                />
-              )}
             </div>
           </Resizable>
         )}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -582,11 +582,13 @@ function Preview({
                         height: `${inspectFrame.height * 100}%`,
                       }}
                     />
-                    <DimensionsBox
-                      device={device}
-                      frame={inspectFrame}
-                      wrapperDivRef={wrapperDivRef}
-                    />
+                    {isInspecting && (
+                      <DimensionsBox
+                        device={device}
+                        frame={inspectFrame}
+                        wrapperDivRef={wrapperDivRef}
+                      />
+                    )}
                   </div>
                 )}
                 {projectStatus === "refreshing" && (

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -25,6 +25,7 @@ import {
   InspectStackData,
 } from "../../common/Project";
 import { useUtils } from "../providers/UtilsProvider";
+import { AndroidSupportedDevices, iOSSupportedDevices } from "../utilities/consts";
 
 type LoadingComponentProps = {
   finishedInitialLoad: boolean;
@@ -70,6 +71,10 @@ function PreviewView() {
   const selectedDevice = projectState?.selectedDevice;
   const devicesNotFound = projectState !== undefined && devices.length === 0;
   const isStarting = projectState.status === "starting";
+
+  const deviceProperties = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
+    return sd.modelName === projectState?.selectedDevice?.name;
+  });
 
   const { openModal } = useModal();
   const { openFileAt } = useUtils();
@@ -225,6 +230,8 @@ function PreviewView() {
         <InspectDataMenu
           inspectLocation={inspectStackData.requestLocation}
           inspectStack={inspectStackData.stack}
+          device={deviceProperties}
+          frame={inspectFrame}
           onSelected={onInspectorItemSelected}
           onHover={(item) => {
             if (item.frame) {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, MouseEvent } from "react";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import { vscode } from "../utilities/vscode";
 import Preview from "../components/Preview";
 import IconButton from "../components/shared/IconButton";
@@ -14,9 +15,15 @@ import DeviceSettingsIcon from "../components/icons/DeviceSettingsIcon";
 import { useDevices } from "../providers/DevicesProvider";
 import { useProject } from "../providers/ProjectProvider";
 import DeviceSelect from "../components/DeviceSelect";
+import { InspectDataMenu } from "../components/InspectDataMenu";
 import Button from "../components/shared/Button";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
-import { RecordingData, ZoomLevelType } from "../../common/Project";
+import {
+  RecordingData,
+  ZoomLevelType,
+  InspectDataStackItem,
+  Frame,
+  InspectStackData,
+} from "../../common/Project";
 import { useUtils } from "../providers/UtilsProvider";
 
 type LoadingComponentProps = {
@@ -44,8 +51,10 @@ function PreviewView() {
   const { projectState, project, deviceSettings } = useProject();
   const { reportIssue, showDismissableError } = useUtils();
 
-  const [isInspecting, setIsInspecting] = useState(false);
   const [isPressing, setIsPressing] = useState(false);
+  const [isInspecting, setIsInspecting] = useState(false);
+  const [inspectFrame, setInspectFrame] = useState<Frame | null>(null);
+  const [inspectStackData, setInspectStackData] = useState<InspectStackData | null>(null);
   const zoomLevel = projectState.previewZoom ?? "Fit";
   const onZoomChanged = useCallback(
     (zoom: ZoomLevelType) => {
@@ -63,6 +72,7 @@ function PreviewView() {
   const isStarting = projectState.status === "starting";
 
   const { openModal } = useModal();
+  const { openFileAt } = useUtils();
 
   const extensionVersion = document.querySelector<HTMLMetaElement>(
     "meta[name='radon-ide-version']"
@@ -119,6 +129,16 @@ function PreviewView() {
       showDismissableError("Failed to capture replay");
     }
   };
+
+  function onInspectorItemSelected(item: InspectDataStackItem) {
+    openFileAt(item.source.fileName, item.source.line0Based, item.source.column0Based);
+    setIsInspecting(false);
+  }
+
+  function resetInspector() {
+    setInspectFrame(null);
+    setInspectStackData(null);
+  }
 
   function onMouseDown(e: MouseEvent<HTMLDivElement>) {
     e.preventDefault();
@@ -183,7 +203,10 @@ function PreviewView() {
         <Preview
           key={selectedDevice.id}
           isInspecting={isInspecting}
-          setIsInspecting={setIsInspecting}
+          inspectFrame={inspectFrame}
+          setInspectFrame={setInspectFrame}
+          setInspectStackData={setInspectStackData}
+          onInspectorItemSelected={onInspectorItemSelected}
           isPressing={isPressing}
           setIsPressing={setIsPressing}
           zoomLevel={zoomLevel}
@@ -195,6 +218,20 @@ function PreviewView() {
         <LoadingComponent
           finishedInitialLoad={finishedInitialLoad}
           devicesNotFound={devicesNotFound}
+        />
+      )}
+
+      {!replayData && inspectStackData && (
+        <InspectDataMenu
+          inspectLocation={inspectStackData.requestLocation}
+          inspectStack={inspectStackData.stack}
+          onSelected={onInspectorItemSelected}
+          onHover={(item) => {
+            if (item.frame) {
+              setInspectFrame(item.frame);
+            }
+          }}
+          onCancel={() => resetInspector()}
         />
       )}
 


### PR DESCRIPTION
This PR includes improvements to the inspector menu:

- hides inspector in the replay view
- corrects the positioning of the `InspectDataMenu`, ensuring the `DropdownMenu` appears at the cursor location
- adds label that displays the dimensions of the inspected element to the `InspectDataMenu` (similar to #585)
- adds a key prop to the components list in `InspectDataMenu` to prevent error messages

### How Has This Been Tested: 
- open the replay view and attempt to use the inspector using right mouse button
- close the replay view and confirm the inspector menu operates correctly
- ensure that the inspector menu displays the components' dimensions at the top as expected


<img width="331" alt="Screenshot 2024-10-18 at 19 26 18" src="https://github.com/user-attachments/assets/06509476-9ec0-43f8-8a3d-8bab66ea0b2a">
<img width="375" alt="Screenshot 2024-10-18 at 19 28 59" src="https://github.com/user-attachments/assets/ad944985-6b86-494c-a0a4-6940e5fec354">
