### PR TITLE
Fix the Debugger.scriptParsed event handling

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -148,7 +148,9 @@ export class DebugAdapter extends DebugSession {
             const consumer = await new SourceMapConsumer(sourceMap);
 
             // We detect when a source map for the entire bundle is loaded by checking if __prelude__ module is present in the sources.
-            const isMainBundle = sourceMap.sources.includes("__prelude__");
+            const isMainBundle = sourceMap.sources.some((source: string) =>
+              source.includes("__prelude__")
+            );
 
             if (isMainBundle) {
               this.sendCDPMessage("Runtime.evaluate", {


### PR DESCRIPTION
This PR fixes the issue with the heuristic checking if the parsed script is the main bundle, in some RN versions the module `__prelude__` is called `/__prelude__ ` instead, so we change the logic to match both possibilities  

### How Has This Been Tested: 
- Run RN 76 test app and set a breakpoint in changed line if on the first pass isMainBundle is true everything works as expected. 



