### PR TITLE
Fix expo-go project configuration and better handle metro being terminated when quering for launch deeplink

### DIFF
--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -123,7 +123,7 @@ export async function buildIos(
 
   if (!(await dependencyManager.checkIOSDirectoryExists())) {
     throw new Error(
-      "Ios directory does not exist, configure build source in launch configuration or use expo prebuild to generate the directory"
+      '"ios" directory does not exist, configure build source in launch configuration or use expo prebuild to generate the directory'
     );
   }
 

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -57,7 +57,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
     projectState.selectedDevice?.platform === DevicePlatform.Android
   ) {
     description =
-      "Your project does not have an android directory, configure custom build source, eas or use expo prebuild to generate missing files.";
+      'Your project does not have "android" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure external build source using launch configuration.';
   }
 
   if (
@@ -65,7 +65,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
     projectState.selectedDevice?.platform === DevicePlatform.IOS
   ) {
     description =
-      "Your project does not have an ios directory, configure custom build source, eas or use expo prebuild to generate missing files.";
+      'Your project does not have "ios" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure external build source using launch configuration.';
   }
 
   const buildErrorAlert = {

--- a/test-apps/expo-go/package-lock.json
+++ b/test-apps/expo-go/package-lock.json
@@ -8,11 +8,13 @@
       "name": "expo-go",
       "version": "1.0.0",
       "dependencies": {
+        "@types/react": "~18.2.45",
         "expo": "~50.0.14",
         "expo-status-bar": "~1.11.1",
         "radon-ide": "^0.0.1",
         "react": "18.2.0",
-        "react-native": "0.73.6"
+        "react-native": "0.73.6",
+        "typescript": "^5.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -6062,6 +6064,20 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.13",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
+      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
+      "integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -7270,6 +7286,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -12624,6 +12645,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/test-apps/expo-go/package.json
+++ b/test-apps/expo-go/package.json
@@ -7,14 +7,16 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "copy-shared": "node ../shared/copy.js bare ./shared" 
+    "copy-shared": "node ../shared/copy.js bare ./shared"
   },
   "dependencies": {
     "expo": "~50.0.14",
     "expo-status-bar": "~1.11.1",
     "radon-ide": "^0.0.1",
     "react": "18.2.0",
-    "react-native": "0.73.6"
+    "react-native": "0.73.6",
+    "typescript": "^5.3.0",
+    "@types/react": "~18.2.45"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/test-apps/expo-go/tsconfig.json
+++ b/test-apps/expo-go/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
When testing expo-go I encountered a few small issues this PR is addressing:
1) Unclear messages when expo-go project couldn't launch 
2) Recently we added "shared example code" to expo-go project, but since it is using typescript, expo-go project should have the typescript dependencies added
3) Because of the missing dependencies, metro process would terminate, resulting in the deeplink lookup failure which wasn't properly reported

We are making the following adjustments to address these issues:
1) Updating text in errors to clearly indicate when talking about "android" and "ios" folders. We also change the wording a bit which should now be easier to understand (at least in my opinion)
2) We are adding missing packages to expo-go test app project
3) We are changing the logic for handling deeplink requests, such that in case the metro instance is not reachable, we reject with a clear message instead of letting the process proceed and fail and some later, unrelated step.

### How Has This Been Tested: 
1. Run expo-go test app on Android.


