### PR TITLE
Enable expo router integration to work with v4 version

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -65,7 +65,7 @@ function transformWrapper({ filename, src, ...rest }) {
     const { version } = requireFromAppDir("expo-router/package.json");
     if (version.startsWith("2.")) {
       src = `${src};require("__RNIDE_lib__/expo_router_v2_plugin.js");`;
-    } else if (version.startsWith("3.")) {
+    } else if (version.startsWith("3.") || version.startsWith("4.")) {
       src = `${src};require("__RNIDE_lib__/expo_router_plugin.js");`;
     }
   } else if (


### PR DESCRIPTION
Expo router v4 is around the corner. It seems that API-wise from the IDE point of there were no changes and I tested the current v3 integration with a fresh v4 project.

### How Has This Been Tested: 
1. Create new project for expo 52 with expo-router v4 preview
2. Test URL bar after switching between routes
3. We will add this to one of test apps once there's a beta release of Expo 52


