### PR TITLE
Add Hebrew to locale list

### DIFF
--- a/packages/vscode-extension/src/webview/utilities/localeList.json
+++ b/packages/vscode-extension/src/webview/utilities/localeList.json
@@ -124,6 +124,10 @@
     "Description": "Gujarati"
   },
   {
+    "localeIdentifier": "he_IL",
+    "Description": "Hebrew (Israel)"
+  },
+  {
     "localeIdentifier": "hi_IN",
     "Description": "Hindi (India)"
   },


### PR DESCRIPTION
This PR adds missing Hebrew localeIdentifierto the `localeList.json`.

### How Has This Been Tested: 
- Tested following the test plan from #590 (same for iOS).

|Before|After|
|-|-|
|<img width="484" alt="Screenshot 2024-12-17 at 17 10 02" src="https://github.com/user-attachments/assets/24721583-6d19-4c9d-b14f-96f882de92cd" />|<img width="477" alt="Screenshot 2024-12-17 at 17 19 23" src="https://github.com/user-attachments/assets/efc0c7ae-1ae7-444e-b123-aad738ce6334" />|

|iOS|Android|
|-|-|
|<img width="562" alt="" src="https://github.com/user-attachments/assets/c85ab9bd-e791-48ca-90fc-675cfdc15720" />|<img width="562" alt="" src="https://github.com/user-attachments/assets/1efa550e-67a2-4afc-99cd-d716ade4c743"/>|
