### PR TITLE
Change InspectDataMenu style class names to fix naming conflict

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.css
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.css
@@ -7,7 +7,7 @@
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
   box-shadow: var(--swm-backdrop-shadow);
-  max-width: calc(var(--radix-inspect-data-menu-content-available-width) - 10px);
+  max-width: calc(var(--radix-dropdown-menu-content-available-width) - 10px);
 }
 
 .inspect-data-menu-content code {

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.css
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.css
@@ -1,4 +1,4 @@
-.dropdown-menu-content {
+.inspect-data-menu-content {
   min-width: 50px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;
@@ -7,24 +7,24 @@
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
   box-shadow: var(--swm-backdrop-shadow);
-  max-width: calc(var(--radix-dropdown-menu-content-available-width) - 10px);
+  max-width: calc(var(--radix-inspect-data-menu-content-available-width) - 10px);
 }
 
-.dropdown-menu-content code {
+.inspect-data-menu-content code {
   font-family: monospace;
   font-size: clamp(5px, 5vw, 12px);
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.dropdown-menu-label {
+.inspect-data-menu-label {
     font-size: 12px;
     line-height: 25px;
     padding-left: 5px;
     color: var(--swm-secondary-text);
   }
 
-.dropdown-menu-item {
+.inspect-data-menu-item {
   font-size: clamp(4px, 4vw, 12px);
   line-height: 1;
   color: var(--swm-default-text);
@@ -41,18 +41,18 @@
   margin: 1px 0;
 }
 
-.dropdown-menu-item[data-disabled] {
+.inspect-data-menu-item[data-disabled] {
   color: var(--swm-disabled-text);
   pointer-events: none;
 }
 
-.dropdown-menu-item[data-highlighted] {
+.inspect-data-menu-item[data-highlighted] {
   background-color: var(--swm-dropdown-item-highlighted);
   color: var(--swm-default-text);
   overflow-wrap: anywhere;
 }
 
-.dropdown-menu-item .right-slot {
+.inspect-data-menu-item .right-slot {
   color: var(--swm-device-select-rich-item-subtitle);
   font-size: 90%;
   margin-left: auto;

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -50,8 +50,8 @@ export function InspectDataMenu({
         }}>
         <DropdownMenu.Trigger />
         <DropdownMenu.Portal>
-          <DropdownMenu.Content className="dropdown-menu-content">
-            <DropdownMenu.Label className="dropdown-menu-label">
+          <DropdownMenu.Content className="inspect-data-menu-content">
+            <DropdownMenu.Label className="inspect-data-menu-label">
               {displayDimensionsText}
             </DropdownMenu.Label>
             {filteredData.map((item, index) => {
@@ -59,7 +59,7 @@ export function InspectDataMenu({
               const fileName = item.source.fileName.split("/").pop();
               return (
                 <DropdownMenu.Item
-                  className="dropdown-menu-item"
+                  className="inspect-data-menu-item"
                   key={index}
                   onSelect={() => onSelected(item)}
                   onMouseEnter={() => onHover(item)}>


### PR DESCRIPTION
Fixes a small style regression after #639 

#639 introduced class names conflict, which caused an unexpected change in appearance of "Device Settings" (most notably, smaller padding). This PR fixes it.

## What it looked like before regression

![before](https://github.com/user-attachments/assets/a74567f9-1696-4371-bea7-26637515c2bc)

## After regression

![after](https://github.com/user-attachments/assets/a3b7a017-43de-4791-b9d9-4ba83d23b3c6)

### How Has This Been Tested: 

Tested in `react-native-75`



