### PR TITLE
Remove discord section in docs

### DIFF
--- a/packages/docs/docs/getting-started.md
+++ b/packages/docs/docs/getting-started.md
@@ -54,7 +54,3 @@ For troubleshooting and guide on reporting issues head to [troubleshooting](./tr
 ### ⚒️ Extension Development
 
 If you want to develop the extension and contribute updates head to [development](./development.md) section.
-
-## Discord
-
-Make sure to join [Software Mansion](https://swmansion.com) Discord channel using invite link: https://discord.gg/jWhHbxQsPd and contact us to get added to `radon-ide-beta` channel where we discuss issues and communicate our plans and updates.


### PR DESCRIPTION
We no longer have a generic discord channel and instead prefer communication on Github. The discord channel is currently only available for supporter's license holders. Therefore I'm deleting the link to discord to avoid confusion.