### PR TITLE
Fix appearance on high contrast themes

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -137,7 +137,8 @@
 }
 
 /* Light theme */
-body[data-vscode-theme-kind="vscode-light"] {
+body[data-vscode-theme-kind="vscode-light"],
+body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-active-item: var(--blue-dark-100);
   --swm-preview-background: var(--white);
 
@@ -294,7 +295,8 @@ body[data-vscode-theme-kind="vscode-light"] {
 }
 
 /* Dark theme */
-body[data-vscode-theme-kind="vscode-dark"] {
+body[data-vscode-theme-kind="vscode-dark"],
+body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-active-item: var(--blue-dark-100);
   --swm-preview-background: var(--background-dark-100);
 


### PR DESCRIPTION
Fixes #702 

### Screens

<img width="1507" alt="Zrzut ekranu 2024-11-7 o 18 36 29" src="https://github.com/user-attachments/assets/d5c1235a-d9f0-439a-9a03-57c41a8b6cbb">
<img width="1510" alt="Zrzut ekranu 2024-11-7 o 18 35 49" src="https://github.com/user-attachments/assets/1a6fb6ed-6608-49b9-bbcb-859b078fc6ae">

### How Has This Been Tested: 

Set theme to `Dark High Contrast` or `Light High Contrast` in vscode and open any app in extension. Check appearance of component:
- any dialog/modal
- any popup
- tooltips
- buttons
- inspector menu
- inspector overlay
- device settings
- manage devices
- replay overlay
- replay UI



