### PR TITLE
Shorten duration of replay rewind animation

### DIFF
--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
@@ -18,7 +18,7 @@ function acceleratedRewind(
   setTimeCallback: (time: number) => void,
   readyCallback: () => void
 ) {
-  const rewindTimeSec = 1.6;
+  const rewindTimeSec = 0.6;
 
   const v0 = 0.1;
   const vFinal = 2 / rewindTimeSec - v0;

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
@@ -18,13 +18,8 @@ function acceleratedRewind(
   setTimeCallback: (time: number) => void,
   readyCallback: () => void
 ) {
-  // If REPLAY_REWIND_INTRODUCE_KEY is missing in global state, we assume that the
-  // replay rewind feature has not been introduced. In this case, we use a longer
-  // rewind time to help users more easily understand the rewind feature.
-  const REPLAY_REWIND_INTRODUCE_KEY = "wasReplayRewindIntroduced";
-  const wasRewindIntroduced = localStorage.getItem(REPLAY_REWIND_INTRODUCE_KEY) ?? false;
+  const rewindTimeSec = 0.6;
 
-  const rewindTimeSec = wasRewindIntroduced ? 0.6 : 1.6;
   const v0 = 0.1;
   const vFinal = 2 / rewindTimeSec - v0;
   const acc = (vFinal - v0) / rewindTimeSec;
@@ -52,10 +47,6 @@ function acceleratedRewind(
     }
   }
   requestAnimationFrame(frame);
-
-  if (!wasRewindIntroduced) {
-    localStorage.setItem(REPLAY_REWIND_INTRODUCE_KEY, "true");
-  }
 }
 
 function isVideoPlaying(videoElement: HTMLVideoElement) {

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
@@ -18,8 +18,13 @@ function acceleratedRewind(
   setTimeCallback: (time: number) => void,
   readyCallback: () => void
 ) {
-  const rewindTimeSec = 0.6;
+  // If REPLAY_REWIND_INTRODUCE_KEY is missing in global state, we assume that the
+  // replay rewind feature has not been introduced. In this case, we use a longer
+  // rewind time to help users more easily understand the rewind feature.
+  const REPLAY_REWIND_INTRODUCE_KEY = "wasReplayRewindIntroduced";
+  const wasRewindIntroduced = localStorage.getItem(REPLAY_REWIND_INTRODUCE_KEY) ?? false;
 
+  const rewindTimeSec = wasRewindIntroduced ? 0.6 : 1.6;
   const v0 = 0.1;
   const vFinal = 2 / rewindTimeSec - v0;
   const acc = (vFinal - v0) / rewindTimeSec;
@@ -47,6 +52,10 @@ function acceleratedRewind(
     }
   }
   requestAnimationFrame(frame);
+
+  if (!wasRewindIntroduced) {
+    localStorage.setItem(REPLAY_REWIND_INTRODUCE_KEY, "true");
+  }
 }
 
 function isVideoPlaying(videoElement: HTMLVideoElement) {


### PR DESCRIPTION
This PR shortens duration of rewind animation to improve the usability of the rewind feature.

### Testing:
Ensure that the duration of the replay takes 0.6sec.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/68c8354f-49b7-4d1e-af49-11230540591e"/>|<video src="https://github.com/user-attachments/assets/c03b42f3-ec96-4174-8418-bf596b62a2a2" />|
