### PR TITLE
Add useInspector hook

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -163,20 +163,7 @@ function getInspectorDataForCoordinates(mainContainerRef, x, y, requestStack, ca
     mainContainerRef.current,
     x * screenWidth,
     y * screenHeight,
-    (viewData) => {
-      const frame = viewData.frame;
-      const scaledFrame = scaleFrame({
-        x: frame.left,
-        y: frame.top,
-        width: frame.width,
-        height: frame.height
-      });
-
-      if (!requestStack) {
-        callback({ frame: scaledFrame });
-        return;
-      }
-
+    (viewData) =>
       Promise.all(traverseComponentsTreeUp(viewData.closestInstance, []))
         .then((stack) => stack.filter(Boolean))
         .then((stack) => 
@@ -185,11 +172,7 @@ function getInspectorDataForCoordinates(mainContainerRef, x, y, requestStack, ca
             frame: scaleFrame(stackElement.frame)
           }))
         ).then((scaledStack) => 
-          callback({
-            frame: scaledFrame,
-            stack: scaledStack
-          }));
-      }
+          callback({ stack: scaledStack }))
   );
 };
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -75,7 +75,7 @@ export type Frame = {
   height: number;
 };
 
-export type InspectDataStackItem = {
+export type InspectElement = {
   componentName: string;
   hide: boolean;
   source: {
@@ -86,14 +86,9 @@ export type InspectDataStackItem = {
   frame: Frame;
 };
 
-export type InspectStackData = {
-  requestLocation: { x: number; y: number };
-  stack: InspectDataStackItem[];
-};
-
 export type InspectData = {
-  stack: InspectDataStackItem[] | undefined;
-  frame: Frame;
+  requestLocation?: { x: number; y: number };
+  stack: InspectElement[]
 };
 
 export type TouchPoint = {
@@ -153,7 +148,6 @@ export interface ProjectInterface {
   inspectElementAt(
     xRatio: number,
     yRatio: number,
-    requestStack: boolean,
     callback: (inspectData: InspectData) => void
   ): Promise<void>;
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -88,7 +88,7 @@ export type InspectElement = {
 
 export type InspectData = {
   requestLocation?: { x: number; y: number };
-  stack: InspectElement[]
+  stack: InspectElement[];
 };
 
 export type TouchPoint = {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -273,11 +273,7 @@ export class DeviceSession implements Disposable {
     return this.device.sendPaste(text);
   }
 
-  public inspectElementAt(
-    xRatio: number,
-    yRatio: number,
-    callback: (inspectData: any) => void
-  ) {
+  public inspectElementAt(xRatio: number, yRatio: number, callback: (inspectData: any) => void) {
     const id = this.inspectCallID++;
     const listener = (event: string, payload: any) => {
       if (event === "RNIDE_inspectData" && payload.id === id) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -276,7 +276,6 @@ export class DeviceSession implements Disposable {
   public inspectElementAt(
     xRatio: number,
     yRatio: number,
-    requestStack: boolean,
     callback: (inspectData: any) => void
   ) {
     const id = this.inspectCallID++;
@@ -287,7 +286,7 @@ export class DeviceSession implements Disposable {
       }
     };
     this.devtools?.addListener(listener);
-    this.devtools.send("RNIDE_inspect", { x: xRatio, y: yRatio, id, requestStack });
+    this.devtools.send("RNIDE_inspect", { x: xRatio, y: yRatio, id });
   }
 
   public openNavigation(id: string) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -409,12 +409,11 @@ export class Project
   public async inspectElementAt(
     xRatio: number,
     yRatio: number,
-    requestStack: boolean,
     callback: (inspectData: InspectData) => void
   ) {
-    this.deviceSession?.inspectElementAt(xRatio, yRatio, requestStack, (inspectData) => {
+    this.deviceSession?.inspectElementAt(xRatio, yRatio, (inspectData) => {
       let stack = undefined;
-      if (requestStack && inspectData?.stack) {
+      if (inspectData?.stack) {
         stack = inspectData.stack;
         const inspectorExcludePattern = workspace
           .getConfiguration("RadonIDE")
@@ -432,7 +431,7 @@ export class Project
           }
         });
       }
-      callback({ frame: inspectData.frame, stack });
+      callback({ stack });
     });
   }
 

--- a/packages/vscode-extension/src/webview/components/DimensionsBox.tsx
+++ b/packages/vscode-extension/src/webview/components/DimensionsBox.tsx
@@ -14,7 +14,7 @@ const VERTICAL_ARROW_MARGIN = 0.015;
 const HORIZONTAL_ARROW_MARGIN = 0.03;
 
 type DimensionsBoxProps = {
-  inspector: Inspector
+  inspector: Inspector;
   wrapperDivRef: React.RefObject<HTMLDivElement>;
 };
 
@@ -64,7 +64,7 @@ function DimensionsBox({ inspector, wrapperDivRef }: DimensionsBoxProps) {
     return "inside";
   })();
 
-  console.log('fractionalDimensionsBox boxPosition', boxPosition);
+  console.log("fractionalDimensionsBox boxPosition", boxPosition);
 
   const positionalProps = (() => {
     switch (boxPosition) {
@@ -83,7 +83,9 @@ function DimensionsBox({ inspector, wrapperDivRef }: DimensionsBoxProps) {
       case "right":
         return {
           "--top": `${(fractionalDim.top + fractionalDim.height / 2) * 100}%`,
-          "--left": `${(fractionalDim.left + fractionalDim.width + HORIZONTAL_ARROW_MARGIN) * 100}%`,
+          "--left": `${
+            (fractionalDim.left + fractionalDim.width + HORIZONTAL_ARROW_MARGIN) * 100
+          }%`,
           "--box-transform": "translate(0%, -50%)",
         };
       case "left":

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -54,7 +54,7 @@ export function InspectDataMenu({
   const [shouldShowAll, setShouldShowAll] = useState(false);
 
   const { focusedElement, inspectData } = inspector;
-  
+
   if (!focusedElement || !inspectData?.requestLocation) {
     return;
   }

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -14,10 +14,7 @@ import PreviewLoader from "./PreviewLoader";
 import { useBuildErrorAlert, useBundleErrorAlert } from "../hooks/useBuildErrorAlert";
 import Debugger from "./Debugger";
 import { useNativeRebuildAlert } from "../hooks/useNativeRebuildAlert";
-import {
-  RecordingData,
-  ZoomLevelType,
-} from "../../common/Project";
+import { RecordingData, ZoomLevelType } from "../../common/Project";
 import { useResizableProps } from "../hooks/useResizableProps";
 import ZoomControls from "./ZoomControls";
 import { Platform } from "../providers/UtilsProvider";
@@ -499,7 +496,6 @@ function Preview({
   const normalTouchIndicatorSize = 33;
   const smallTouchIndicatorSize = 9;
 
-
   function getPhoneInspectOverlay() {
     const { focusedElement } = inspector;
 
@@ -520,10 +516,7 @@ function Preview({
             height: `${inspectArea.height * 100}%`,
           }}
         />
-        <DimensionsBox
-          inspector={inspector}
-          wrapperDivRef={wrapperDivRef}
-        />
+        <DimensionsBox inspector={inspector} wrapperDivRef={wrapperDivRef} />
       </div>
     );
   }
@@ -581,7 +574,7 @@ function Preview({
                   </div>
                 )}
 
-                {!replayData && getPhoneInspectOverlay() }
+                {!replayData && getPhoneInspectOverlay()}
 
                 {projectStatus === "refreshing" && (
                   <div className="phone-screen phone-refreshing-overlay">

--- a/packages/vscode-extension/src/webview/hooks/useInspector.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useInspector.tsx
@@ -6,34 +6,34 @@ import { useProject } from "../providers/ProjectProvider";
 import { DeviceProperties } from "../utilities/consts";
 
 export type InspectArea = {
-  left: number,
-  top: number,
-  width: number,
-  height: number,
+  left: number;
+  top: number;
+  width: number;
+  height: number;
 };
 
 export interface InspectorProps {
-  deviceProperties?: DeviceProperties,
-  onInspectElementLeftClicked: (item: InspectElement | undefined) => void,
-  onInspectElementRightClicked: (item: InspectElement | undefined) => void
+  deviceProperties?: DeviceProperties;
+  onInspectElementLeftClicked: (item: InspectElement | undefined) => void;
+  onInspectElementRightClicked: (item: InspectElement | undefined) => void;
 }
 
 export interface Inspector {
-  inspectData: InspectData | null,
-  focusedElement: InspectElement | null,
-  setFocusedElement: (element: InspectElement | null) => void,
-  getFractionalDimensions: (element: InspectElement) => InspectArea
-  getExactDimensions: (element: InspectElement) => InspectArea | null
-  onMouseMove: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
-  onMouseDown: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
-  onMouseLeave: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
-  reset: () => void
+  inspectData: InspectData | null;
+  focusedElement: InspectElement | null;
+  setFocusedElement: (element: InspectElement | null) => void;
+  getFractionalDimensions: (element: InspectElement) => InspectArea;
+  getExactDimensions: (element: InspectElement) => InspectArea | null;
+  onMouseMove: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void;
+  onMouseDown: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void;
+  onMouseLeave: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void;
+  reset: () => void;
 }
 
-export const useInspector = ({ 
-  deviceProperties, 
+export const useInspector = ({
+  deviceProperties,
   onInspectElementLeftClicked,
-  onInspectElementRightClicked
+  onInspectElementRightClicked,
 }: InspectorProps): Inspector => {
   const { project } = useProject();
 
@@ -45,7 +45,7 @@ export const useInspector = ({
       left: element.frame.x,
       top: element.frame.y,
       width: element.frame.width,
-      height: element.frame.height
+      height: element.frame.height,
     };
   }
 
@@ -60,13 +60,13 @@ export const useInspector = ({
       left: element.frame.x * screenWidth,
       top: element.frame.y * screenHeight,
       width: element.frame.width * screenWidth,
-      height: element.frame.height * screenHeight
+      height: element.frame.height * screenHeight,
     };
   }
 
   const sendInspectUnthrottled = (
     event: MouseEvent<HTMLDivElement>,
-    touchPosition: { x: number, y: number },
+    touchPosition: { x: number; y: number },
     type: "Move" | "Leave" | "Down" | "RightButtonDown"
   ) => {
     if (type === "Leave") {
@@ -74,24 +74,24 @@ export const useInspector = ({
     }
 
     const { x: clampedX, y: clampedY } = touchPosition;
-    
+
     project.inspectElementAt(clampedX, clampedY, (newInspectData) => {
-        setInspectData({
-          requestLocation: { x: event.clientX, y: event.clientY },
-          stack: newInspectData.stack,
-        });
-
-        const firstItem = newInspectData?.stack?.find((item) => !item.hide);
-
-        if (firstItem) {
-          setFocusedElement(firstItem);
-          if (type === 'Down') {
-            onInspectElementLeftClicked(firstItem);
-          } else if (type === 'RightButtonDown') {
-            onInspectElementRightClicked(firstItem);
-          }
-        }
+      setInspectData({
+        requestLocation: { x: event.clientX, y: event.clientY },
+        stack: newInspectData.stack,
       });
+
+      const firstItem = newInspectData?.stack?.find((item) => !item.hide);
+
+      if (firstItem) {
+        setFocusedElement(firstItem);
+        if (type === "Down") {
+          onInspectElementLeftClicked(firstItem);
+        } else if (type === "RightButtonDown") {
+          onInspectElementRightClicked(firstItem);
+        }
+      }
+    });
   };
 
   const sendInspect = throttle(sendInspectUnthrottled, 50);
@@ -119,6 +119,6 @@ export const useInspector = ({
     onMouseMove,
     onMouseDown,
     onMouseLeave,
-    reset
+    reset,
   };
 };

--- a/packages/vscode-extension/src/webview/hooks/useInspector.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useInspector.tsx
@@ -1,0 +1,124 @@
+import { useState, MouseEvent } from "react";
+import { InspectData, InspectElement } from "../../common/Project";
+import { throttle } from "../../utilities/throttle";
+import { TouchPosition } from "../types";
+import { useProject } from "../providers/ProjectProvider";
+import { DeviceProperties } from "../utilities/consts";
+
+export type InspectArea = {
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+};
+
+export interface InspectorProps {
+  deviceProperties?: DeviceProperties,
+  onInspectElementLeftClicked: (item: InspectElement | undefined) => void,
+  onInspectElementRightClicked: (item: InspectElement | undefined) => void
+}
+
+export interface Inspector {
+  inspectData: InspectData | null,
+  focusedElement: InspectElement | null,
+  setFocusedElement: (element: InspectElement | null) => void,
+  getFractionalDimensions: (element: InspectElement) => InspectArea
+  getExactDimensions: (element: InspectElement) => InspectArea | null
+  onMouseMove: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
+  onMouseDown: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
+  onMouseLeave: (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) => void,
+  reset: () => void
+}
+
+export const useInspector = ({ 
+  deviceProperties, 
+  onInspectElementLeftClicked,
+  onInspectElementRightClicked
+}: InspectorProps): Inspector => {
+  const { project } = useProject();
+
+  const [inspectData, setInspectData] = useState<InspectData | null>(null);
+  const [focusedElement, setFocusedElement] = useState<InspectElement | null>(null);
+
+  function getFractionalDimensions(element: InspectElement): InspectArea {
+    return {
+      left: element.frame.x,
+      top: element.frame.y,
+      width: element.frame.width,
+      height: element.frame.height
+    };
+  }
+
+  function getExactDimensions(element: InspectElement): InspectArea | null {
+    if (!deviceProperties) {
+      return null;
+    }
+
+    const { screenHeight, screenWidth } = deviceProperties;
+
+    return {
+      left: element.frame.x * screenWidth,
+      top: element.frame.y * screenHeight,
+      width: element.frame.width * screenWidth,
+      height: element.frame.height * screenHeight
+    };
+  }
+
+  const sendInspectUnthrottled = (
+    event: MouseEvent<HTMLDivElement>,
+    touchPosition: { x: number, y: number },
+    type: "Move" | "Leave" | "Down" | "RightButtonDown"
+  ) => {
+    if (type === "Leave") {
+      return;
+    }
+
+    const { x: clampedX, y: clampedY } = touchPosition;
+    
+    project.inspectElementAt(clampedX, clampedY, (newInspectData) => {
+        setInspectData({
+          requestLocation: { x: event.clientX, y: event.clientY },
+          stack: newInspectData.stack,
+        });
+
+        const firstItem = newInspectData?.stack?.find((item) => !item.hide);
+
+        if (firstItem) {
+          setFocusedElement(firstItem);
+          if (type === 'Down') {
+            onInspectElementLeftClicked(firstItem);
+          } else if (type === 'RightButtonDown') {
+            onInspectElementRightClicked(firstItem);
+          }
+        }
+      });
+  };
+
+  const sendInspect = throttle(sendInspectUnthrottled, 50);
+
+  const onMouseMove = (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) =>
+    sendInspect(e, touchPosition, "Move", false);
+
+  const onMouseDown = (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) =>
+    sendInspect(e, touchPosition, e.button === 2 ? "RightButtonDown" : "Down", true);
+
+  const onMouseLeave = (e: MouseEvent<HTMLDivElement>, touchPosition: TouchPosition) =>
+    sendInspect(e, touchPosition, "Leave", true);
+
+  const reset = () => {
+    setInspectData(null);
+    setFocusedElement(null);
+  };
+
+  return {
+    inspectData,
+    focusedElement,
+    setFocusedElement,
+    getFractionalDimensions,
+    getExactDimensions,
+    onMouseMove,
+    onMouseDown,
+    onMouseLeave,
+    reset
+  };
+};

--- a/packages/vscode-extension/src/webview/types.ts
+++ b/packages/vscode-extension/src/webview/types.ts
@@ -1,0 +1,4 @@
+export type TouchPosition = {
+  x: number,
+  y: number,
+};

--- a/packages/vscode-extension/src/webview/types.ts
+++ b/packages/vscode-extension/src/webview/types.ts
@@ -1,4 +1,4 @@
 export type TouchPosition = {
-  x: number,
-  y: number,
+  x: number;
+  y: number;
 };

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -14,11 +14,7 @@ import { useProject } from "../providers/ProjectProvider";
 import DeviceSelect from "../components/DeviceSelect";
 import { InspectDataMenu } from "../components/InspectDataMenu";
 import Button from "../components/shared/Button";
-import {
-  InspectElement,
-  RecordingData,
-  ZoomLevelType,
-} from "../../common/Project";
+import { InspectElement, RecordingData, ZoomLevelType } from "../../common/Project";
 import { useUtils } from "../providers/UtilsProvider";
 import { AndroidSupportedDevices, iOSSupportedDevices } from "../utilities/consts";
 import "./View.css";
@@ -143,7 +139,7 @@ function PreviewView() {
   const inspector = useInspector({
     deviceProperties,
     onInspectElementLeftClicked: openInspectElementSourceLocation,
-    onInspectElementRightClicked: () => setIsInspectDataMenuOpen(true)
+    onInspectElementRightClicked: () => setIsInspectDataMenuOpen(true),
   });
 
   const showReplayButton = deviceSettings.replaysEnabled;


### PR DESCRIPTION
This PR is the next part of #666 right after #693.

## Changes

- Extract the convoluted inspector logic in `webview` from `Preview` and `PreviewView` to a custom hook `useInspector`
- Simplify inspector related interfaces (see `Project.ts`)
- **Remove the `requestStack` parameter in inspect functions.** For #666 we will need to request the stack every time, because it's necessary to evaluate padding/margins, therefore `requestStack` would always be true, so we can remove it. I decided to do it now because it also simplifies `useInspector` logic.

### How Has This Been Tested: 

TODO: Testing after #693 is merged



