### PR TITLE
Implement reboot functionality

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -336,6 +336,14 @@ export class Project
 
   public async reload(type: ReloadAction): Promise<boolean> {
     this.updateProjectState({ status: "starting" });
+
+    if (type === "reboot") {
+      const deviceInfo = this.projectState.selectedDevice!;
+      await this.start(true, false);
+      await this.selectDevice(deviceInfo);
+      return true;
+    }
+
     const success = (await this.deviceSession?.perform(type)) ?? false;
     if (success) {
       this.updateProjectState({ status: "running" });

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -337,6 +337,7 @@ export class Project
   public async reload(type: ReloadAction): Promise<boolean> {
     this.updateProjectState({ status: "starting" });
 
+    // this action needs to be handled outside of device session as it resets the device session itself
     if (type === "reboot") {
       const deviceInfo = this.projectState.selectedDevice!;
       await this.start(true, false);

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -18,6 +18,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
         "Reload JS": () => project.reload("reloadJs"),
         "Restart app process": () => project.reload("restartProcess"),
         "Reinstall app": () => project.reload("reinstall"),
+        "Reboot": () => project.reload("reboot"),
         "Clean rebuild": () => project.restart(true),
       }}>
       <span className="codicon codicon-refresh" />


### PR DESCRIPTION
This PR add a possibility to reboot the reboot  device, metro and devtools processes without triggering clean build. It was previously only possible by closing and reopening the IDE panel itself. 

This also will provide necessary functionality for  #663

### How Has This Been Tested: 

- run an application and pick "reboot" option from reload dropdown menu


