### PR TITLE
Use websocket /message endpoint to deliver reload request

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -280,7 +280,7 @@ export class Metro implements Disposable {
     ws.send(
       JSON.stringify({
         version: 2 /* protocol version, needs to be set to 2 */,
-        method: message,
+        method,
       })
     );
     // we disconnect immediately after sending the message as there's no need

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -267,26 +267,33 @@ export class Metro implements Disposable {
     return initPromise;
   }
 
-  public async reload() {
-    const appReady = this.devtools.appReady();
-    await fetch(`http://localhost:${this._port}/reload`);
-    await appReady;
-  }
-
-  public async openDevMenu() {
-    // to send request to open dev menu, we route it through metro process
-    // that maintains a websocket connection with the device. Specifically,
-    // /message endpoint is used to send messages to the device, and metro proxies
-    // messages between different clients connected to that endpoint.
-    // Therefore, to send the message to the device we:
-    // 1. connect to the /message endpoint over websocket
-    // 2. send specifically formatted message to open dev menu
+  private async sendMessageToDevice(message: "devMenu" | "reload") {
+    // we use metro's /message websocket endpoint to deliver specifically formatted
+    // messages to the device.
+    // Metro implements a websocket proxy that proxies messages between connected
+    // clients. This is a mechanism used by the CLI to deliver messages for things
+    // like reload or open dev menu.
+    // The message format is a JSON object with a "method" field that specifies
+    // the action, and version field with the protocol version (currently 2).
     const ws = new WebSocket(`ws://localhost:${this._port}/message`);
     await new Promise((resolve) => ws.addEventListener("open", resolve));
     ws.send(
-      JSON.stringify({ version: 2 /* protocol version, needs to be set to 2 */, method: "devMenu" })
+      JSON.stringify({
+        version: 2 /* protocol version, needs to be set to 2 */,
+        method: message,
+      })
     );
+    // we disconnect immediately after sending the message as there's no need
+    // to keep the connection open since we use it on rare occations.
     ws.close();
+  }
+
+  public async reload() {
+    await this.sendMessageToDevice("reload");
+  }
+
+  public async openDevMenu() {
+    await this.sendMessageToDevice("devMenu");
   }
 
   public async getDebuggerURL() {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -267,7 +267,7 @@ export class Metro implements Disposable {
     return initPromise;
   }
 
-  private async sendMessageToDevice(message: "devMenu" | "reload") {
+  private async sendMessageToDevice(method: "devMenu" | "reload") {
     // we use metro's /message websocket endpoint to deliver specifically formatted
     // messages to the device.
     // Metro implements a websocket proxy that proxies messages between connected


### PR DESCRIPTION
In Expo 52, the metro /reload endpoint has been moved to a new location. As a consequence we couldn't perform JS reloads which resulted in the app being stuck in "reloading" state.

This PR updates the way we trigger reload action. A while ago, we switched the mechanism for triggering devMenu to use /message endpoint. This endpoint is also capable of handling reload command. Here, we are swapping out the reload implementation to use the /message websocket endpoint to deliver it. This method is more portable and work across older version while also being supported by expo SDK 52 (given https://github.com/expo/expo/issues/32399 is published)

Fixes #664

### How Has This Been Tested: 
1. Use reloads and dev menu across different projects, specifically older ones like RN 73, expo-go and on Expo 52 (not yet added here as test project)



