### PR TITLE
Refactor throttling logic for async function

### DIFF
--- a/packages/vscode-extension/src/builders/PlatformBuildCache.ts
+++ b/packages/vscode-extension/src/builders/PlatformBuildCache.ts
@@ -112,16 +112,18 @@ export class PlatformBuildCache {
   }
 
   public async calculateFingerprint() {
+    Logger.info("Calculating fingerprint");
     const customFingerprint = await this.calculateCustomFingerprint();
 
     if (customFingerprint) {
+      Logger.info("Using custom fingerprint", customFingerprint);
       return customFingerprint;
     }
 
     const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
       ignorePaths: IGNORE_PATHS,
     });
-    Logger.log(`Workspace fingerprint: '${fingerprint.hash}'`);
+    Logger.info("App folder fingerprint", fingerprint.hash);
     return fingerprint.hash;
   }
 

--- a/packages/vscode-extension/src/builders/PlatformBuildCache.ts
+++ b/packages/vscode-extension/src/builders/PlatformBuildCache.ts
@@ -112,18 +112,18 @@ export class PlatformBuildCache {
   }
 
   public async calculateFingerprint() {
-    Logger.info("Calculating fingerprint");
+    Logger.debug("Calculating fingerprint");
     const customFingerprint = await this.calculateCustomFingerprint();
 
     if (customFingerprint) {
-      Logger.info("Using custom fingerprint", customFingerprint);
+      Logger.debug("Using custom fingerprint", customFingerprint);
       return customFingerprint;
     }
 
     const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
       ignorePaths: IGNORE_PATHS,
     });
-    Logger.info("App folder fingerprint", fingerprint.hash);
+    Logger.debug("App folder fingerprint", fingerprint.hash);
     return fingerprint.hash;
   }
 

--- a/packages/vscode-extension/src/builders/PlatformBuildCache.ts
+++ b/packages/vscode-extension/src/builders/PlatformBuildCache.ts
@@ -123,7 +123,7 @@ export class PlatformBuildCache {
     const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
       ignorePaths: IGNORE_PATHS,
     });
-    Logger.debug("App folder fingerprint", fingerprint.hash);
+    Logger.log("App folder fingerprint", fingerprint.hash);
     return fingerprint.hash;
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -24,7 +24,7 @@ import { extensionContext } from "../utilities/extensionContext";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { DependencyManager } from "../dependency/DependencyManager";
-import { throttle } from "../utilities/throttle";
+import { throttle, throttleAsync } from "../utilities/throttle";
 import { DebugSessionDelegate } from "../debugging/DebugSession";
 import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
@@ -596,7 +596,7 @@ export class Project
     }
   };
 
-  private checkIfNativeChanged = throttle(async () => {
+  private checkIfNativeChanged = throttleAsync(async () => {
     if (!this.isCachedBuildStale && this.projectState.selectedDevice) {
       const platform = this.projectState.selectedDevice.platform;
       const isCacheStale = await PlatformBuildCache.forPlatform(platform).isCacheStale();

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -606,7 +606,7 @@ export class Project
         this.eventEmitter.emit("needsNativeRebuild");
       }
     }
-  }, 300);
+  }, 1000);
 }
 
 function watchProjectFiles(onChange: () => void) {

--- a/packages/vscode-extension/src/utilities/throttle.ts
+++ b/packages/vscode-extension/src/utilities/throttle.ts
@@ -54,8 +54,13 @@ export function throttleAsync<T extends AsyncFn>(func: T, limitMs: number): T {
               timeout = null;
               recentArgs = null;
             } else {
-              // we use 0 timeout here to avoid potentially infinite nesting
-              setTimeout(execute, 0);
+              // if new arguments were provided while the function was executing,
+              // we need to run it again to ensure the last call is executed.
+              // we use setTimeout to avoid potentially infinite recursion, and
+              // to ensure the function is not run more often than once every
+              // `limitMs` milliseconds, we schedule it to run after the provided
+              // limit.
+              setTimeout(execute, limitMs);
             }
           });
       };


### PR DESCRIPTION
When testing Radon I encountered an issue with newly cloned repo in which the IDE would generate an excessive number of npm subprocesses. The issue turned out to be related to fingerprint library, which on some occasions can spawn at least three npm processes. The main problem though was that this problem was amplified by the fact we'd request fingerprint calculation upon the watched files update. Even though the requests were throttled, because they'd take significant time to compute, we'd end up spawning many concurrent processes. This was specifically noticeable at the moment when the project was installing node modules which generates a ton of fs events that resulted in the fingerprint calculation getting triggered.

The solution this PR is implementing is to add a new throttling mechanism for async functions. It is a non-standard mechanism hence we're introducing a new method. The new mechanism is then used to throttle async code that calculates the fingerprint.

The mechanism works by keeping the following constraints:
1) it never allows for the method to be called more often than every X millisecond
2) it never allows for the method to be executed concurrently
3) when called multiple times, it is guaranteed that the latest call with the most recent arguments will be executed

### How Has This Been Tested: 
1. Clone some open source RN project
2. Without installing node modules just open it with the IDE
3. On my laptop before this change, I'd observe an excessive number of npm processes being spawned.


