### PR TITLE
Fix metro cache issue when running project from CLI and IDE interchangeably

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -1,4 +1,4 @@
-const ORIGINAL_TRANSFORMER_PATH = process.env.REACT_NATIVE_IDE_ORIG_BABEL_TRANSFORMER_PATH;
+const ORIGINAL_TRANSFORMER_PATH = process.env.RADON_IDE_ORIG_BABEL_TRANSFORMER_PATH;
 const path = require("path");
 const { requireFromAppDir, overrideModuleFromAppDir } = require("./metro_helpers");
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -121,7 +121,7 @@ export type RecordingData = {
 export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
   reload(type: ReloadAction): Promise<boolean>;
-  restart(forceCleanBuild: boolean): Promise<void>;
+  restart(clean: "all" | "metro" | false): Promise<void>;
   goHome(homeUrl: string): Promise<void>;
   selectDevice(deviceInfo: DeviceInfo): Promise<boolean>;
   renameDevice(deviceInfo: DeviceInfo, newDisplayName: string): Promise<void>;

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import WebSocket from "ws";
-import { Disposable, Uri, workspace } from "vscode";
+import { Disposable, ExtensionMode, Uri, workspace } from "vscode";
 import stripAnsi from "strip-ansi";
 import { exec, ChildProcess, lineReader } from "../utilities/subprocess";
 import { Logger } from "../Logger";
@@ -191,6 +191,7 @@ export class Metro implements Disposable {
     if (launchConfiguration.metroConfigPath) {
       metroConfigPath = findCustomMetroConfig(launchConfiguration.metroConfigPath);
     }
+    const isExtensionDev = extensionContext.extensionMode === ExtensionMode.Development;
     const metroEnv = {
       ...launchConfiguration.env,
       ...(metroConfigPath ? { RN_IDE_METRO_CONFIG_PATH: metroConfigPath } : {}),
@@ -199,6 +200,7 @@ export class Metro implements Disposable {
       RCT_DEVTOOLS_PORT: this.devtools.port.toString(),
       RADON_IDE_LIB_PATH: libPath,
       RADON_IDE_VERSION: extensionContext.extension.packageJSON.version,
+      ...(isExtensionDev ? { RADON_IDE_DEV: "1" } : {}),
     };
     let bundlerProcess: ChildProcess;
 

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -197,7 +197,8 @@ export class Metro implements Disposable {
       NODE_PATH: path.join(appRootFolder, "node_modules"),
       RCT_METRO_PORT: "0",
       RCT_DEVTOOLS_PORT: this.devtools.port.toString(),
-      REACT_NATIVE_IDE_LIB_PATH: libPath,
+      RADON_IDE_LIB_PATH: libPath,
+      RADON_IDE_VERSION: extensionContext.extension.packageJSON.version,
     };
     let bundlerProcess: ChildProcess;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -278,7 +278,7 @@ export class Project
 
   //#region Session lifecycle
   public async restart(
-    forceCleanBuild: boolean,
+    clean: "all" | "metro" | false,
     onlyReloadJSWhenPossible: boolean = true,
     restartDevice: boolean = false
   ) {
@@ -295,9 +295,9 @@ export class Project
 
     // we first consider forceCleanBuild flag, if set we always perform a clean
     // start of the project and select the device
-    if (forceCleanBuild) {
+    if (clean) {
       await this.start(true, true);
-      await this.selectDevice(deviceInfo, true);
+      await this.selectDevice(deviceInfo, clean === "all");
       return;
     }
 
@@ -348,7 +348,7 @@ export class Project
     return success;
   }
 
-  private async start(restart: boolean, forceCleanBuild: boolean) {
+  private async start(restart: boolean, resetMetroCache: boolean) {
     if (restart) {
       const oldDevtools = this.devtools;
       const oldMetro = this.metro;
@@ -365,7 +365,7 @@ export class Project
 
     Logger.debug(`Launching metro`);
     this.metro.start(
-      forceCleanBuild,
+      resetMetroCache,
       throttle((stageProgress: number) => {
         this.reportStageProgress(stageProgress, StartupMessage.WaitingForAppToLoad);
       }, 100),

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -18,7 +18,8 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
         "Reload JS": () => project.reload("reloadJs"),
         "Restart app process": () => project.reload("restartProcess"),
         "Reinstall app": () => project.reload("reinstall"),
-        "Clean rebuild": () => project.restart(true),
+        "Clear metro cache": () => project.restart("metro"),
+        "Clean rebuild": () => project.restart("all"),
       }}>
       <span className="codicon codicon-refresh" />
     </IconButtonWithOptions>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -18,7 +18,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
         "Reload JS": () => project.reload("reloadJs"),
         "Restart app process": () => project.reload("restartProcess"),
         "Reinstall app": () => project.reload("reinstall"),
-        "Clear metro cache": () => project.restart("metro"),
+        "Clear Metro cache": () => project.restart("metro"),
         "Clean rebuild": () => project.restart("all"),
       }}>
       <span className="codicon codicon-refresh" />

--- a/packages/vscode-extension/src/webview/hooks/useNativeRebuildAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useNativeRebuildAlert.tsx
@@ -14,7 +14,7 @@ function Actions({ closeAlert }: Props) {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.restart(true);
+          project.restart("all");
           closeAlert();
         }}
         tooltip={{ label: "Rebuild", side: "bottom" }}>


### PR DESCRIPTION
When working on a single project with IDE and from CLI interchangeably, metro cache may cause bundling issue because of the way we override files in babel transformer. This can happen when transformed output of certain files, for which we modify the source code is cached. Although I couldn't find a reliable way of reproducing this problem, it seem to randomly pop up when building from CLI and then using the IDE, and can surface via the CLI bundler or the IDE bundler.

To workaround this problem, we are using cacheVersion metro configuration option. This lets the IDE to generate its own, unique cache keys such that to avoid cache collisions between the metro started via CLI and in the IDE. 

Here's a breakdown of changes we're making here:
1) We're adding cacheVersion config option to metro
2) We're adding blockList option to metro's resolver, as fixing the cache issue revealed another issue with metro resolving files from under the extension directory when used with expo's fast resolver option (EXPO_USE_FAST_RESOLVER)
3) We're adding an option to restart the project with metro cache reset – this way to provide an easy troubleshooting step for the cases when this or some other metro cache related issue occurs

We're also renaming some env variables starting with REACT_NATIVE_IDE to RADON_IDE that I discovered in the metro config code.

### How Has This Been Tested: 
1) I used a new create-expo-stack project with tailwind, expo-dev-client (SDK 51) and EXPO_USE_FAST_RESOLVER option
2) Build the project from CLI and IDE interchangeably several times until you start getting weird bundle errors
3) After this change, it should no longer happen
4) Test "Clear metro cache" option and see that it restarts the process, make sure the native build doesn't trigger and also that it takes longer to bundle first time it loads after this option is selected


