### PR TITLE
Fix package manager detection

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -309,8 +309,12 @@
                   }
                 }
               },
+              "packageManager": {
+                "type": "string",
+                "description": "Package manager used for the project (eg. yarn)."
+              },
               "preview": {
-                "description": "Custommize the behavior of device preview",
+                "description": "Customize the behavior of device preview",
                 "type": "object",
                 "properties": {
                   "waitForAppLaunch": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -311,7 +311,7 @@
               },
               "packageManager": {
                 "type": "string",
-                "description": "Package manager used for the project (eg. yarn)."
+                "description": "Package manager used for the project. Available options include: npm, yarn, pnpm, bun."
               },
               "preview": {
                 "description": "Customize the behavior of device preview",
@@ -400,7 +400,7 @@
               },
               "packageManager": {
                 "type": "string",
-                "description": "Package manager used for the project (eg. yarn)."
+                "description": "Package manager used for the project. Available options include: npm, yarn, pnpm, bun."
               },
               "preview": {
                 "description": "Customize the behavior of device preview",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -398,6 +398,10 @@
                   }
                 }
               },
+              "packageManager": {
+                "type": "string",
+                "description": "Package manager used for the project (eg. yarn)."
+              },
               "preview": {
                 "description": "Customize the behavior of device preview",
                 "type": "object",

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -25,6 +25,7 @@ export type LaunchConfigurationOptions = {
     buildType?: string;
     productFlavor?: string;
   };
+  packageManager?: string;
   preview?: {
     waitForAppLaunch?: boolean;
   };

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -26,6 +26,7 @@ import { shouldUseExpoCLI } from "../utilities/expoCli";
 import { CancelToken } from "../builders/cancelToken";
 import { getAndroidSourceDir } from "../builders/buildAndroid";
 import { Platform } from "../utilities/platform";
+import { requireNoCache } from "../utilities/requireNoCache";
 
 export class DependencyManager implements Disposable, DependencyManagerInterface {
   // React Native prepares build scripts based on node_modules, we need to reinstall pods if they change
@@ -305,12 +306,6 @@ async function testCommand(cmd: string) {
   } catch (_) {
     return false;
   }
-}
-
-function requireNoCache(...params: Parameters<typeof require.resolve>) {
-  const module = require.resolve(...params);
-  delete require.cache[module];
-  return require(module);
 }
 
 function npmPackageVersionCheck(dependency: string, minVersion?: string | semver.SemVer) {

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -4,7 +4,6 @@ import { command } from "./subprocess";
 import { getAppRootFolder } from "./extensionContext";
 import { isWorkspaceRoot } from "./common";
 import { Logger } from "../Logger";
-import { window } from "vscode";
 
 export type PackageManagerInfo = {
   name: "npm" | "pnpm" | "yarn" | "bun";
@@ -63,10 +62,6 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     if (packageManagerCandidates.length > 1) {
       Logger.warn(
         "Your workspace contains multiple package manager lock files, it might cause wrong manager to be used"
-      );
-      window.showWarningMessage(
-        "Your workspace contains multiple package manager lock files, it might cause wrong manager to be used.",
-        "dismiss"
       );
     }
 

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -17,7 +17,7 @@ function isPackageManager(candidate: string): boolean {
   return packageManagers.includes(candidate);
 }
 
-async function getDirFilesSortedByModificationDate(dir: string) {
+async function listFilesSortedByModificationDate(dir: string) {
   const files = await fs.promises.readdir(dir);
 
   return files
@@ -25,7 +25,7 @@ async function getDirFilesSortedByModificationDate(dir: string) {
       name: fileName,
       time: fs.statSync(`${dir}/${fileName}`).mtime.getTime(),
     }))
-    .sort((a, b) => a.time - b.time)
+    .sort((a, b) => b.time - a.time)
     .map((file) => file.name);
 }
 
@@ -83,7 +83,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
       } as const)
     );
 
