### PR TITLE
Fix Eas builds on Android

### DIFF
--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -64,6 +64,13 @@ async function fetchBuild(config: EasConfig, platform: DevicePlatform) {
 
   const build = maxBy(builds, "completedAt")!;
 
+  if (!build.binaryUrl.endsWith(".apk") && !build.binaryUrl.endsWith(".apex")) {
+    Logger.error(
+      `EAS build artefact needs to be in .apk or .apex format to work with the Radon IDE, make sure you set up eas to use "development" profile`
+    );
+    return undefined;
+  }
+
   Logger.debug(`Using EAS build artifact with ID ${build.id}.`);
   return build;
 }
@@ -80,7 +87,10 @@ async function downloadAppFromEas(
   const { id, binaryUrl } = build;
 
   const tmpDirectory = await mkdtemp(path.join(os.tmpdir(), "rn-ide-eas-build-"));
-  const binaryPath = path.join(tmpDirectory, id);
+  const binaryPath =
+    platform === DevicePlatform.Android
+      ? path.join(tmpDirectory, `${id}.apk`)
+      : path.join(tmpDirectory, id);
 
   const success = await downloadBinary(binaryUrl, binaryPath);
   if (!success) {

--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -66,7 +66,7 @@ async function fetchBuild(config: EasConfig, platform: DevicePlatform) {
 
   if (!build.binaryUrl.endsWith(".apk") && !build.binaryUrl.endsWith(".apex")) {
     Logger.error(
-      `EAS build artefact needs to be in .apk or .apex format to work with the Radon IDE, make sure you set up eas to use "development" profile`
+      `EAS build artifact needs to be a development build in .apk or .apex format to work with the Radon IDE, make sure you set up eas to use "development" profile`
     );
     return undefined;
   }

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -33,9 +33,9 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
         return {};
       }
 
-      const { android, appRoot, ios, isExpo, metroConfigPath, env } = RNIDEConfiguration;
+      const { android, appRoot, ios, isExpo, metroConfigPath, env, eas } = RNIDEConfiguration;
 
-      return { android, appRoot, ios, isExpo, metroConfigPath, env };
+      return { android, appRoot, ios, isExpo, metroConfigPath, env, eas };
     };
 
     this.config = getCurrentConfig();

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -30,7 +30,8 @@ function BuildErrorActions({
         onClick={() => {
           if (logsButtonDestination === "extension") {
             project.focusExtensionLogsOutput();
-            return;
+          } else {
+            project.focusBuildOutput();
           }
           project.focusBuildOutput();
         }}

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -8,7 +8,11 @@ import { useLaunchConfig } from "../providers/LaunchConfigProvider";
 import { useDependencies } from "../providers/DependenciesProvider";
 import { DevicePlatform } from "../../common/DeviceManager";
 
-function BuildErrorActions() {
+function BuildErrorActions({
+  logsButtonDestination,
+}: {
+  logsButtonDestination?: "build" | "extension";
+}) {
   const { project } = useProject();
   const { openModal } = useModal();
   return (
@@ -24,6 +28,10 @@ function BuildErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
+          if (logsButtonDestination === "extension") {
+            project.focusExtensionLogsOutput();
+            return;
+          }
           project.focusBuildOutput();
         }}
         tooltip={{ label: "Open build logs", side: "bottom" }}>
@@ -42,11 +50,12 @@ function BuildErrorActions() {
 }
 
 export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
-  const { ios, xcodeSchemes } = useLaunchConfig();
+  const { ios, xcodeSchemes, eas } = useLaunchConfig();
   const { dependencies } = useDependencies();
   const { projectState } = useProject();
 
   let description = "Open build logs to find out what went wrong.";
+  let actions = <BuildErrorActions />;
 
   if (!ios?.scheme && xcodeSchemes.length > 1) {
     description = `Your project uses multiple build schemas. Currently used scheme: '${xcodeSchemes[0]}'. You can change it in the launch configuration.`;
@@ -68,11 +77,20 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
       'Your project does not have "ios" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure external build source using launch configuration.';
   }
 
+  const isEasBuild =
+    (!!eas?.android && projectState.selectedDevice?.platform === DevicePlatform.Android) ||
+    (!!eas?.ios && projectState.selectedDevice?.platform === DevicePlatform.IOS);
+
+  if (isEasBuild) {
+    description = "Your Project Eas build has failed, see extension logs to see what went wrong.";
+    actions = <BuildErrorActions logsButtonDestination="extension" />;
+  }
+
   const buildErrorAlert = {
     id: "build-error-alert",
     title: "Cannot run project",
     description,
-    actions: <BuildErrorActions />,
+    actions,
   };
 
   useToggleableAlert(shouldDisplayAlert, buildErrorAlert);

--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { makeProxy } from "../utilities/rpc";
 import {
+  EasConfig,
   LaunchConfig,
   LaunchConfigUpdater,
   LaunchConfigurationOptions,
@@ -18,11 +19,16 @@ const launchConfig = makeProxy<LaunchConfig>("LaunchConfig");
 type LaunchConfigContextType = LaunchConfigurationOptions & {
   update: LaunchConfigUpdater;
   xcodeSchemes: string[];
+  eas?: {
+    ios?: EasConfig;
+    android?: EasConfig;
+  };
 };
 
 const LaunchConfigContext = createContext<LaunchConfigContextType>({
   update: () => {},
   xcodeSchemes: [],
+  eas: {},
 });
 
 export default function LaunchConfigProvider({ children }: PropsWithChildren) {

--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -28,7 +28,6 @@ type LaunchConfigContextType = LaunchConfigurationOptions & {
 const LaunchConfigContext = createContext<LaunchConfigContextType>({
   update: () => {},
   xcodeSchemes: [],
-  eas: {},
 });
 
 export default function LaunchConfigProvider({ children }: PropsWithChildren) {


### PR DESCRIPTION
This PR adds additional user facing information about eas builds, to let users know when production build is used instead of development one. More over eas build crashes are getting a new build error alert description to redirect users to Radon IDE log instead of non existing build logs.

Finally this PR adds .apk file extension to android packages to avoid errors with tools we use to install and uninstall application on device.

Fixes android portion of  #678

### How Has This Been Tested: 

Run an application using eas on android using production and development profiles. 



