### PR TITLE
Block touch and keypress events, hide multitouch indicators in replays

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -548,35 +548,33 @@ function Preview({
                 />
                 {replayData && <ReplayUI onClose={onReplayClose} replayData={replayData} />}
 
-                {isMultiTouching && (
-                  <div
-                    style={{
-                      "--x": `${touchPoint.x * 100}%`,
-                      "--y": `${touchPoint.y * 100}%`,
-                      "--size": `${normalTouchIndicatorSize}px`,
-                    }}>
-                    <TouchPointIndicator isPressing={isPressing} />
-                  </div>
-                )}
-                {isMultiTouching && (
-                  <div
-                    style={{
-                      "--x": `${anchorPoint.x * 100}%`,
-                      "--y": `${anchorPoint.y * 100}%`,
-                      "--size": `${smallTouchIndicatorSize}px`,
-                    }}>
-                    <TouchPointIndicator isPressing={false} />
-                  </div>
-                )}
-                {isMultiTouching && (
-                  <div
-                    style={{
-                      "--x": `${mirroredTouchPosition.x * 100}%`,
-                      "--y": `${mirroredTouchPosition.y * 100}%`,
-                      "--size": `${normalTouchIndicatorSize}px`,
-                    }}>
-                    <TouchPointIndicator isPressing={isPressing} />
-                  </div>
+                {!replayData && isMultiTouching && (
+                  <>
+                    <div
+                      style={{
+                        "--x": `${touchPoint.x * 100}%`,
+                        "--y": `${touchPoint.y * 100}%`,
+                        "--size": `${normalTouchIndicatorSize}px`,
+                      }}>
+                      <TouchPointIndicator isPressing={isPressing} />
+                    </div>
+                    <div
+                      style={{
+                        "--x": `${anchorPoint.x * 100}%`,
+                        "--y": `${anchorPoint.y * 100}%`,
+                        "--size": `${smallTouchIndicatorSize}px`,
+                      }}>
+                      <TouchPointIndicator isPressing={false} />
+                    </div>
+                    <div
+                      style={{
+                        "--x": `${mirroredTouchPosition.x * 100}%`,
+                        "--y": `${mirroredTouchPosition.y * 100}%`,
+                        "--size": `${normalTouchIndicatorSize}px`,
+                      }}>
+                      <TouchPointIndicator isPressing={isPressing} />
+                    </div>
+                  </>
                 )}
 
                 {!replayData && inspectFrame && (

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -459,8 +459,11 @@ function Preview({
     function keyEventHandler(e: KeyboardEvent) {
       if (document.activeElement === wrapperDivRef.current) {
         e.preventDefault();
-        const isKeydown = e.type === "keydown";
+        if (replayData) {
+          return;
+        }
 
+        const isKeydown = e.type === "keydown";
         const isMultitouchKeyPressed = Platform.select({
           macos: e.code === "AltLeft" || e.code === "AltRight",
           windows: e.code === "ControlLeft" || e.code === "ControlRight",
@@ -484,7 +487,7 @@ function Preview({
       document.removeEventListener("keydown", keyEventHandler);
       document.removeEventListener("keyup", keyEventHandler);
     };
-  }, [project]);
+  }, [project, replayData]);
 
   useEffect(() => {
     if (projectStatus === "running") {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -278,11 +278,19 @@ function Preview({
 
   type MouseMove = "Move" | "Down" | "Up";
   function sendTouch(event: MouseEvent<HTMLDivElement>, type: MouseMove) {
+    if (replayData) {
+      return;
+    }
+
     const { x, y } = getTouchPosition(event);
     project.dispatchTouches([{ xRatio: x, yRatio: y }], type);
   }
 
   function sendMultiTouch(event: MouseEvent<HTMLDivElement>, type: MouseMove) {
+    if (replayData) {
+      return;
+    }
+
     const pt = getTouchPosition(event);
     const secondPt = calculateMirroredTouchPosition(pt, anchorPoint);
     project.dispatchTouches(


### PR DESCRIPTION
This PR blocks sending of touch and keyboard events and hides multitouch indicators during replays.

#### Test plan:

1. Open a replay and attempt to use multitouch. Confirm that multitouch indicators are not visible.
2. Uncomment the "SIMSERVER_LOG": "debug" flag in the extension's config. Open a replay in the test app, click both inside and outside of the device screen, press any keyboard button and ensure that the logs do not include the "Sending touch" or Sending key" entries.

before:
https://github.com/user-attachments/assets/ba93504a-8008-4b70-9902-ea0f3fb7e2af

after:

https://github.com/user-attachments/assets/ae38420d-660d-4b0e-8811-5277808a2715
