### PR TITLE
Simplify Device Settings menu

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -34,6 +34,11 @@
   color: var(--swm-default-text);
 }
 
+.device-settings-items-row {
+  display: flex;
+  justify-content: space-between;
+}
+
 .device-settings-margin {
   margin-bottom: 24px;
 }

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -4,7 +4,7 @@
 
 .device-settings-heading {
   text-align: center;
-  margin: 0 0 10px 0;
+  margin: 0 0 15px 0;
   color: var(--swm-default-text);
 }
 

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -4,7 +4,7 @@
 
 .device-settings-heading {
   text-align: center;
-  margin-top: 0px;
+  margin: 0 0 10px 0;
   color: var(--swm-default-text);
 }
 
@@ -40,7 +40,7 @@
 }
 
 .device-settings-margin {
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .icons-container {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -34,11 +34,6 @@
   color: var(--swm-default-text);
 }
 
-.device-settings-items-row {
-  display: flex;
-  justify-content: space-between;
-}
-
 .device-settings-margin {
   margin-bottom: 20px;
 }

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -138,7 +138,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
-                className="dropdown-menu-content"
+                className="dropdown-menu-subcontent"
                 sideOffset={2}
                 alignOffset={-5}>
                 {resetOptions.map((option, index) => (
@@ -225,7 +225,7 @@ const BiometricsItem = () => {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent className="dropdown-menu-content">
+        <DropdownMenu.SubContent className="dropdown-menu-subcontent">
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -121,17 +121,15 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             <div className="device-settings-margin" />
           </form>
           {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
-          <div className="device-settings-items-row">
-            <DropdownMenu.Item
-              className="dropdown-menu-item"
-              onSelect={() => {
-                openModal("Location", <DeviceLocationView />);
-              }}>
-              <span className="codicon codicon-location" />
-              Set Location
-            </DropdownMenu.Item>
-            <LocalizationItem />
-          </div>
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
+            onSelect={() => {
+              openModal("Location", <DeviceLocationView />);
+            }}>
+            <span className="codicon codicon-location" />
+            Location
+          </DropdownMenu.Item>
+          <LocalizationItem />
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-redo" />
@@ -209,7 +207,7 @@ const LocalizationItem = () => {
           openModal("Localization", <DeviceLocalizationView />);
         }}>
         <span className="codicon codicon-globe" />
-        Set Localization
+        Localization
       </DropdownMenu.Item>
     </>
   );

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -122,7 +122,6 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
             <DropdownMenu.Arrow className="dropdown-menu-arrow" />
           </form>
-          <Label>Device location</Label>
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {
@@ -132,7 +131,6 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             Set Device Location
           </DropdownMenu.Item>
           <LocalizationItem />
-          <Label>Permissions</Label>
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-redo" />
@@ -155,7 +153,6 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
-          <Label>Screen settings</Label>
           <div className="dropdown-menu-item">
             <span className="icons-container">
               <span className="codicon codicon-triangle-left icons-rewind" />
@@ -187,7 +184,6 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>
           </div>
-          <Label>Deep Links</Label>
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => openModal("Open Deep Link", <OpenDeepLinkView />)}>
@@ -204,7 +200,6 @@ const LocalizationItem = () => {
   const { openModal } = useModal();
   return (
     <>
-      <Label>Device Localization</Label>
       <DropdownMenu.Item
         className="dropdown-menu-item"
         onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -135,6 +135,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-redo" />
               Reset Permissions
+              <span className="codicon codicon-chevron-right right-slot" />
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -63,8 +63,8 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
       <DropdownMenu.Portal>
         <DropdownMenu.Content className="dropdown-menu-content device-settings-content">
           <h4 className="device-settings-heading">Device Settings</h4>
-          <Label>Device appearance</Label>
           <form>
+            <Label>Device appearance</Label>
             <RadioGroup.Root
               className="radio-group-root"
               defaultValue={deviceSettings.appearance}
@@ -119,7 +119,8 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               <span className="device-settings-large-text-indicator" />
             </div>
             <div className="device-settings-margin" />
-            {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
+          </form>
+          {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
           <div className="device-settings-items-row">
             <DropdownMenu.Item
               className="dropdown-menu-item"

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -154,6 +154,12 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
+            onSelect={() => openModal("Open Deep Link", <OpenDeepLinkView />)}>
+            <span className="codicon codicon-link" />
+            Open Deep Link
+          </DropdownMenu.Item>
           <div className="dropdown-menu-item">
             <span className="icons-container">
               <span className="codicon codicon-triangle-left icons-rewind" />
@@ -185,12 +191,6 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>
           </div>
-          <DropdownMenu.Item
-            className="dropdown-menu-item"
-            onSelect={() => openModal("Open Deep Link", <OpenDeepLinkView />)}>
-            <span className="codicon codicon-link" />
-            Open Deep Link
-          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -120,17 +120,17 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             </div>
             <div className="device-settings-margin" />
             {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
-            <DropdownMenu.Arrow className="dropdown-menu-arrow" />
-          </form>
-          <DropdownMenu.Item
-            className="dropdown-menu-item"
-            onSelect={() => {
-              openModal("Location", <DeviceLocationView />);
-            }}>
-            <span className="codicon codicon-location" />
-            Set Device Location
-          </DropdownMenu.Item>
-          <LocalizationItem />
+          <div className="device-settings-items-row">
+            <DropdownMenu.Item
+              className="dropdown-menu-item"
+              onSelect={() => {
+                openModal("Location", <DeviceLocationView />);
+              }}>
+              <span className="codicon codicon-location" />
+              Set Location
+            </DropdownMenu.Item>
+            <LocalizationItem />
+          </div>
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-redo" />
@@ -191,6 +191,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>
           </div>
+          <DropdownMenu.Arrow className="dropdown-menu-arrow" />
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
@@ -207,7 +208,7 @@ const LocalizationItem = () => {
           openModal("Localization", <DeviceLocalizationView />);
         }}>
         <span className="codicon codicon-globe" />
-        Set Device Localization
+        Set Localization
       </DropdownMenu.Item>
     </>
   );

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -12,7 +12,7 @@ button {
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;
   box-shadow: var(--swm-backdrop-shadow);
-  max-height: calc(var(--radix-dropdown-menu-content-available-height) - 50px);
+  max-height: calc(var(--radix-dropdown-menu-content-available-height) - 40px);
   overflow-y: auto;
   box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -15,7 +15,6 @@ button {
   box-shadow: var(--swm-backdrop-shadow);
   max-height: calc(var(--radix-dropdown-menu-content-available-height) - 40px);
   overflow-y: auto;
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 .dropdown-menu-subcontent {

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -3,7 +3,8 @@ button {
   all: unset;
 }
 
-.dropdown-menu-content {
+.dropdown-menu-content,
+.dropdown-menu-subcontent {
   min-width: 220px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;
@@ -17,10 +18,17 @@ button {
   box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
-.dropdown-menu-content[data-side="bottom"] {
+.dropdown-menu-subcontent {
+  max-height: calc(var(--radix-dropdown-menu-content-available-height));
+}
+
+.dropdown-menu-content[data-side="bottom"],
+.dropdown-menu-subcontent[data-side="bottom"] {
   animation-name: slideUpAndFade;
 }
-.dropdown-menu-content[data-side="top"] {
+
+.dropdown-menu-content[data-side="top"],
+.dropdown-menu-subcontent[data-side="top"] {
   animation-name: slideDownAndFade;
 }
 

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -77,6 +77,7 @@ button {
 
 .dropdown-menu-arrow {
   fill: var(--swm-popover-background);
+  height: 0;
 }
 
 .right-slot {

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -14,7 +14,7 @@ button {
   box-shadow: var(--swm-backdrop-shadow);
   max-height: calc(var(--radix-dropdown-menu-content-available-height) - 50px);
   overflow-y: auto;
-  box-shadow: 10px 0 20px 2px rgba(0, 0, 0, 0.1), -5px 10px 25px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 
 .dropdown-menu-content[data-side="bottom"] {

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -14,6 +14,7 @@ button {
   box-shadow: var(--swm-backdrop-shadow);
   max-height: calc(var(--radix-dropdown-menu-content-available-height) - 50px);
   overflow-y: auto;
+  box-shadow: 10px 0 20px 2px rgba(0, 0, 0, 0.1), -5px 10px 25px 0 rgba(0, 0, 0, 0.1);
 }
 
 .dropdown-menu-content[data-side="bottom"] {

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -154,8 +154,8 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
 
   /* Shadows */
   --swm-focus-outline: 0 0 0 2px var(--navy-light-20);
-  --swm-backdrop-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-
+  --swm-backdrop-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1),
+    1px -4px 6px -3px rgb(0 0 0 / 0.1);
   /* Device select */
   --swm-device-select-background: var(--navy-light-10);
   --swm-device-select-trigger-text: var(--navy-light-100);
@@ -312,8 +312,8 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
 
   /* Shadows */
   --swm-focus-outline: 0 0 0 2px var(--background-dark-50);
-  --swm-backdrop-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-
+  --swm-backdrop-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1),
+    1px -4px 6px -3px rgb(0 0 0 / 0.1);
   /* Device select */
   --swm-device-select-background: var(--background-dark-80);
   --swm-device-select-trigger-text: var(--off-white);

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -312,7 +312,7 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
 
   /* Shadows */
   --swm-focus-outline: 0 0 0 2px var(--background-dark-50);
-  --swm-backdrop-shadow: none;
+  --swm-backdrop-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 
   /* Device select */
   --swm-device-select-background: var(--background-dark-80);


### PR DESCRIPTION
This PR simplifies the Device Settings UI by reordering items and removing unnecessary labels. It also adds shadows to `--swm-backdrop-shadow` in dark theme to visually distinguish them from the background.

|Before|After|
|-|-|
|<img width="522" alt="Screenshot 2024-11-18 at 10 57 30" src="https://github.com/user-attachments/assets/153e56c6-4d79-47da-8ae7-fa70ac48e22f">|<img width="501" alt="Screenshot 2024-11-18 at 13 07 51" src="https://github.com/user-attachments/assets/60710772-86b0-4c8e-ae0b-3007cedf4659"><img width="501" alt="Screenshot 2024-11-18 at 13 06 56" src="https://github.com/user-attachments/assets/0b94a980-c129-499b-9e97-1abd04f97c15">|




