### PR TITLE
Fix mobile sidebar menu cropped

### DIFF
--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -1,6 +1,7 @@
 :root {
   --swm-expandable-transition: transform 200ms ease;
   --swm-logo-height: 36px;
+  --swm-sidebar-header-height: 68px;
 }
 
 table {
@@ -116,6 +117,10 @@ table thead tr {
 
 nav [class*="_sidebarFooter"] {
   display: none;
+}
+
+nav [class*="navbar-sidebar__items"] {
+  height: calc(100% - var(--swm-sidebar-header-height));
 }
 
 img + blockquote {


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/69d7cb03-88c7-487c-ba8a-57b6f66639a2)


## After


![image](https://github.com/user-attachments/assets/5a9b224b-dacf-44f8-998c-b0f29e436761)


Fixes #749


