### PR TITLE
Properly match line number to fix multi-line previews

### DIFF
--- a/packages/vscode-extension/src/providers/PreviewCodeLensProvider.ts
+++ b/packages/vscode-extension/src/providers/PreviewCodeLensProvider.ts
@@ -80,11 +80,13 @@ export class PreviewCodeLensProvider implements CodeLensProvider {
   }
 
   addPreviewCodeLenses(text: string, document: TextDocument, codeLenses: CodeLens[]) {
-    // Detect usage of the preview function followed by an opening parenthesis
-    // which are not preceded by double slashes indicating a comment. Detected example: preview(
-    const previewRegex = /^(?:(?!\/\/) )*\bpreview\b\s*\(/gm;
+    // Detect usage of the 'preview(' function followed by '<' character representing JSX opening tag.
+    // Elliminate lines that contain double slashes indicating a comment.
+    const previewRegex = /^(?:(?!\/\/) )*preview\(\s*<\s*/gm;
     for (const match of text.matchAll(previewRegex)) {
-      const range = this.createRange(document, match.index);
+      // for the range, we are interested in line where the JSX tag starts, hence we check the last index
+      // of the matched regex.
+      const range = this.createRange(document, match.index + match[0].length - 1);
       const command: Command = {
         title: "Open preview",
         command: "RNIDE.showPanel",


### PR DESCRIPTION
This PR fixes an issue with previews that span multiple lines, for example:
```tsx
preview(
  <Button
    title="Button"
    onPress={() => {
      console.log('Hello');
    }}
  />,
);
```

Opening this issue would previously result in no interaction and an error about missing name would be displayed in the console.

The root cause of the issue is the mismatch between line numbers which codelens provider uses for requesting preview render, and the line number the preview uses to register. In the previous implementation when rendering preview, we'd request it using filename and line number of where `preview` instruction was used. On the other hand, when registering preview components, we use the line where component is defined (this is a line number extracted by the JSX transformer)

This worked ok for components that would be placed in the same line, for example:
```tsx
preview(<NiceButton color="blue" />);
```

But, for multi-line previews as shown above, the tag can be in a different line.

The fix is to update codelens provider to not just match `preview(` but also look for the opening JSX tag ('<' character). We then use the location of the opening JSX tag as the line where the preview is expected.

Fixes  #690

### How Has This Been Tested: 
1. Open RN 76 example where multi-line preview is used on MainScreen
2. Launch the multi line preview
3. Add another single-line one, and make sure it works
4. Add preview that's commented out to verify it's not being picked up by the codelens provider

