### PR TITLE
Add option to display screen touches

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -13,6 +13,7 @@ export type DeviceSettings = {
   hasEnrolledBiometrics: boolean;
   locale: Locale;
   replaysEnabled: boolean;
+  showTouches: boolean;
 };
 
 export type ProjectState = {

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -44,6 +44,14 @@ export abstract class DeviceBase implements Disposable {
     this.preview?.dispose();
   }
 
+  public showTouches() {
+    return this.preview?.showTouches();
+  }
+
+  public hideTouches() {
+    return this.preview?.hideTouches();
+  }
+
   public stopReplays() {
     return this.preview?.stopReplays();
   }

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -94,6 +94,14 @@ export class Preview implements Disposable {
     });
   }
 
+  public showTouches() {
+    this.subprocess?.stdin?.write("pointer show true\n");
+  }
+
+  public hideTouches() {
+    this.subprocess?.stdin?.write("pointer show false\n");
+  }
+
   public startReplays() {
     const stdin = this.subprocess?.stdin;
     if (!stdin) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -152,6 +152,9 @@ export class DeviceSession implements Disposable {
     if (this.deviceSettings?.replaysEnabled) {
       this.device.startReplays();
     }
+    if (this.deviceSettings?.showTouches) {
+      this.device.showTouches();
+    }
 
     const launchDurationSec = (Date.now() - launchRequestTime) / 1000;
     Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");
@@ -298,6 +301,11 @@ export class DeviceSession implements Disposable {
       this.device.startReplays();
     } else {
       this.device.stopReplays();
+    }
+    if (settings.showTouches && !this.isLaunching) {
+      this.device.showTouches();
+    } else {
+      this.device.hideTouches();
     }
     return this.device.changeSettings(settings);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -79,6 +79,7 @@ export class Project
       hasEnrolledBiometrics: false,
       locale: "en_US",
       replaysEnabled: false,
+      showTouches: false,
     };
     this.devtools = new Devtools();
     this.metro = new Metro(this.devtools, this);

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -155,7 +155,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
-          <Label>Screen recording</Label>
+          <Label>Screen settings</Label>
           <div className="dropdown-menu-item">
             <span className="icons-container">
               <span className="codicon codicon-triangle-left icons-rewind" />
@@ -169,6 +169,20 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
                 project.updateDeviceSettings({ ...deviceSettings, replaysEnabled: checked })
               }
               defaultChecked={deviceSettings.replaysEnabled}
+              style={{ marginLeft: "5px" }}>
+              <Switch.Thumb className="switch-thumb" />
+            </Switch.Root>
+          </div>
+          <div className="dropdown-menu-item">
+            <span className="codicon codicon-record" />
+            Show Touches
+            <Switch.Root
+              className="switch-root small-switch"
+              id="enable-replays"
+              onCheckedChange={(checked) =>
+                project.updateDeviceSettings({ ...deviceSettings, showTouches: checked })
+              }
+              defaultChecked={deviceSettings.showTouches}
               style={{ marginLeft: "5px" }}>
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -169,7 +169,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
                 project.updateDeviceSettings({ ...deviceSettings, replaysEnabled: checked })
               }
               defaultChecked={deviceSettings.replaysEnabled}
-              style={{ marginLeft: "5px" }}>
+              style={{ marginLeft: "auto" }}>
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>
           </div>
@@ -183,7 +183,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
                 project.updateDeviceSettings({ ...deviceSettings, showTouches: checked })
               }
               defaultChecked={deviceSettings.showTouches}
-              style={{ marginLeft: "5px" }}>
+              style={{ marginLeft: "auto" }}>
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>
           </div>

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -28,6 +28,7 @@ const defaultDeviceSettings: DeviceSettings = {
   },
   locale: "en_US",
   replaysEnabled: false,
+  showTouches: false,
 };
 
 const ProjectContext = createContext<ProjectContextProps>({


### PR DESCRIPTION
This PR add option to show touches on the device screen and on replays.

As part of this PR:
1) We're updating simulator server version to include changes necessary for drawing touch pointers
2) We're adding new device setting for showing touches
3) We're renaming "screen recording" section to "screen settings" as it now includes both "screen recording" and "show touches" options.

### How Has This Been Tested: 
1. Run one of the test apps
2. Enable show touches -> start pressing the screen to see touch indicator
3. Record video to see the indicator being visible on the recording
4. Disable show touches option to see them gone
