### PR TITLE
Fix preview on RN 76

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -69,7 +69,7 @@ function useAgentListener(agent, eventName, listener, deps = []) {
   }, [agent, ...deps]);
 }
 
-export function AppWrapper({ children, initialProps, ..._rest }) {
+export function AppWrapper({ children, initialProps, fabric }) {
   const rootTag = useContext(RootTagContext);
   const [devtoolsAgent, setDevtoolsAgent] = useState(null);
   const [hasLayout, setHasLayout] = useState(false);
@@ -102,13 +102,14 @@ export function AppWrapper({ children, initialProps, ..._rest }) {
     (previewKey) => {
       AppRegistry.runApplication(InternalImports.PREVIEW_APP_KEY, {
         rootTag,
-        initialProps: { previewKey },
+        initialProps: { ...initialProps, previewKey },
+        fabric,
       });
       const preview = global.__RNIDE_previews.get(previewKey);
       const urlPrefix = previewKey.startsWith("sb://") ? "sb:" : "preview:";
       handleNavigationChange({ id: previewKey, name: urlPrefix + preview.name });
     },
-    [rootTag, handleNavigationChange]
+    [rootTag, handleNavigationChange, initialProps, fabric]
   );
 
   const closePreview = useCallback(() => {


### PR DESCRIPTION
This PR fixes problem with preview functionality being broken on React Native 76 (and on Fabric specifically).

The root cause was in the missing parameters we send to AppRegistry.runApplication
On React Native 76, the renderer expects to receive `fabric` parameter and also optionally `concurrentRoot` parameter that is placed under `initialProps` objects. Because of the fact both of those parameters were missing, rendering of the Preview container would throw weird error about missing createElement and similar methods.

The fix is to capture `initialProps` and `fabric` attributes from the original app wrapper, and forward them when calling AppRegistry.runApplication later on.

### How Has This Been Tested: 
1. Open RN 76 example
2. Launch preview – before nothing would happen and there'd be a wall of errors in the console. Now preview renders ok. Note that there's another preview related issue, so you need to make sure `preview` call and the component it renders are defined on the same line.


