### PR TITLE
Bring back ability to reveal preview when stuck on waiting

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -105,7 +105,7 @@ export class DeviceSession implements Disposable {
     throw new Error("Not implemented " + type);
   }
 
-  private async launchApp(previewReadyCallback: PreviewReadyCallback) {
+  private async launchApp(previewReadyCallback?: PreviewReadyCallback) {
     const launchRequestTime = Date.now();
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
       platform: this.device.platform,
@@ -144,7 +144,7 @@ export class DeviceSession implements Disposable {
       this.metro.ready(),
       this.device.startPreview().then((url) => {
         previewURL = url;
-        previewReadyCallback(url);
+        previewReadyCallback && previewReadyCallback(url);
       }),
       waitForAppReady,
     ]);

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -597,8 +597,8 @@ export class Project
 
       const previewURL = await newDeviceSession.start(this.deviceSettings, {
         cleanBuild: forceCleanBuild,
-        previewReadyCallback: (previewURL) => {
-          this.updateProjectStateForDevice(deviceInfo, { previewURL });
+        previewReadyCallback: (url) => {
+          this.updateProjectStateForDevice(deviceInfo, { previewURL: url });
         },
       });
       this.updateProjectStateForDevice(this.projectState.selectedDevice!, {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -597,6 +597,9 @@ export class Project
 
       const previewURL = await newDeviceSession.start(this.deviceSettings, {
         cleanBuild: forceCleanBuild,
+        previewReadyCallback: (previewURL) => {
+          this.updateProjectStateForDevice(deviceInfo, { previewURL });
+        },
       });
       this.updateProjectStateForDevice(this.projectState.selectedDevice!, {
         previewURL,


### PR DESCRIPTION
In #475 we accidently broke the functionality that'd allow users to tap on "waiting for app to load" text in order to reveal the device preview.

This option was pretty handy specifically to troubleshoot issues when app gets stuck because of expo devclient onboarding dialog.

This PR brings back the callback-based code that got removed in #475 with small adjustments as the underlying implementation from deviceSession got split into two separate methods in the meantime.

### How Has This Been Tested: 
1. Run expo dev client 51
2. Use "reinstall app" option, the app would get stuck on the waiting to load screen
3. Click on the "waiting to load" text to reveal preview – after this change you should be able to see the preview, without this change the button would do nothing as the frontend code doesn't have access to the preview URL until the app is fully launched.


