### PR TITLE
Disable react compiler for app wrapper to workaround runtime issues

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -1,3 +1,5 @@
+"use no memo";
+
 const { useContext, useState, useEffect, useRef, useCallback } = require("react");
 const {
   LogBox,

--- a/test-apps/react-native-76/babel.config.js
+++ b/test-apps/react-native-76/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  plugins: [['babel-plugin-react-compiler', {target: '18'}]],
   presets: ['module:@react-native/babel-preset'],
 };

--- a/test-apps/react-native-76/package-lock.json
+++ b/test-apps/react-native-76/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "radon-ide": "^0.0.1",
         "react": "18.3.1",
+        "react-compiler-runtime": "^19.0.0-beta-6fc168f-20241025",
         "react-native": "0.76.0-rc.6"
       },
       "devDependencies": {
@@ -26,7 +27,9 @@
         "@types/react": "^18.2.6",
         "@types/react-test-renderer": "^18.0.0",
         "babel-jest": "^29.6.3",
+        "babel-plugin-react-compiler": "^19.0.0-beta-6fc168f-20241025",
         "eslint": "^8.19.0",
+        "eslint-plugin-react-compiler": "^19.0.0-beta-6fc168f-20241025",
         "jest": "^29.6.3",
         "prettier": "2.8.8",
         "react-test-renderer": "18.3.1",
@@ -601,6 +604,23 @@
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3751,6 +3771,15 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "19.0.0-beta-6fc168f-20241025",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.0.0-beta-6fc168f-20241025.tgz",
+      "integrity": "sha512-wFVeXhF0hkiRe4bEM0jzeTFMlMbcKNTwhXcFvqUIVB6WXf+3vdwOWGWnw7jwvDb2mzvsIZOFt/96itOFt1rwjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.19.0"
+      }
+    },
     "node_modules/babel-plugin-syntax-hermes-parser": {
       "version": "0.23.1",
       "license": "MIT",
@@ -5040,6 +5069,41 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler": {
+      "version": "19.0.0-beta-6fc168f-20241025",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-6fc168f-20241025.tgz",
+      "integrity": "sha512-mHn5tYt9dT4GiXHF5muiz6p+4Lirgi0Oc87N2KrbB/ciSkT+VZ8iJA+6bbS4//ljYzYbxBbPMHWS/dZWhQrbpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "hermes-parser": "^0.20.1",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/hermes-estree": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
+      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/hermes-parser": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
+      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+      "dev": true,
+      "dependencies": {
+        "hermes-estree": "0.20.1"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -8588,6 +8652,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-compiler-runtime": {
+      "version": "19.0.0-beta-6fc168f-20241025",
+      "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-19.0.0-beta-6fc168f-20241025.tgz",
+      "integrity": "sha512-XY5p6GUVaz8P0c/B/2ebqz/xdp0YOtidtOSuiYyQB05fMws0Qys+zubDH7IKQBEtw4AKoCzrJ6ReeTtFLOKniw==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-devtools-core": {
       "version": "5.3.2",
       "license": "MIT",
@@ -10185,6 +10257,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/test-apps/react-native-76/package.json
+++ b/test-apps/react-native-76/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "radon-ide": "^0.0.1",
     "react": "18.3.1",
+    "react-compiler-runtime": "^19.0.0-beta-6fc168f-20241025",
     "react-native": "0.76.0-rc.6"
   },
   "devDependencies": {
@@ -29,7 +30,9 @@
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",
+    "babel-plugin-react-compiler": "^19.0.0-beta-6fc168f-20241025",
     "eslint": "^8.19.0",
+    "eslint-plugin-react-compiler": "^19.0.0-beta-6fc168f-20241025",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "18.3.1",


### PR DESCRIPTION
This PR fixes issue with Radon IDE not working with recent versions of react compiler.

We've been testing Radon with some previous versions of the compiler where this issue didn't occur. I only recently stumbled upon it when testing an app that was using a most recent version of the compiler.

The issue I started seeing is when compiler was enabled, I would get errors about react-compiler-runtime not being a function when accessed from the wrapper component. I'm assuming this has to do with wrapper component being injected by the IDE babel plugin which may confuse babel which while processes the file with react runtime plugin may not properly link the runtime imports which are necessary for React 17 and 18.

For the time being, the fix is to disable react compiler at the wrapper file level. This prevents the file from being processed by the compiler plugin as as a consequence, no runtime imports are added.

This PR also adds compiler to react-native-76 test app so that we can test this easier and avoid potential regressions related to react compiler in the future.

### How Has This Been Tested: 
1. Use RN 76 app with react compiler enable and see it runs ok
2. Before the change in wrapper, the app would get stuck on loading and errors about react-compiler-runtime not being a function were shown in the logs.


