### PR TITLE
Update iOS builds to use latest iOS SDK

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -124,7 +124,6 @@ export class BuildManager {
           }
         };
         buildResult = await buildIos(
-          deviceInfo,
           getAppRootFolder(),
           forceCleanBuild,
           cancelToken,

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -5,7 +5,7 @@ import { Logger } from "../Logger";
 import { CancelToken } from "./cancelToken";
 import { BuildIOSProgressProcessor } from "./BuildIOSProgressProcessor";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
-import { IOSDeviceInfo, DevicePlatform } from "../common/DeviceManager";
+import { DevicePlatform } from "../common/DeviceManager";
 import { EXPO_GO_BUNDLE_ID, downloadExpoGo, isExpoGoProject } from "./expoGo";
 import { findXcodeProject, findXcodeScheme, IOSProjectInfo } from "../utilities/xcode";
 import { runExternalBuild } from "./customBuild";


### PR DESCRIPTION
In #587 we updated the way we build iOS apps. We started extracting the SDK from the selected device, and using that for the build. Apparently, the assumption that the installed SDK matches the simulator SDK isn't necessarily correct.

When new SDK is released and xcode is updated, the previous versions of SDK seem to get deleted. This isn't true for simulator runtimes. As a result, simulators can continue to use older runtimes while it is no longer possible for xcodebuild to access these.

In this PR, we are updating iOS build pipeline to use "iphonesimulator" without specifying the exact version. This turns out to be handled well by xcodebuild and allows it to select the most recent, available SDK.

### How Has This Been Tested: 
1. Create iOS device with iOS 17 runtime (make sure you don't have SDK 17 installed by running `xcodebuild -showsdks`
2. Force rebuild the app to make sure the build process starts. 
3. Before this change the build would fail because of missing sdk


