### PR TITLE
Don't focus on debug panel if it means hiding IDE

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -30,7 +30,6 @@ import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
 import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { PlatformBuildCache } from "../builders/PlatformBuildCache";
-import { TabPanel } from "../panels/Tabpanel";
 import { PanelLocation } from "../common/WorkspaceConfig";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -30,6 +30,8 @@ import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
 import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { PlatformBuildCache } from "../builders/PlatformBuildCache";
+import { TabPanel } from "../panels/Tabpanel";
+import { PanelLocation } from "../common/WorkspaceConfig";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
@@ -138,7 +140,15 @@ export class Project
     } else {
       this.updateProjectState({ status: "debuggerPaused" });
     }
-    commands.executeCommand("workbench.view.debug");
+
+    // we don't want to focus on debug side panel if it means hiding Radon IDE
+    const panelLocation = workspace
+      .getConfiguration("RadonIDE")
+      .get<PanelLocation>("panelLocation");
+
+    if (panelLocation === "tab") {
+      commands.executeCommand("workbench.view.debug");
+    }
   }
 
   onDebuggerResumed() {


### PR DESCRIPTION
This PR stops focus on debug panel when debug was paused if the IDE is located in side panel, to avoid hiding it when debugger is used. 


### How Has This Been Tested: 

Run ide in side panel and use debugger, then do the same in the tab panel. 


