### PR TITLE
Prevent clicks on device screen behind the UrlBar and SelectDevice

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useState } from "react";
 import * as Select from "@radix-ui/react-select";
 import { DeviceInfo, DevicePlatform } from "../../common/DeviceManager";
 import "./DeviceSelect.css";
@@ -100,6 +100,8 @@ interface DeviceSelectProps {
 }
 
 function DeviceSelect({ onValueChange, devices, value, label, disabled }: DeviceSelectProps) {
+  const [isOpen, setOpen] = useState<boolean>(false);
+
   const { projectState } = useProject();
   const selectedProjectDevice = projectState?.selectedDevice;
 
@@ -111,7 +113,20 @@ function DeviceSelect({ onValueChange, devices, value, label, disabled }: Device
   );
 
   return (
-    <Select.Root onValueChange={onValueChange} value={value}>
+    <Select.Root
+      onValueChange={(newValue) => {
+        onValueChange(newValue);
+        setTimeout(() => {
+          setOpen(!isOpen);
+        }, 0);
+      }}
+      value={value}
+      onOpenChange={() => {
+        setTimeout(() => {
+          setOpen(!isOpen);
+        }, 0);
+      }}
+      open={isOpen}>
       <Select.Trigger className="device-select-trigger" disabled={disabled}>
         <Select.Value placeholder="No devices found">
           <div className="device-select-value">

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useState } from "react";
 import * as Select from "@radix-ui/react-select";
 import "./UrlSelect.css";
 
@@ -29,13 +29,28 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
   // component. This prefix is stripped off when the selected value is passed back
   // through onValueChange.
 
+  const [isOpen, setOpen] = useState<boolean>(false);
+
   const handleValueChange = (newSelection: string) => {
     const stripped = newSelection.replace(/^recent#/, "");
     onValueChange(stripped);
+
+    setTimeout(() => {
+      setOpen(!isOpen);
+    }, 0);
   };
 
   return (
-    <Select.Root onValueChange={handleValueChange} value={value} disabled={disabled}>
+    <Select.Root
+      onValueChange={handleValueChange}
+      value={value}
+      disabled={disabled}
+      onOpenChange={() => {
+        setTimeout(() => {
+          setOpen(!isOpen);
+        }, 0);
+      }}
+      open={isOpen}>
       <Select.Trigger className="url-select-trigger">
         <Select.Value placeholder="/" aria-label={value} />
       </Select.Trigger>


### PR DESCRIPTION
This PR addresses the issue where selecting items from UrlBar or DeviceSelect results in touch events interacting with elements underneath. This is especially problematic when the touch position is above the device screen, unintentionally sending touch to the device.

The likely cause is the Select.Item implementation in Radix's Select. A similar problem was reported in [this Radix issue](https://github.com/radix-ui/primitives/issues/1658). That issue was closed as it was confirmed to be solved since the react-select 2.1.2-rc.8 version. However, updating the package didn't resolve our issue.

The root of the problem is that when an item is clicked, the select value changes so quickly that the popper disappears, causing the touch event to simultaneously click on the element behind it.

To solve it, an `isOpen` state has been added which manages the opening and closing of the Select.Content. This state is modified using `setTimeout` with a duration of `0 ms`, delaying the state update (`setOpen(!isOpen)`) to the end of the JS call stack, which allows the touch event to complete before closing the Select.Content, preventing any accidental clicks.

Fixes  #649 

### How Has This Been Tested: 
- Followed test steps from issue #649, also confirmed on iOS devices, and similarly tested DeviceSelect.


