### PR TITLE
[iOS] Add native logs 

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -54,7 +54,7 @@ type PrivacyServiceName =
 
 export class IosSimulatorDevice extends DeviceBase {
   private nativeLogsOutputChannel: OutputChannel | undefined;
-  
+
   constructor(private readonly deviceUDID: string, private readonly _deviceInfo: DeviceInfo) {
     super();
   }
@@ -352,13 +352,11 @@ export class IosSimulatorDevice extends DeviceBase {
 
   private getNativeLogsPath() {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
-    const logFile = path.join(deviceSetLocation, this.deviceUDID, "data", "radon_ide_ios_process.log");
-
-    return logFile;
+    return path.join(deviceSetLocation, this.deviceUDID, "data", "radon_ide_ios_process.log");
   }
 
   mirrorNativeLogs(logFile: string) {
-    this.nativeLogsOutputChannel = window.createOutputChannel("Radon IDE (iOS Native Logs)", 'log');
+    this.nativeLogsOutputChannel = window.createOutputChannel("Radon IDE (iOS Native Logs)", "log");
     this.nativeLogsOutputChannel.clear();
 
     if (fs.existsSync(logFile)) {
@@ -371,7 +369,7 @@ export class IosSimulatorDevice extends DeviceBase {
   async launchWithBuild(build: IOSBuildResult) {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
     const logFile = this.getNativeLogsPath();
-    
+
     await this.terminateAnyRunningApplications();
     this.mirrorNativeLogs(logFile);
 
@@ -381,7 +379,7 @@ export class IosSimulatorDevice extends DeviceBase {
       deviceSetLocation,
       "launch",
       `--stdout=${logFile}`,
-      `--stderr=${logFile}`,  
+      `--stderr=${logFile}`,
       "--terminate-running-process",
       this.deviceUDID,
       build.bundleID,

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -13,6 +13,7 @@ import { BuildResult } from "../builders/BuildManager";
 import { AppPermissionType, DeviceSettings, Locale } from "../common/Project";
 import { EXPO_GO_BUNDLE_ID, fetchExpoLaunchDeeplink } from "../builders/expoGo";
 import { IOSBuildResult } from "../builders/buildIOS";
+import { CancelToken } from "../builders/cancelToken";
 
 const LEFT_META_HID_CODE = 0xe3;
 const RIGHT_META_HID_CODE = 0xe7;
@@ -54,6 +55,7 @@ type PrivacyServiceName =
 
 export class IosSimulatorDevice extends DeviceBase {
   private nativeLogsOutputChannel: OutputChannel | undefined;
+  private lunchedAppCancelToken = new CancelToken();
 
   constructor(private readonly deviceUDID: string, private readonly _deviceInfo: DeviceInfo) {
     super();
@@ -76,6 +78,7 @@ export class IosSimulatorDevice extends DeviceBase {
   public dispose() {
     super.dispose();
     this.nativeLogsOutputChannel?.dispose();
+    this.lunchedAppCancelToken.cancel();
     return exec("xcrun", [
       "simctl",
       "--set",
@@ -376,6 +379,8 @@ export class IosSimulatorDevice extends DeviceBase {
       build.bundleID,
     ]);
 
+    this.lunchedAppCancelToken.adapt(process);
+    
     lineReader(process).onLineRead(this.nativeLogsOutputChannel.appendLine);
   }
 

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -380,7 +380,7 @@ export class IosSimulatorDevice extends DeviceBase {
     ]);
 
     this.lunchedAppCancelToken.adapt(process);
-    
+
     lineReader(process).onLineRead(this.nativeLogsOutputChannel.appendLine);
   }
 

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -357,9 +357,12 @@ export class IosSimulatorDevice extends DeviceBase {
       this.nativeLogsOutputChannel.dispose();
     }
 
-    this.nativeLogsOutputChannel = window.createOutputChannel("Radon IDE (iOS Simulator Logs)", "log");
+    this.nativeLogsOutputChannel = window.createOutputChannel(
+      "Radon IDE (iOS Simulator Logs)",
+      "log"
+    );
     this.nativeLogsOutputChannel.clear();
-    
+
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
     const process = exec("xcrun", [

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -354,7 +354,7 @@ export class IosSimulatorDevice extends DeviceBase {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
     await this.terminateAnyRunningApplications();
-    
+
     if (this.nativeLogsOutputChannel) {
       this.nativeLogsOutputChannel.dispose();
     }

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -351,8 +351,10 @@ export class IosSimulatorDevice extends DeviceBase {
   }
 
   async launchWithBuild(build: IOSBuildResult) {
-    await this.terminateAnyRunningApplications();
+    const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
+    await this.terminateAnyRunningApplications();
+    
     if (this.nativeLogsOutputChannel) {
       this.nativeLogsOutputChannel.dispose();
     }
@@ -362,8 +364,6 @@ export class IosSimulatorDevice extends DeviceBase {
       "log"
     );
     this.nativeLogsOutputChannel.clear();
-
-    const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
     const process = exec("xcrun", [
       "simctl",

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -238,32 +238,3 @@ export async function calculateMD5(fsPath: string, hash: Hash = createHash("md5"
   }
   return hash;
 }
-
-function readFileWithSize(filePath: string, from: number): Promise<{ size: number; data: string }> {
-  return new Promise((resolve, reject) => {
-    let size = 0;
-    const chunks: Uint8Array[] = [];
-    const stream = fs.createReadStream(filePath, { start: from });
-
-    stream.on("data", function (chunk: Uint8Array) {
-      size += chunk.length;
-      chunks.push(chunk);
-    });
-
-    stream.on("error", () => reject());
-
-    stream.on("close", () => resolve({ size, data: Buffer.concat(chunks).toString() }));
-  });
-}
-
-export function watchFileContent(filePath: string, callback: (data: string) => void) {
-  let fileEnd = 0;
-
-  fs.watchFile(filePath, async (curr, prev) => {
-    if (curr.mtime > prev.mtime) {
-      const { data, size } = await readFileWithSize(filePath, fileEnd);
-      fileEnd += size;
-      callback(data);
-    }
-  });
-}

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -239,31 +239,31 @@ export async function calculateMD5(fsPath: string, hash: Hash = createHash("md5"
   return hash;
 }
 
-const readFileWithSize = (filePath: string, from: number): Promise<{size: number, data: string}> => new Promise((resolve, reject) => {
-  let size = 0;
-  const chunks: Uint8Array[] = [];
-  const stream = fs.createReadStream(filePath, {start: from});
+function readFileWithSize(filePath: string, from: number): Promise<{ size: number; data: string }> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Uint8Array[] = [];
+    const stream = fs.createReadStream(filePath, { start: from });
 
-  stream.on('data', function(chunk: Uint8Array) {
-    size += chunk.length;
-    chunks.push(chunk);
+    stream.on("data", function (chunk: Uint8Array) {
+      size += chunk.length;
+      chunks.push(chunk);
+    });
+
+    stream.on("error", () => reject());
+
+    stream.on("close", () => resolve({ size, data: Buffer.concat(chunks).toString() }));
   });
-
-  stream.on('error', () => reject());
-
-  stream.on('close', () => resolve({size, data: Buffer.concat(chunks).toString()}));
-});
+}
 
 export const watchFileContent = function (filePath: string, callback: (data: string) => void) {
   let fileEnd = 0;
 
   fs.watchFile(filePath, async (curr, prev) => {
     if (curr.mtime > prev.mtime) {
-      const {data, size} = await readFileWithSize(filePath, fileEnd);
+      const { data, size } = await readFileWithSize(filePath, fileEnd);
       fileEnd += size;
       callback(data);
     }
-  }); 
+  });
 };
-
-

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -256,7 +256,7 @@ function readFileWithSize(filePath: string, from: number): Promise<{ size: numbe
   });
 }
 
-export function watchFileContent (filePath: string, callback: (data: string) => void) {
+export function watchFileContent(filePath: string, callback: (data: string) => void) {
   let fileEnd = 0;
 
   fs.watchFile(filePath, async (curr, prev) => {
@@ -266,4 +266,4 @@ export function watchFileContent (filePath: string, callback: (data: string) => 
       callback(data);
     }
   });
-};
+}

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -238,3 +238,32 @@ export async function calculateMD5(fsPath: string, hash: Hash = createHash("md5"
   }
   return hash;
 }
+
+const readFileWithSize = (filePath: string, from: number): Promise<{size: number, data: string}> => new Promise((resolve, reject) => {
+  let size = 0;
+  const chunks: Uint8Array[] = [];
+  const stream = fs.createReadStream(filePath, {start: from});
+
+  stream.on('data', function(chunk: Uint8Array) {
+    size += chunk.length;
+    chunks.push(chunk);
+  });
+
+  stream.on('error', () => reject());
+
+  stream.on('close', () => resolve({size, data: Buffer.concat(chunks).toString()}));
+});
+
+export const watchFileContent = function (filePath: string, callback: (data: string) => void) {
+  let fileEnd = 0;
+
+  fs.watchFile(filePath, async (curr, prev) => {
+    if (curr.mtime > prev.mtime) {
+      const {data, size} = await readFileWithSize(filePath, fileEnd);
+      fileEnd += size;
+      callback(data);
+    }
+  }); 
+};
+
+

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -256,7 +256,7 @@ function readFileWithSize(filePath: string, from: number): Promise<{ size: numbe
   });
 }
 
-export const watchFileContent = function (filePath: string, callback: (data: string) => void) {
+export function watchFileContent (filePath: string, callback: (data: string) => void) {
   let fileEnd = 0;
 
   fs.watchFile(filePath, async (curr, prev) => {

--- a/test-apps/react-native-76/ios/Podfile.lock
+++ b/test-apps/react-native-76/ios/Podfile.lock
@@ -1719,65 +1719,65 @@ SPEC CHECKSUMS:
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 8d54e8b503c75afaf8f4cf61a22e2fe8e1badcde
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
   RCTDeprecation: 41b81ffee0755cd07c0ccc9132bda4d15548f54c
   RCTRequired: 67416fa5a975096df7226fed460bc468226440a9
   RCTTypeSafety: b5997285e05d3e2960fd1b5704cca2066db42300
   React: 2bbc56a13da3eb90a3417be54d7882d653a5ce3d
   React-callinvoker: 6cbc2bb752c2ca492ea4d36c5b05436c60bfaa92
-  React-Core: 39d2057537745f93b1c2cc4ad6c210e0d269bb02
-  React-CoreModules: eb7ab7dbd2ae00d6a19f60ec7780f81c266ebd78
-  React-cxxreact: f911fc86b34a7c7a166a8f582aaf38f350b787d2
+  React-Core: 4d2a21c0d9fe3110edea3f614abce09f0f91f452
+  React-CoreModules: 8ac3d1dd702ff5f0dc8e9e886279d83592dbe51c
+  React-cxxreact: 1ef6ee99202acc23155ede85b0aa60c9cb6c01ea
   React-debug: 612aa1f74bd6ef1ec2d34ea427d2316428757fb7
-  React-defaultsnativemodule: 8d4f282d45c9e5c8b6dfb21d3818ecb4d438929e
-  React-domnativemodule: 3065cd6597dc08daae2bce52531e2c9f37bbc8c7
-  React-Fabric: b365a71c07e9b2902299b68419b28e8c4277a557
-  React-FabricComponents: d680578e824bbdef418cae70697786bb12b248de
-  React-FabricImage: f223fd3a32642cc157d6013a97695a69b4d416b1
+  React-defaultsnativemodule: d054d5a183b14f5f7e9704c7ab1ef28c0e83e796
+  React-domnativemodule: a220054118f01bd125d108ef1f9db5b4a4377fac
+  React-Fabric: 1f34899e0ddba53f66cfefc7fe2b940b95258445
+  React-FabricComponents: 8e3304eb6aa0aa2cab8a64251e1e9e8b6af8e0a3
+  React-FabricImage: e482b4159dabb3f775e5c804399470eeb6832039
   React-featureflags: 0fa2e6491b2ed1753b495229b292670a37aeb8f5
-  React-featureflagsnativemodule: f9bc68341172a699c213aa689635901c3c4b0c4d
-  React-graphics: b17369a2aeb3949957b59ce0f4b2118a0bde86b4
-  React-hermes: 1beb90db74f2a3c06277ba3dee4a9cbdc1d38b57
-  React-idlecallbacksnativemodule: 3884619506b02e5cc71a7f23e46dad679e441eb6
-  React-ImageManager: 286882bd4fe41bee58da68403024efefb54e7601
-  React-jserrorhandler: e95815657ee08ea88ab4890309ffb2bfc2cb5f54
-  React-jsi: 33cd45a947ce461e228179a7b1f175742d528fff
-  React-jsiexecutor: 55a0a1c8ba0025648131519c6aa8fe8e58415b4d
-  React-jsinspector: 1fa973c8bfcc1747cdf880e4470047e37667b1df
-  React-jsitracing: 1c49248a400cc501b692517bebbd6cde2e3d236f
-  React-logger: a6d7479d445d6b557ab73729dc71db14d35b0f93
-  React-Mapbuffer: 30cda50703756c688d4cd016ee84b54b80f6435e
-  React-microtasksnativemodule: 8fc3fb2e65975db9f323a4d84a44d313b57c4f33
+  React-featureflagsnativemodule: f67c9975c0dcd10bc1f399d735c458439b589e17
+  React-graphics: 6a2bf599c58dc046b4cfcc41309c4836fc238b29
+  React-hermes: 268ff69bf685e60da3eebeeed186bb92fc305771
+  React-idlecallbacksnativemodule: 9ff0223ac226d752929e83b486c9fc6acaa682ce
+  React-ImageManager: 0b4e2345571148ae9943c8a519a86ea0a1130f0c
+  React-jserrorhandler: ed30b234e4b015fdc847db8bb4fc997756f15938
+  React-jsi: 695a9d613ac8216b888ef8debc043761eb420a21
+  React-jsiexecutor: bc421f87e09681d5d5f1fb82b313630d27b8080e
+  React-jsinspector: 2f8a95650022b3c1fd183741fd9a07af3948fe2b
+  React-jsitracing: 43ac9ae9885ba8593d57e4be81ea562924d0b2c1
+  React-logger: 3df04ae5880797df10366f0214b1ddb3c3e888ac
+  React-Mapbuffer: 0587471debf4805f93d0f26f70d06341a90831b0
+  React-microtasksnativemodule: 1c260bc8e9b59bc90e6d515700a91a01d6165064
   React-nativeconfig: 6bf19f5279402e095a35ac880144c14aa9b63df4
-  React-NativeModulesApple: 1636a3fcfc14025481c5933f4582a512f65cb152
-  React-perflogger: c6e000a569b3a45d5de65b0bf81e35d91f3fe5a8
-  React-performancetimeline: 4e2fed8ce8f5b1b303b4e6ebf5a5f85494fd0a85
+  React-NativeModulesApple: a3858ea4c89b5352e36860034944fe20e6848eba
+  React-perflogger: 1e3ac11eac401e39abb3d5d0ed0588dcf8c87d31
+  React-performancetimeline: 9a14212b65c6b7fb95aaef64eb28b2a706f4d936
   React-RCTActionSheet: 0169a12a5f5085d31d93294c0302aff66e9f9cee
-  React-RCTAnimation: a2039d635e1519bd736b983cce266e9081b073ee
-  React-RCTAppDelegate: 2087344d4417abee751eb7f65b6ef572119f0b05
-  React-RCTBlob: 22dbeb1e49faf83bda307060162de6c22becbe47
-  React-RCTFabric: 1c66506f73632c5d38b400e669ca94706c19c8b0
-  React-RCTImage: dbdc3981f8b0fc6e0f358cb9a4db8bf42c0fea7d
-  React-RCTLinking: 5705a5ae9ea58b803a4b6bfbb1b0f6baf377bb76
-  React-RCTNetwork: a6e333a48abdbe892fc2961c6cf32472969acb01
-  React-RCTSettings: d8a94fb83b800d8c272503b8312ebac019b40d08
-  React-RCTText: dd601ba38405f56c6bbb936815fbf8f1dabc33c7
-  React-RCTVibration: 249ce3aa017d9093228372b193fa55741cc73fe7
+  React-RCTAnimation: a6d29a810430cb58c95ae5e1f67e432a1db27305
+  React-RCTAppDelegate: 85cc27deda68eff86cf739aaa3ff3433fc917b8f
+  React-RCTBlob: b968df17b5df1afc619a3cad69a0a970b3030639
+  React-RCTFabric: 9e3bb92b4c388f4e90672cf073f906884489012b
+  React-RCTImage: 78cbfae55ea3ec1c901476000162b2847d6cf55a
+  React-RCTLinking: 0fe1678f2c1bb97f41e809ffd4039eba43bf70c0
+  React-RCTNetwork: 95a92567b3cc0ec9c7fdf19842abbf53549a840b
+  React-RCTSettings: a9476681dc2abbce2ade3fe7f5f0033a8cee860c
+  React-RCTText: 9964d058399d4b109c733bff190ac0883455f038
+  React-RCTVibration: e4ddb1cc54e9990c7101495e6f56d255b1c45f83
   React-rendererconsistency: 660af52b5b8b2599f0dfde7f8212fb8bf684d968
-  React-rendererdebug: 782760e7f56bc6d78c7917b8000442c79bb0ab15
+  React-rendererdebug: dcd9ede399cc1db859cb353e34d405da968c5a3d
   React-rncore: 855146e1e0b9bdeeddf6f6f1aca5c68d306b5e44
-  React-RuntimeApple: fc2293ed693e2f8ba738a34aac98dafbfe873ffe
-  React-RuntimeCore: 17d33d54ef200d41829a9d0aa95ad454583faf60
+  React-RuntimeApple: 8edaf5102e950f4f3f1b51d68eeb1cce52f107ad
+  React-RuntimeCore: 51ad882d1ee1e31461ac9eb3b45fe7c416b7ab47
   React-runtimeexecutor: 6ed13de8c9a67c6001ba82ca108055d8acfc2f8b
-  React-RuntimeHermes: d9db4a678c02b3ac5f3901a528d37446083de0d8
-  React-runtimescheduler: 88658434e250d004d77f3b8f94078cf5836ff9b5
+  React-RuntimeHermes: d5d6c7e95526df82a1845061f6d1e718fefebe71
+  React-runtimescheduler: 66d4b7d9d7da38226df9671f77153a1fb8eb5d56
   React-timing: 9e213f60979bd63e39cc81f07a02a39b1ba694d5
-  React-utils: 7b5f884193005345985dad15b84f324d6bc7731d
-  ReactCodegen: f4ec52507766ae9229e6daff936ef4819cd38d64
-  ReactCommon: 964a21f03865d9b98dcc64df7b172be083e108c9
+  React-utils: 3150e79f96ae8962a9afab093f9d1c1290cf7f4f
+  ReactCodegen: d5e300d9ee165783f70ddb3f2d834edac95fb0d3
+  ReactCommon: ae12ea136cda6ddd0543a257b146e238c24854bf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: ab232da848cdafe246b43dcddf55ea32748d3283
+  Yoga: dcf6b28b5105d538537e656bf4e239f4d87fc546
 
 PODFILE CHECKSUM: 071b90f05ebee198a276ce4152181e57ed2f999b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
The motivation of this PR is to pass native logs to Radon IDE. Currently, if the app crashes on the native side developer needs to open Xcode anyway.

⚠️ DISCLAIMER: The current approach won't work with Expo Go and Expo Dev Client, as those are run through deep link not `xcrun simctl launch`. 

I tried: `xcrun simctl --set {deviceLocation} spawn booted log stream`, `react-native log-ios`, looking through files in the container if there is something that looks like logs - none of those work. 

<s>What I did:
- add params to `xcrun simctl launch`  that print `stderr` and `stout` to file,
- watch for changes in this log file,
- send new chunks into VSCode output.</s>

**Changed during review:**

What I did:
- add `--console` param to `xcrun simctl launch`, which logs the process output 
- redirect this output to VSCode. 

### How Has This Been Tested: 

**Normal:**
0. Start by adding to AppDelegate.mm, `didFinishLaunchingWithOptions`:
```
  NSLog(@"AppDelegate didFinishLaunchingWithOptions");
```
1. Start the app
2. Go to `Radon IDE (iOS Simulator Logs)` output
4. Verify the logs are ther
5. Restart app process, verify that new logs are comming 

**Crash:**
0. Start by adding to AppDelegate.mm, `didFinishLaunchingWithOptions`:
```

  NSLog(@"AppDelegate didFinishLaunchingWithOptions");

  double delayInSeconds = 5.0;
  dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)); // 1 
  dispatch_after(popTime, dispatch_get_main_queue(), ^(void){ // 2 
    @throw [NSException exceptionWithName:@"Something is not right exception"
                                reason:@"Can't perform this operation because of this or that"
                              userInfo:nil];
  });

```
1. Start the app, it should crash after 5s
2. Go to `Radon IDE (iOS Simulator Logs)` output
3. Look for the error in the output 

### Demo

<video src="https://github.com/user-attachments/assets/ed065f66-b710-4227-8ec6-7ebb72b3964f" />

