### PR TITLE
Fix inaccessible context menu on narrow window

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -140,7 +140,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
-                className="dropdown-menu-content"
+                className="dropdown-menu-subcontent"
                 sideOffset={2}
                 alignOffset={-5}>
                 {resetOptions.map((option, index) => (
@@ -229,7 +229,7 @@ const BiometricsItem = () => {
       </DropdownMenu.SubTrigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.SubContent className="dropdown-menu-content">
+        <DropdownMenu.SubContent className="dropdown-menu-subcontent">
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -70,7 +70,7 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
               <DropdownMenu.SubContent
-                className="dropdown-menu-content"
+                className="dropdown-menu-subcontent"
                 sideOffset={2}
                 alignOffset={-5}>
                 <DropdownMenu.Item

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -122,6 +122,6 @@ button {
 
 @media (max-width: 460px) {
   .dropdown-menu-subcontent {
-    transform: translateX(85%) translateY(25%);
+    transform: translateX(85%) translateY(28px);
   }
 }

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -3,7 +3,8 @@ button {
   all: unset;
 }
 
-.dropdown-menu-content {
+.dropdown-menu-content,
+.dropdown-menu-subcontent {
   min-width: 220px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;
@@ -16,10 +17,12 @@ button {
   overflow-y: auto;
 }
 
-.dropdown-menu-content[data-side="bottom"] {
+.dropdown-menu-content[data-side="bottom"],
+.dropdown-menu-subcontent[data-side="bottom"] {
   animation-name: slideUpAndFade;
 }
-.dropdown-menu-content[data-side="top"] {
+.dropdown-menu-content[data-side="top"],
+.dropdown-menu-subcontent[data-side="top"] {
   animation-name: slideDownAndFade;
 }
 
@@ -108,5 +111,12 @@ button {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (max-width: 460px) {
+  .dropdown-menu-subcontent {
+    transform: translateX(85%) translateY(25%);
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1), 4px -4px 6px -1px rgb(0 0 0 / 0.1);
   }
 }

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -5,8 +5,6 @@ button {
 
 .dropdown-menu-content,
 .dropdown-menu-subcontent {
-.dropdown-menu-content,
-.dropdown-menu-subcontent {
   min-width: 220px;
   background-color: var(--swm-popover-background);
   border-radius: 6px;

--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -117,6 +117,5 @@ button {
 @media (max-width: 460px) {
   .dropdown-menu-subcontent {
     transform: translateX(85%) translateY(25%);
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1), 4px -4px 6px -1px rgb(0 0 0 / 0.1);
   }
 }


### PR DESCRIPTION
This PR addresses the issue of inaccessible submenus when the side panel is too narrow.

Fixes #669 

|Before|After|
|-|-|
|<img width="373" alt="Screenshot 2024-11-18 at 16 20 11" src="https://github.com/user-attachments/assets/a279c90a-56c2-4fef-98a0-b13e33b42ba6">|<video src="https://github.com/user-attachments/assets/a0749108-49fc-4d57-b554-db04fa303e39" />|