### PR TITLE
Fix handling of uncaught errors

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -20,15 +20,6 @@ global.__RNIDE_onDebuggerReady = function () {
   global.__fbDisableExceptionsManager = true;
 };
 
-try{
-  // if debugger is already connected it will run "__RNIDE_onDebuggerReady"
-  // if not it will run "__RNIDE_onDebuggerReady" on execution context creation
-  global.__RNIDE_onRuntimeLoaded(""); // the argument is required by CDP 
-}catch(e){
-  // we ignore the error here because it means, debugger was not connected yet.
-}
-
-
 // We add log this trace to diagnose issues with loading runtime in the IDE
 // The first argument is "__RNIDE_INTERNAL" so we can filter it out in 
 // debug adapter and avoid exposing as part of application logs

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -21,9 +21,9 @@ global.__RNIDE_onDebuggerReady = function () {
 };
 
 // We add log this trace to diagnose issues with loading runtime in the IDE
-// It is necessary that this call is before we override console methods, otherwise
-// this message would be visible in the debug console panel for the IDE users.
-console.log("__RNIDE_INTERNAL: react-native-ide runtime loaded");
+// The first argument is "__RNIDE_INTERNAL" so we can filter it out in 
+// debug adapter and avoid exposing as part of application logs
+console.log("__RNIDE_INTERNAL", "react-native-ide runtime loaded");
 
 function wrapConsole(consoleFunc) {
   return function (...args) {

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -20,10 +20,17 @@ global.__RNIDE_onDebuggerReady = function () {
   global.__fbDisableExceptionsManager = true;
 };
 
+try{
+  global.__RNIDE_onRuntimeLoaded(""); // the argument is required by CDP 
+}catch(e){
+  // we ignore the error here because it means, debugger was not connected yet.
+}
+
+
 // We add log this trace to diagnose issues with loading runtime in the IDE
 // The first argument is "__RNIDE_INTERNAL" so we can filter it out in 
 // debug adapter and avoid exposing as part of application logs
-console.log("__RNIDE_INTERNAL", "react-native-ide runtime loaded");
+console.log("__RNIDE_INTERNAL", "radon-ide runtime loaded");
 
 function wrapConsole(consoleFunc) {
   return function (...args) {

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -21,6 +21,8 @@ global.__RNIDE_onDebuggerReady = function () {
 };
 
 try{
+  // if debugger is already connected it will run "__RNIDE_onDebuggerReady"
+  // if not it will run "__RNIDE_onDebuggerReady" on execution context creation
   global.__RNIDE_onRuntimeLoaded(""); // the argument is required by CDP 
 }catch(e){
   // we ignore the error here because it means, debugger was not connected yet.

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -12,7 +12,7 @@ function __RNIDE_breakOnError(error, isFatal) {
   debugger;
 }
 
-global.__RNIDE_onDebuggerConnected = function () {
+global.__RNIDE_onDebuggerReady = function () {
   // install error handler that breaks into the debugger but only do it when
   // debugger is connected. Otherwise we may miss some important initialization
   // errors or even pause the app execution before the debugger is attached.

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -203,11 +203,12 @@ export class DebugAdapter extends DebugSession {
     // some logs may baypass that, especially when printed in initialization phase, so we
     // need to detect whether the wrapper has added the stack info or not
     // We check if there are more than 3 arguments, and if the last one is a number
-    // We also check if the log is not internal to avoid exposing it as part of
-    // application logs.
+    // We filter out logs that start with __RNIDE_INTERNAL as those are messages
+    // used by IDE for tracking the app state and should not appear in the VSCode
+    // console.
     const argsLen = message.params.args.length;
     let output: OutputEvent;
-    if (message.params.args[0].value === "__RNIDE_INTERNAL") {
+    if (argsLen > 0 && message.params.args[0].value === "__RNIDE_INTERNAL") {
       return;
     } else if (argsLen > 3 && message.params.args[argsLen - 1].type === "number") {
       // Since console.log stack is extracted from Error, unlike other messages sent over CDP

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -107,12 +107,6 @@ export class DebugAdapter extends DebugSession {
       this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 }).catch(ignoreError);
       this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] }).catch(ignoreError);
       this.sendCDPMessage("Runtime.runIfWaitingForDebugger", {}).catch(ignoreError);
-      this.sendCDPMessage("Runtime.addBinding", {
-        name: "__RNIDE_onRuntimeLoaded",
-      });
-      this.sendCDPMessage("Runtime.evaluate", {
-        expression: "__RNIDE_onDebuggerReady()",
-      });
     });
 
     this.connection.on("close", () => {
@@ -143,6 +137,17 @@ export class DebugAdapter extends DebugSession {
           const threadName = context.name;
           this.sendEvent(new ThreadEvent("started", threadId));
           this.threads.push(new Thread(threadId, threadName));
+          this.sendCDPMessage("Runtime.evaluate", {
+            expression: "__RNIDE_onDebuggerReady()",
+          });
+          // because in the debugger shipped with RN 76 an newer execution context
+          // is created before runtime is loaded, we inject the __RNIDE_onRuntimeLoaded
+          // binding in order to alow runtime triggering __RNIDE_onDebuggerReady()
+          // after debugger was already connected.
+          this.sendCDPMessage("Runtime.addBinding", {
+            name: "__RNIDE_onRuntimeLoaded",
+          });
+
           break;
         case "Runtime.bindingCalled":
           if ((message.params.name = "__RNIDE_onRuntimeLoaded")) {

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -203,9 +203,13 @@ export class DebugAdapter extends DebugSession {
     // some logs may baypass that, especially when printed in initialization phase, so we
     // need to detect whether the wrapper has added the stack info or not
     // We check if there are more than 3 arguments, and if the last one is a number
+    // We also check if the log is not internal to avoid exposing it as part of
+    // application logs.
     const argsLen = message.params.args.length;
     let output: OutputEvent;
-    if (argsLen > 3 && message.params.args[argsLen - 1].type === "number") {
+    if (message.params.args[0].value === "__RNIDE_INTERNAL") {
+      return;
+    } else if (argsLen > 3 && message.params.args[argsLen - 1].type === "number") {
       // Since console.log stack is extracted from Error, unlike other messages sent over CDP
       // the line and column numbers are 1-based
       const [scriptURL, generatedLineNumber1Based, generatedColumn1Based] = message.params.args

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -137,27 +137,15 @@ export class DebugAdapter extends DebugSession {
           const threadName = context.name;
           this.sendEvent(new ThreadEvent("started", threadId));
           this.threads.push(new Thread(threadId, threadName));
-          this.sendCDPMessage("Runtime.evaluate", {
-            expression: "__RNIDE_onDebuggerReady()",
-          });
-          // because in the debugger shipped with RN 76 an newer execution context
-          // is created before runtime is loaded, we inject the __RNIDE_onRuntimeLoaded
-          // binding in order to alow runtime triggering __RNIDE_onDebuggerReady()
-          // after debugger was already connected.
-          this.sendCDPMessage("Runtime.addBinding", {
-            name: "__RNIDE_onRuntimeLoaded",
-          });
-
           break;
-        case "Runtime.bindingCalled":
-          if ((message.params.name = "__RNIDE_onRuntimeLoaded")) {
+        case "Debugger.scriptParsed":
+          const sourceMapURL = message.params.sourceMapURL;
+
+          if (message.params.url) {
             this.sendCDPMessage("Runtime.evaluate", {
               expression: "__RNIDE_onDebuggerReady()",
             });
           }
-          break;
-        case "Debugger.scriptParsed":
-          const sourceMapURL = message.params.sourceMapURL;
 
           if (sourceMapURL?.startsWith("data:")) {
             const base64Data = sourceMapURL.split(",")[1];

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -107,9 +107,6 @@ export class DebugAdapter extends DebugSession {
       this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 }).catch(ignoreError);
       this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] }).catch(ignoreError);
       this.sendCDPMessage("Runtime.runIfWaitingForDebugger", {}).catch(ignoreError);
-      this.sendCDPMessage("Runtime.evaluate", {
-        expression: "__RNIDE_onDebuggerConnected()",
-      });
     });
 
     this.connection.on("close", () => {
@@ -140,6 +137,9 @@ export class DebugAdapter extends DebugSession {
           const threadName = context.name;
           this.sendEvent(new ThreadEvent("started", threadId));
           this.threads.push(new Thread(threadId, threadName));
+          this.sendCDPMessage("Runtime.evaluate", {
+            expression: "__RNIDE_onDebuggerReady()",
+          });
           break;
         case "Debugger.scriptParsed":
           const sourceMapURL = message.params.sourceMapURL;

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -213,7 +213,7 @@ export class DebugAdapter extends DebugSession {
     let output: OutputEvent;
     if (argsLen > 0 && message.params.args[0].value === "__RNIDE_INTERNAL") {
       // We return here to avoid passing internal logs to the user debug console,
-      // but they will still be visible in metro log feed. 
+      // but they will still be visible in metro log feed.
       return;
     } else if (argsLen > 3 && message.params.args[argsLen - 1].type === "number") {
       // Since console.log stack is extracted from Error, unlike other messages sent over CDP

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -141,6 +141,10 @@ export class DebugAdapter extends DebugSession {
         case "Debugger.scriptParsed":
           const sourceMapURL = message.params.sourceMapURL;
 
+          // there are a few scripts parsed by the debugger that are not part of
+          // the application code. The below condition makes sure that
+          // __RNIDE_onDebuggerReady() is only called when application bundle is
+          // parsed.
           if (message.params.url) {
             this.sendCDPMessage("Runtime.evaluate", {
               expression: "__RNIDE_onDebuggerReady()",


### PR DESCRIPTION
This PR fixes the problem with debugger ignoring uncaught errors after reloading JS. Because errors Global Handler  was only set on first connection to the debugger it would not be added after reload. The solution was to move the logic of setting the handler to happen on debugger event that is triggered both on first and consecutive application loads. 

### How Has This Been Tested: 

1. Run Test application and cause error
2. reload JS 
3. repet step 1). Before the change it would pass the error to the debug console and not stop the application
4. Test it both on application using RN version older then 76 and 76. 

Additional changes:
this PR also hides related internal logging from the users debug console 