-    const files = await getDirFilesSortedByModificationDate(workspace);
+    const files = await listFilesSortedByModificationDate(workspace);
     const packageManagerCandidates = [];
     for (const file of files) {
       const manager = lockFiles.get(file);

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -41,11 +41,11 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     }
 
     try {
-      const packageManager = require(path.join(workspace, "package.json")).packageManager;
+      const manager = require(path.join(workspace, "package.json")).packageManager;
 
-      if (packageManager) {
+      if (manager) {
         // e.g. yarn@3.6.4
-        const match = packageManager.match(/^([a-zA-Z]+)@/);
+        const match = manager.match(/^([a-zA-Z]+)@/);
         return match ? match[1] : "npm";
       }
     } catch (e) {
@@ -77,8 +77,8 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     const files = await getDirFilesSortedByModificationDate(workspace);
     const packageManagerCandidates = [];
     for (const file of files) {
-      const packageManager = lockFiles.get(file);
-      if (packageManager) {
+      const manager = lockFiles.get(file);
+      if (manager) {
         packageManagerCandidates.push(packageManager);
       }
     }

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -16,6 +16,8 @@ function isPackageManager(candidate: string): boolean {
   return packageManagers.includes(candidate);
 }
 
+const DEFAULT_PACKAGE_MANAGER = "npm";
+
 export async function resolvePackageManager(): Promise<PackageManagerInfo | undefined> {
   function findWorkspace(appRoot: string) {
     let currentDir = appRoot;
@@ -36,7 +38,13 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
   async function findPackageManager(workspace: string) {
     const { packageManager } = getLaunchConfiguration();
 
-    if (packageManager && isPackageManager(packageManager)) {
+    if (packageManager) {
+      if (!isPackageManager(packageManager)) {
+        Logger.warn(
+          `Package manager provided in launch configuration: ${packageManager} is not supported by radon IDE`
+        );
+        return;
+      }
       return packageManager;
     }
 
@@ -46,7 +54,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
       if (manager) {
         // e.g. yarn@3.6.4
         const match = manager.match(/^([a-zA-Z]+)@/);
-        return match ? match[1] : "npm";
+        return match ? match[1] : DEFAULT_PACKAGE_MANAGER;
       }
     } catch (e) {
       // there might be a problem while reading package.json in which case move to looking
@@ -94,7 +102,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     }
 
     // when no package manager were detected we default to npm
-    return "npm";
+    return DEFAULT_PACKAGE_MANAGER;
   }
 
   const name = await findPackageManager(workspacePath ?? appRootPath);

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -37,7 +37,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
         return match ? match[1] : "npm";
       }
     } catch (e) {
-      // there might be a problem while reading package.json in which case move to looking 
+      // there might be a problem while reading package.json in which case move to looking
       // for lock files matching package managers in the workspace root
     }
 
@@ -68,8 +68,8 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     if (packageManagerCandidates) {
       return packageManagerCandidates[0];
     }
-    
-    // when no package manager were detected we default to npm 
+
+    // when no package manager were detected we default to npm
     return "npm";
   }
 

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -4,6 +4,7 @@ import { command } from "./subprocess";
 import { getAppRootFolder } from "./extensionContext";
 import { isWorkspaceRoot } from "./common";
 import { Logger } from "../Logger";
+import { window } from "vscode";
 
 export type PackageManagerInfo = {
   name: "npm" | "pnpm" | "yarn" | "bun";
@@ -61,7 +62,11 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
 
     if (packageManagerCandidates.length > 1) {
       Logger.warn(
-        "Your workspace contains multiple package manager lock files, it might cause wrong manager to be used by the Radon IDE."
+        "Your workspace contains multiple package manager lock files, it might cause wrong manager to be used"
+      );
+      window.showWarningMessage(
+        "Your workspace contains multiple package manager lock files, it might cause wrong manager to be used.",
+        "dismiss"
       );
     }
 

--- a/packages/vscode-extension/src/utilities/requireNoCache.ts
+++ b/packages/vscode-extension/src/utilities/requireNoCache.ts
@@ -1,0 +1,5 @@
+export function requireNoCache(...params: Parameters<typeof require.resolve>) {
+  const module = require.resolve(...params);
+  delete require.cache[module];
+  return require(module);
+}


### PR DESCRIPTION
This PR changes how we detect package manager used by the application, to better deal with a situation when a user has multiple lock files in their repository. A situation like that is quite common, because  users sometimes accidentally run `npm install` before checking that the project actually uses yarn. 

Solution: 
- information set up in package.json takes priority, as it is unprovable that set it up accidentally
- in case the information is missing from package.json we still perform the old check but, we send a warning to the console if multiple lock files are detected
- finally we allow user to set up the package manager in launch configuration by hand and than it takes priority 

### How Has This Been Tested: 

- run https://github.com/Almouro/react-native-performance-workshop in IDE which has multiple lock files and see it working 
- remove the information from package json and the if logger logs the warning
- run expo 52 test app example and see it working correctlly


