### PR TITLE
Use new save command to fix issue with empty replays

### DIFF
--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -64,8 +64,8 @@ export class Preview implements Disposable {
           // video response format for replays looks as follows:
           // video_ready replay <HTTP_URL> <FILE_URL>
           // video_error replay <Error message>
-          const videoReadyMatch = line.match(/video_ready replay\S+ (\S+) (\S+)/);
-          const videoErrorMatch = line.match(/video_error replay\S+ (.*)/);
+          const videoReadyMatch = line.match(/video_ready replay (\S+) (\S+)/);
+          const videoErrorMatch = line.match(/video_error replay (.*)/);
 
           const handlers = this.lastReplayPromise;
           this.lastReplayPromise = undefined;
@@ -94,14 +94,12 @@ export class Preview implements Disposable {
     });
   }
 
-  static replayID = 0;
-
   public startReplays() {
     const stdin = this.subprocess?.stdin;
     if (!stdin) {
       throw new Error("sim-server process not available");
     }
-    stdin.write(`video replay_${++Preview.replayID} start -m -b 50\n`); // 50MB buffer for in-memory video
+    stdin.write(`video replay start -m -b 50\n`); // 50MB buffer for in-memory video
   }
 
   public stopReplays() {
@@ -109,7 +107,7 @@ export class Preview implements Disposable {
     if (!stdin) {
       throw new Error("sim-server process not available");
     }
-    stdin.write(`video replay_${Preview.replayID} stop\n`);
+    stdin.write(`video replay stop\n`);
   }
 
   public captureReplay() {
@@ -127,9 +125,7 @@ export class Preview implements Disposable {
       promise.then(this.lastReplayPromise.resolve, this.lastReplayPromise.reject);
     }
     this.lastReplayPromise = { resolve: resolvePromise!, reject: rejectPromise! };
-    stdin.write(`video replay_${Preview.replayID} stop\n`);
-    // immediately restart replays
-    this.startReplays();
+    stdin.write(`video replay save\n`);
     return promise;
   }
 


### PR DESCRIPTION
This PR brings on the changes from simulator-server that aim to address the issue with empty / erronous replays.

This issue would arise in when user enables the replays for the device and then w/o any interaction with the screen would snap a replay. With the previous version, this would result in an error, as sim-server wouldn't register any frames since replays were enabled. The second issue was similar but had to do with the fact that after snapping the replay we'd need to stop and start replays again, resulting in the same behavior that'd arise immediately after starting. For this purpose `save` command have been introduced that apart from fixing the issue would let the video buffer retain frames when saving. This way the follow-up replays can also contain frames from previous ones if they are not that far apart.

This PR:
1) Bumps simulator-server version to one that includes aforementioned fixes
2) Updates the code to use `save` command. We are also removing IDs that we'd previously used for individual recording session as now we only have one session that stops only when the user disables replays in the device setting.

### How Has This Been Tested: 
1. Run one project on iOS and Android with replays disabled
2. Enable replays and snap replay w/o doing anything on the screen -> see that a very short replay gets recorded
3. Do something with the screen and record another replay
4. Close replay, do some more stuff on screen and record another one -> see that the last one also includes recording of the screen from before the previous replay was recorded

