### PR TITLE
Fix debugger threads not being cleaned up properly

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -190,8 +190,19 @@ export class DebugAdapter extends DebugSession {
           this.sendEvent(new ContinuedEvent(this.threads[0].id));
           break;
         case "Runtime.executionContextsCleared":
+          // clear all existing threads, source maps, and variable store
+          const allThreads = this.threads;
+          this.threads = [];
+          this.sourceMaps = [];
           this.variableStore.clearReplVariables();
           this.variableStore.clearCDPVariables();
+
+          // send events for all threads that exited
+          allThreads.forEach((thread) => {
+            this.sendEvent(new ThreadEvent("exited", thread.id));
+          });
+
+          // send event to clear console
           this.sendEvent(new OutputEvent("\x1b[2J", "console"));
           break;
         case "Runtime.consoleAPICalled":


### PR DESCRIPTION
This PR adds a proper cleanup of debugger threads and source maps when the runtime is cleared fixing the issue where multiple hermes instances would appear in the threads section of the debugger after reloads.

Fixes #703

In this PR we utilize the `Runtime.executionContextsCleared` CDP message to delete virtual threads that we create in `Runtime.executionContextCreated` to track hermes VM instances.

We also update that message handler to clear source maps object as it is associated with the running VM, so when the VM reloads we need to propagate source maps again (which already happens).

### How Has This Been Tested: 
1. With old and new debugger (i.e. on RN76 and epxo-router projects) try the below
2. Set breakpoint, make sure the debugger stops
3. Reload JS several times
4. Observe there are no additional hermes instances getting listed in call stack section of the debugger tab
5. Make sure the breakpoint still function after the reloads.



