### PR TITLE
Fix setting a 0 0 coordinate on Android  

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -178,16 +178,17 @@ export class AndroidEmulatorDevice extends DeviceBase {
         "location_mode",
         "3",
       ]);
-      // note that geo fix command takes arguments: $longitude , $latitude so the order is reversed compared to most conventions
-      await exec(ADB_PATH, [
-        "-s",
-        this.serial!,
-        "emu",
-        "geo",
-        "fix",
-        settings.location.longitude.toString(),
-        settings.location.latitude.toString(),
-      ]);
+
+      // This is a work around for the problem with emu geo command not working  when passed, 0 0 coordinates
+      // when provided coordinates are close enough to 0 that the adb assumes they are 0 we pass the smallest
+      // working number instead. Moreover note that geo fix command takes arguments:
+      // $longitude , $latitude so the order is reversed compared to most conventions
+      const areCoordinatesToCloseToZero =
+        Math.abs(settings.location.latitude) < 0.00001 &&
+        Math.abs(settings.location.longitude) < 0.00001;
+      const lat = areCoordinatesToCloseToZero ? "0.00001" : settings.location.latitude.toString();
+      const long = areCoordinatesToCloseToZero ? "0.00001" : settings.location.longitude.toString();
+      await exec(ADB_PATH, ["-s", this.serial!, "emu", "geo", "fix", long, lat]);
     }
     return shouldRestart;
   }


### PR DESCRIPTION
This PR fixes an issue with setting android device GPS coordinates. The command `adb emu geo fix` that we use to set the location has a bug that causes it to not work when coordinates 0 0 are passed. The fix changes 0 0 to 0.00001 0.00001 instead. 

The fix is worthwhile as 0 0 is a natural think to type into the coordinates box when you want to just check is your application responses in any way to the change in location. (this is how the bug was discovered) 

### How Has This Been Tested: 

- run android emulator 
- open google maps 
- change location to 0 0 


