### PR TITLE
Support text paste on iOS

### DIFF
--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -7,7 +7,7 @@ import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
 
 export abstract class DeviceBase implements Disposable {
-  private preview: Preview | undefined;
+  protected preview: Preview | undefined;
   private previewStartPromise: Promise<string> | undefined;
   private acquired = false;
 
@@ -69,8 +69,8 @@ export abstract class DeviceBase implements Disposable {
     this.preview?.sendKey(keyCode, direction);
   }
 
-  public sendPaste(text: string) {
-    this.preview?.sendPaste(text);
+  public async sendPaste(text: string) {
+    return this.preview?.sendPaste(text);
   }
 
   async startPreview() {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -207,6 +207,20 @@ export class IosSimulatorDevice extends DeviceBase {
     ]);
   }
 
+  public async sendPaste(text: string) {
+    const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
+    const subprocess = exec("xcrun", [
+      "simctl",
+      "--set",
+      deviceSetLocation,
+      "pbcopy",
+      this.deviceUDID,
+    ]);
+    subprocess.stdin?.write(text);
+    subprocess.stdin?.end();
+    await subprocess;
+  }
+
   private async changeLocale(newLocale: Locale): Promise<boolean> {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
     const languageCode = newLocale.match(/([^_-]*)/)![1];

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -211,7 +211,8 @@ export class IosSimulatorDevice extends DeviceBase {
     ]);
   }
 
-  private pressingMetaKeys = 0; // 0 - not pressing, 1+ - how many meta keys are pressed
+  private pressingLeftMetaKey = false;
+  private pressingRightMetaKey = false;
 
   public sendKey(keyCode: number, direction: "Up" | "Down"): void {
     // iOS simulator has a buggy behavior when sending cmd+V key combination.
@@ -219,15 +220,17 @@ export class IosSimulatorDevice extends DeviceBase {
     // Other times it kicks in before the pasteboard is filled with the content
     // therefore pasting the previously compied content instead.
     // As a temporary workaround, we disable sending cmd+V as key combination
-    // entirely to prevent this bugge behavior. Users can still paste content
-    // using the context menu.
+    // entirely to prevent this buggy behavior. Users can still paste content
+    // using the context menu method as they'd do on an iOS device.
     // This is not an ideal workaround as people may still trigger cmd+v by
     // pressing V first and then cmd, but it is good enough to filter out
     // the majority of the noisy behavior since typically you press cmd first.
-    if (keyCode === LEFT_META_HID_CODE || keyCode === RIGHT_META_HID_CODE) {
-      this.pressingMetaKeys += direction === "Down" ? 1 : -1;
+    if (keyCode === LEFT_META_HID_CODE) {
+      this.pressingLeftMetaKey = direction === "Down";
+    } else if (keyCode === RIGHT_META_HID_CODE) {
+      this.pressingRightMetaKey = direction === "Down";
     }
-    if (this.pressingMetaKeys > 0 && keyCode === V_KEY_HID_CODE) {
+    if ((this.pressingLeftMetaKey || this.pressingRightMetaKey) && keyCode === V_KEY_HID_CODE) {
       // ignore sending V when meta key is pressed
     } else {
       this.preview?.sendKey(keyCode, direction);

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -138,7 +138,7 @@ export class Preview implements Disposable {
     this.subprocess?.stdin?.write(`key ${direction} ${keyCode}\n`);
   }
 
-  public sendPaste(text: string) {
+  public async sendPaste(text: string) {
     this.subprocess?.stdin?.write(`paste ${text}\n`);
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -254,7 +254,7 @@ export class DeviceSession implements Disposable {
   }
 
   public sendPaste(text: string) {
-    this.device.sendPaste(text);
+    return this.device.sendPaste(text);
   }
 
   public inspectElementAt(

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -154,7 +154,7 @@ export class Project
   }
 
   async dispatchPaste(text: string) {
-    this.deviceSession?.sendPaste(text);
+    await this.deviceSession?.sendPaste(text);
   }
 
   onBundleError(): void {


### PR DESCRIPTION
This PR adds text paste support on iOS.

For Android, we use simulator-server to pass paste command. On iOS that was tricky to do and since there's a simctl command for paste we can use that instead.

In this change, we are overriding the sendPaste implementation for iOS that uses simctl pbcopy command that expects the pasted text to be sent via standard input.

In addition, we disable sending cmd+v key combination as HID keys to the simulator. It turned out to result in a buggy behavior when sometimes the key combination would trigger paste action and actually paste text into a focused text input, while most of the times it'd just do nothing. There were also instances where the previous text was pasted instead. Blocking this behavior isn't ideal but it puts iOS functionality in pair with Android while also avoiding a number of issues. It appears like the bugs are not caused by the IDE since we also observe these when testing paste functionality with the standard iOS simulator app.

Closes: #553

### How Has This Been Tested: 
1. Open any text example, add TextInput field
2. Copy some text using cmd+c and use cmd+v with the iOS simulator focused
3. Now when long-pressing the input field you can paste the copied text


