### PR TITLE
Set minimum size for the device in zoom controls

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -20,6 +20,8 @@
   aspect-ratio: var(--phone-aspect-ratio);
   max-width: 100%;
   max-height: 100%;
+  min-height: 350px;
+  align-self: start;
   /* object-fit: scale-down; */
 }
 

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -8,6 +8,8 @@ import "./ZoomControls.css";
 const ZOOM_STEP = 0.05;
 const ZOOM_SELECT_NUMERIC_VALUES = [0.5, 0.6, 0.7, 0.8, 0.9, 1];
 export const DEVICE_DEFAULT_SCALE = 1 / 3;
+export const MIN_FIT_ZOOM_LEVEL = 0.4;
+export const FIT_MODE_WINDOW_HEIGHT_THRESHOLD = 470;
 
 type ZoomControlsProps = {
   zoomLevel: ZoomLevelType;

--- a/packages/vscode-extension/src/webview/components/ZoomControls.tsx
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.tsx
@@ -8,8 +8,7 @@ import "./ZoomControls.css";
 const ZOOM_STEP = 0.05;
 const ZOOM_SELECT_NUMERIC_VALUES = [0.5, 0.6, 0.7, 0.8, 0.9, 1];
 export const DEVICE_DEFAULT_SCALE = 1 / 3;
-export const MIN_FIT_ZOOM_LEVEL = 0.4;
-export const FIT_MODE_WINDOW_HEIGHT_THRESHOLD = 470;
+export const MIN_ZOOM_LEVEL = 0.4;
 
 type ZoomControlsProps = {
   zoomLevel: ZoomLevelType;
@@ -72,7 +71,10 @@ function ZoomControls({ zoomLevel, onZoomChanged, device, wrapperDivRef }: ZoomC
       currentZoomLevel = zoomLevel;
     }
     // toFixed() is necessary because of floating point rounding errors
-    const newZoomLevel = +(currentZoomLevel + (shouldIncrease ? ZOOM_STEP : -ZOOM_STEP)).toFixed(2);
+    const zoomAfterStep = currentZoomLevel + (shouldIncrease ? ZOOM_STEP : -ZOOM_STEP);
+    const newZoomLevel = +(zoomAfterStep > MIN_ZOOM_LEVEL ? zoomAfterStep : MIN_ZOOM_LEVEL).toFixed(
+      2
+    );
 
     if (newZoomLevel >= ZOOM_STEP) {
       onZoomChanged(newZoomLevel);

--- a/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useResizableProps.tsx
@@ -2,11 +2,7 @@ import { ResizeCallback } from "re-resizable";
 import { CSSProperties, useCallback, useEffect, useState } from "react";
 import { DeviceProperties } from "../utilities/consts";
 import { ZoomLevelType } from "../../common/Project";
-import {
-  DEVICE_DEFAULT_SCALE,
-  MIN_FIT_ZOOM_LEVEL,
-  FIT_MODE_WINDOW_HEIGHT_THRESHOLD,
-} from "../components/ZoomControls";
+import { DEVICE_DEFAULT_SCALE } from "../components/ZoomControls";
 
 type UseResizableProps = {
   wrapperDivRef: React.RefObject<HTMLDivElement>;
@@ -35,17 +31,10 @@ export function useResizableProps({
   const calculatePhoneDimensions = useCallback(
     (delta = 0) => {
       if (zoomLevel === "Fit") {
-        const windowHeight = document.getElementById("root")?.clientHeight ?? 0;
-        if (windowHeight < FIT_MODE_WINDOW_HEIGHT_THRESHOLD) {
-          setPhoneHeight(device.frameHeight * MIN_FIT_ZOOM_LEVEL * DEVICE_DEFAULT_SCALE + delta);
-          setMaxWidth(undefined);
-        } else {
-          setPhoneHeight("100%");
-          setMaxWidth("100%");
-        }
+        setPhoneHeight("100%");
+        setMaxWidth("100%");
         return;
       }
-
       setPhoneHeight(device.frameHeight * zoomLevel * DEVICE_DEFAULT_SCALE + delta);
       setMaxWidth(undefined);
     },
@@ -63,17 +52,6 @@ export function useResizableProps({
   );
 
   useEffect(calculatePhoneDimensions, [zoomLevel]);
-
-  useEffect(() => {
-    const handleResize = () => {
-      calculatePhoneDimensions();
-    };
-
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [calculatePhoneDimensions]);
 
   return {
     size: { width: "auto", height: phoneHeight },


### PR DESCRIPTION
This PR fixes the issue where the "fit" mode causes indefinite shrinking of the device display. Included changes:
- sets a minimum device height of 350px in the CSS, which restricts the "fit" mode
- adds minimum zoom level of 0.4 (`MIN_ZOOM_LEVEL`) to prevent excessive zooming out

Fixes #654 

### How Has This Been Tested: 
- `MIN_ZOOM_LEVEL` and minimal device height in CSS settings were chosen and tested on a 14-inch MacBook 
- Select "fit" mode and adjust the tab's height. Use the zoom out button to zoom out as far as possible. In both cases, ensure that the minimum device size display remains readable.

before:
https://github.com/user-attachments/assets/5fbb86e1-ad9f-4338-9070-6679d9b26d08

after:
https://github.com/user-attachments/assets/8fa2437d-fa49-4702-8464-89652a21e8f6


