### PR TITLE
Remove previous app button

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -263,8 +263,43 @@ export class IosSimulatorDevice extends DeviceBase {
     }
   }
 
+  /**
+   * This function terminates any running applications. Might be useful when you launch a new application
+   * before terminating the previous one.
+   */
+  async terminateAnyRunningApplications() {
+    const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
+    const { stdout } = await exec("xcrun", [
+      "simctl",
+      "--set",
+      deviceSetLocation,
+      "listapps",
+      this.deviceUDID,
+    ]);
+
+    const regex = /ApplicationType = User;\s*[^{}]*?\bCFBundleIdentifier = "([^"]+)/g;
+
+    let match;
+    while ((match = regex.exec(stdout)) !== null) {
+      const bundleID = match[1];
+      // Terminate the app if it's running:
+      try {
+        await exec(
+          "xcrun",
+          ["simctl", "--set", deviceSetLocation, "terminate", this.deviceUDID, bundleID],
+          { allowNonZeroExit: true }
+        );
+      } catch (e) {
+        // terminate will exit with non-zero code when the app wasn't running. we ignore this error
+      }
+    }
+  }
+
   async launchWithBuild(build: IOSBuildResult) {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
+
+    await this.terminateAnyRunningApplications();
+
     await exec("xcrun", [
       "simctl",
       "--set",
@@ -279,7 +314,7 @@ export class IosSimulatorDevice extends DeviceBase {
   async launchWithExpoDeeplink(bundleID: string, expoDeeplink: string) {
     // For Expo dev-client and Expo Go setup, we use deeplink to launch the app. For this approach to work we do the following:
     // 1. Add the deeplink to the scheme approval list via defaults
-    // 2. Terminate the app if it's running
+    // 2. Terminate any app if it's running
     // 3. Open the deeplink
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
@@ -299,16 +334,7 @@ export class IosSimulatorDevice extends DeviceBase {
       bundleID,
     ]);
 
-    // Terminate the app if it's running:
-    try {
-      await exec(
-        "xcrun",
-        ["simctl", "--set", deviceSetLocation, "terminate", this.deviceUDID, bundleID],
-        { allowNonZeroExit: true }
-      );
-    } catch (e) {
-      // terminate will exit with non-zero code when the app wasn't running. we ignore this error
-    }
+    await this.terminateAnyRunningApplications();
 
     // Use openurl to open the deeplink:
     await exec("xcrun", [

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -279,9 +279,13 @@ export class IosSimulatorDevice extends DeviceBase {
 
     const regex = /ApplicationType = User;\s*[^{}]*?\bCFBundleIdentifier = "([^"]+)/g;
 
+    const matches = [];
     let match;
     while ((match = regex.exec(stdout)) !== null) {
-      const bundleID = match[1];
+      matches.push(match[1]);
+    }
+
+    const terminateApp = async (bundleID: string) => {
       // Terminate the app if it's running:
       try {
         await exec(
@@ -292,7 +296,13 @@ export class IosSimulatorDevice extends DeviceBase {
       } catch (e) {
         // terminate will exit with non-zero code when the app wasn't running. we ignore this error
       }
-    }
+    };
+
+    await Promise.all(
+      matches.map((bundleID) => {
+        return terminateApp(bundleID);
+      })
+    );
   }
 
   async launchWithBuild(build: IOSBuildResult) {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -298,11 +298,7 @@ export class IosSimulatorDevice extends DeviceBase {
       }
     };
 
-    await Promise.all(
-      matches.map((bundleID) => {
-        return terminateApp(bundleID);
-      })
-    );
+    await Promise.all(matches.map(terminateApp));
   }
 
   async launchWithBuild(build: IOSBuildResult) {


### PR DESCRIPTION
This PR removes the "previous app button" from top left corner of the ios simulator. Before this change If the user switched workspaces without shouting down the ios simulator, the button pointing to the previous app would appear in top left corner of the application. Clicking the button would break the IDE functionality as there is no way of navigating through the simulator and the only way to recover would be to restart app process (which would still  leave the button in the corner).

The solution it to terminate any open applications before launching a new one. 

<img width="247" alt="Screenshot 2024-10-24 at 20 34 01" src="https://github.com/user-attachments/assets/b3540378-bd53-4b8a-be10-afd72feb4fe8">



### How Has This Been Tested: 

- open an application ios using IDE
- switch workspaces without closing ide 
- in the new workspace open the ios application using the same device 
- switch workspaces back to the original one without closing ide


