### PR TITLE
Fix log counter multiplying itself after reload 

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -150,9 +150,6 @@ export class DeviceSession implements Disposable {
     ]);
     Logger.debug("App and preview ready, moving on...");
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
-    if (this.debugSession) {
-      this.debugSession.dispose();
-    }
     await this.startDebugger();
 
     this.isLaunching = false;
@@ -229,6 +226,9 @@ export class DeviceSession implements Disposable {
   }
 
   private async startDebugger() {
+    if (this.debugSession) {
+      this.debugSession.dispose();
+    }
     this.debugSession = new DebugSession(this.metro, this.debugEventDelegate);
     const started = await this.debugSession.start();
     if (started) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -85,10 +85,12 @@ export class DeviceSession implements Disposable {
   public async perform(type: ReloadAction) {
     switch (type) {
       case "reinstall":
+        this.debugSession?.dispose();
         await this.installApp({ reinstall: true });
         await this.launchApp();
         return true;
       case "restartProcess":
+        this.debugSession?.dispose();
         await this.launchApp();
         return true;
       case "reloadJs":

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -85,12 +85,10 @@ export class DeviceSession implements Disposable {
   public async perform(type: ReloadAction) {
     switch (type) {
       case "reinstall":
-        this.debugSession?.dispose();
         await this.installApp({ reinstall: true });
         await this.launchApp();
         return true;
       case "restartProcess":
-        this.debugSession?.dispose();
         await this.launchApp();
         return true;
       case "reloadJs":
@@ -152,6 +150,9 @@ export class DeviceSession implements Disposable {
     ]);
     Logger.debug("App and preview ready, moving on...");
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
+    if (this.debugSession) {
+      this.debugSession.dispose();
+    }
     await this.startDebugger();
 
     this.isLaunching = false;


### PR DESCRIPTION
This PR fixes log counter multiplication after, either `restartProcess`  or `reinstall` reload options. It was caused by the old DebugSession not being disposed of. 

To solve the issue we dispose the old debag session before creating a new one.

### How Has This Been Tested: 

- run any application and reload it using  `restartProcess`  or `reinstall` 
- check if the log counter works as expected


