### PR TITLE
Fix light theme shadows

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -122,7 +122,7 @@ function DeviceSelect({ onValueChange, devices, value, label, disabled }: Device
       </Select.Trigger>
 
       <Select.Portal>
-        <Select.Content className="device-select-content dropdown-menu-content" position="popper">
+        <Select.Content className="device-select-content" position="popper">
           <Select.ScrollUpButton className="device-select-scroll">
             <span className="codicon codicon-chevron-up" />
           </Select.ScrollUpButton>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -66,7 +66,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
           <Label>Device appearance</Label>
           <form>
             <RadioGroup.Root
-              className="dropdown-menu-content radio-group-root"
+              className="radio-group-root"
               defaultValue={deviceSettings.appearance}
               onValueChange={(value) => {
                 project.updateDeviceSettings({


### PR DESCRIPTION
This PR removes unnecessary shadow inside the device settings dropdown and manage devices select on light mode. 

This visual change shouldn't have any effect on the dark mode.

## Before


<img width="343" alt="Screenshot 2024-11-08 at 13 59 14" src="https://github.com/user-attachments/assets/ce2ae576-6a22-40d6-841e-0f54f2c706dc">

![image](https://github.com/user-attachments/assets/b73d37aa-0ae0-4d08-ab99-19611b2636d5)



## After
<img width="321" alt="Screenshot 2024-11-08 at 13 56 39" src="https://github.com/user-attachments/assets/cc547160-c617-4d01-9fe4-3ab064ec7059">


<img width="302" alt="Screenshot 2024-11-08 at 13 56 31" src="https://github.com/user-attachments/assets/2daa5e1a-4823-46bd-ae3f-c341761f8268">


## How to test

Run the extension on both light and dark mode to test.

