### PR TITLE
Refactor debug adapter

### DIFF
--- a/packages/vscode-extension/src/debugging/BreakpointsController.ts
+++ b/packages/vscode-extension/src/debugging/BreakpointsController.ts
@@ -1,0 +1,79 @@
+import { SourceMapConsumer } from "source-map";
+import { CDPCommunicator } from "./CDPCommunicator";
+import { MyBreakpoint } from "./MyBreakpoint";
+import { SourceMapController } from "./SourceMapsController";
+import { Breakpoint } from "@vscode/debugadapter";
+import { DebugProtocol } from "@vscode/debugprotocol";
+
+export class BreakpointsController {
+  private breakpoints = new Map<string, Array<MyBreakpoint>>();
+
+  constructor(
+    private sourceMapController: SourceMapController,
+    private CDPCommunicator: CDPCommunicator
+  ) {}
+
+  public updateBreakpointsInSource(sourceURL: string, consumer: SourceMapConsumer) {
+    // this method gets called after we are informed that a new script has been parsed. If we
+    // had breakpoints set in that script, we need to let the runtime know about it
+
+    // the number of consumer mapping entries can be close to the number of symbols in the source file.
+    // we optimize the process by collecting unique source URLs which map to actual individual source files.
+    // note: apparently despite the TS types from the source-map library, mapping.source can be null
+    const uniqueSourceMapPaths = new Set<string>();
+    consumer.eachMapping((mapping) => mapping.source && uniqueSourceMapPaths.add(mapping.source));
+
+    uniqueSourceMapPaths.forEach((sourceMapPath) => {
+      const absoluteFilePath = this.sourceMapController.toAbsoluteFilePath(sourceMapPath);
+      const breakpoints = this.breakpoints.get(absoluteFilePath) || [];
+      breakpoints.forEach(async (bp) => {
+        await bp.reset(sourceMapPath);
+      });
+    });
+  }
+
+  public async setBreakpoints(
+    sourcePath: string,
+    breakpoints: DebugProtocol.SourceBreakpoint[] | undefined
+  ) {
+    const previousBreakpoints = this.breakpoints.get(sourcePath) || [];
+
+    const newBreakpoints = (breakpoints || []).map((bp) => {
+      const previousBp = previousBreakpoints.find(
+        (prevBp) => prevBp.line === bp.line && prevBp.column === bp.column
+      );
+      if (previousBp) {
+        return previousBp;
+      } else {
+        return new MyBreakpoint(
+          this.CDPCommunicator,
+          this.sourceMapController,
+          false,
+          bp.line,
+          bp.column
+        );
+      }
+    });
+
+    // remove old breakpoints
+    previousBreakpoints.forEach((bp) => {
+      if (
+        bp.verified &&
+        !newBreakpoints.find((newBp) => newBp.line === bp.line && newBp.column === bp.column)
+      ) {
+        bp.delete();
+      }
+    });
+
+    this.breakpoints.set(sourcePath, newBreakpoints);
+
+    const resolvedBreakpoints = await Promise.all<Breakpoint>(
+      newBreakpoints.map(async (bp) => {
+        await bp.add(sourcePath);
+        return bp;
+      })
+    );
+
+    return resolvedBreakpoints;
+  }
+}

--- a/packages/vscode-extension/src/debugging/CDPCommunicator.ts
+++ b/packages/vscode-extension/src/debugging/CDPCommunicator.ts
@@ -1,0 +1,83 @@
+import WebSocket from "ws";
+import { Logger } from "../Logger";
+
+type ResolveType<T = unknown> = (result: T) => void;
+type RejectType = (error: unknown) => void;
+
+type PromiseHandlers<T = unknown> = {
+  resolve: ResolveType<T>;
+  reject: RejectType;
+};
+
+export class CDPCommunicator {
+  private connection: WebSocket;
+
+  private cdpMessageId = 0;
+  private cdpMessagePromises: Map<number, PromiseHandlers> = new Map();
+
+  constructor(
+    websocketAddress: string,
+    onConnectionClosed: () => void,
+    onIncomingCDPMethod: (message: any) => Promise<void>
+  ) {
+    this.connection = new WebSocket(websocketAddress);
+
+    this.connection.on("open", this.setUpDebugger);
+
+    this.connection.on("close", onConnectionClosed);
+
+    this.connection.on("message", async (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.result || message.error) {
+        this.handleCDPMessagePromise(message);
+        return;
+      }
+      await onIncomingCDPMethod(message);
+    });
+  }
+
+  private setUpDebugger = () => {
+    // the below catch handler is used to ignore errors coming from non critical CDP messages we
+    // expect in some setups to fail
+    const ignoreError = () => {};
+    Logger.debug("Frytki", this);
+    this.sendCDPMessage("FuseboxClient.setClientMetadata", {}).catch(ignoreError);
+    this.sendCDPMessage("Runtime.enable", {});
+    this.sendCDPMessage("Debugger.enable", { maxScriptsCacheSize: 100000000 });
+    this.sendCDPMessage("Debugger.setPauseOnExceptions", { state: "none" });
+    this.sendCDPMessage("Debugger.setAsyncCallStackDepth", { maxDepth: 32 }).catch(ignoreError);
+    this.sendCDPMessage("Debugger.setBlackboxPatterns", { patterns: [] }).catch(ignoreError);
+    this.sendCDPMessage("Runtime.runIfWaitingForDebugger", {}).catch(ignoreError);
+  };
+
+  private handleCDPMessagePromise = (message: any) => {
+    const messagePromise = this.cdpMessagePromises.get(message.id);
+    this.cdpMessagePromises.delete(message.id);
+    if (message.result && messagePromise?.resolve) {
+      messagePromise.resolve(message.result);
+    } else if (message.error && messagePromise?.reject) {
+      Logger.warn("CDP message error received", message.error);
+      // create an error object such that we can capture stack trace and assign
+      // all object error properties as provided by CDP
+      const error = new Error();
+      Object.assign(error, message.error);
+      messagePromise.reject(error);
+    }
+  };
+
+  public closeConnection() {
+    this.connection.close();
+  }
+
+  public async sendCDPMessage(method: string, params: object) {
+    const message = {
+      id: ++this.cdpMessageId,
+      method: method,
+      params: params,
+    };
+    this.connection.send(JSON.stringify(message));
+    return new Promise<any>((resolve, reject) => {
+      this.cdpMessagePromises.set(message.id, { resolve, reject });
+    });
+  }
+}

--- a/packages/vscode-extension/src/debugging/MyBreakpoint.ts
+++ b/packages/vscode-extension/src/debugging/MyBreakpoint.ts
@@ -1,21 +1,135 @@
 import { Breakpoint, Source } from "@vscode/debugadapter";
+import { CDPCommunicator } from "./CDPCommunicator";
+import { SourceMapController } from "./SourceMapsController";
+import { Logger } from "../Logger";
 
 export class MyBreakpoint extends Breakpoint {
   public readonly line: number;
   public readonly column: number | undefined;
   private _id: number | undefined;
-  constructor(verified: boolean, line: number, column?: number, source?: Source) {
+  private executingQueue: boolean = false;
+  private cdpCommunicationQueue: Array<() => Promise<void>> = [];
+
+  constructor(
+    private CDPCommunicator: CDPCommunicator,
+    private sourceMapController: SourceMapController,
+    verified: boolean,
+    line: number,
+    column?: number,
+    source?: Source
+  ) {
     super(verified, line, column, source);
     this.column = column;
     this.line = line;
   }
-  setId(id: number): void {
+
+  public async delete() {
+    return this.addTaskToQueue(async () => {
+      await this.deleteCDPBreakpoint();
+    });
+  }
+
+  public reset(sourceMapPath: string) {
+    return this.addTaskToQueue(async () => {
+      await this.resetCDPBreakpoint(sourceMapPath);
+    });
+  }
+
+  public async add(sourcePath: string) {
+    return this.addTaskToQueue(async () => {
+      await this.setCDPBreakpoint(sourcePath);
+    });
+  }
+
+  public setId(id: number): void {
     super.setId(id);
     this._id = id;
   }
-  getId(): number | undefined {
+
+  public getId(): number | undefined {
     // we cannot use `get id` here, because Breakpoint actually has a private field
     // called id, and it'd collide with this getter making it impossible to set it
     return this._id;
+  }
+
+  private async resetCDPBreakpoint(sourceMapPath: string) {
+    if (this.verified) {
+      await this.CDPCommunicator.sendCDPMessage("Debugger.removeBreakpoint", {
+        breakpointId: this.getId(),
+      });
+      this.verified = false;
+    }
+    await this.setCDPBreakpoint(sourceMapPath);
+  }
+
+  private async setCDPBreakpoint(sourcePath: string) {
+    if (this.verified) {
+      return;
+    }
+
+    const generatedPos = this.sourceMapController.toGeneratedPosition(
+      sourcePath,
+      this.line,
+      this.column ?? 0
+    );
+    if (!generatedPos) {
+      return;
+    }
+
+    const result = await this.CDPCommunicator.sendCDPMessage("Debugger.setBreakpointByUrl", {
+      // in CDP line and column numbers are 0-based
+      lineNumber: generatedPos.lineNumber1Based - 1,
+      url: generatedPos.source,
+      columnNumber: generatedPos.columnNumber0Based,
+      condition: "",
+    });
+    if (result && result.breakpointId !== undefined) {
+      this.setId(result.breakpointId);
+      this.verified = true;
+    }
+  }
+
+  private async deleteCDPBreakpoint() {
+    await this.CDPCommunicator.sendCDPMessage("Debugger.removeBreakpoint", {
+      breakpointId: this.getId(),
+    });
+  }
+
+  private executeCommunication() {
+    if (!this.executingQueue && this.cdpCommunicationQueue.length > 0) {
+      this.executingQueue = true;
+      this.executeNextTask();
+    }
+  }
+
+  private executeNextTask() {
+    if (this.cdpCommunicationQueue.length === 0) {
+      this.executingQueue = false;
+      return;
+    }
+
+    const task = this.cdpCommunicationQueue.shift();
+    task!()
+      .then(() => {
+        this.executeNextTask();
+      })
+      .catch((err) => {
+        Logger.warn("Error executing task on breakpoint:", this.getId(), err);
+        this.executeNextTask();
+      });
+  }
+
+  private async addTaskToQueue(task: () => Promise<void>) {
+    return new Promise<void>((res, rej) => {
+      this.cdpCommunicationQueue.push(() => {
+        return new Promise<void>((resolve) => {
+          task().finally(() => {
+            resolve();
+            res();
+          });
+        });
+      });
+      this.executeCommunication();
+    });
   }
 }

--- a/packages/vscode-extension/src/debugging/MyBreakpoint.ts
+++ b/packages/vscode-extension/src/debugging/MyBreakpoint.ts
@@ -1,0 +1,21 @@
+import { Breakpoint, Source } from "@vscode/debugadapter";
+
+export class MyBreakpoint extends Breakpoint {
+  public readonly line: number;
+  public readonly column: number | undefined;
+  private _id: number | undefined;
+  constructor(verified: boolean, line: number, column?: number, source?: Source) {
+    super(verified, line, column, source);
+    this.column = column;
+    this.line = line;
+  }
+  setId(id: number): void {
+    super.setId(id);
+    this._id = id;
+  }
+  getId(): number | undefined {
+    // we cannot use `get id` here, because Breakpoint actually has a private field
+    // called id, and it'd collide with this getter making it impossible to set it
+    return this._id;
+  }
+}


### PR DESCRIPTION
This PR refactors debug adapter to handle two issues: 
(1) - the `debugAdapter.ts` - file was becoming hard to manage due to it's versatility of use
(2) - solve problems with multiple sources triggering breakpoint updates at the same time

to solve (1) we separate out: `CDPComunicator`, `SourceMapController` and `breakpointController`
to solve (2) we move the responsibility of updating the breakpoints from `breakpointController` to `MyBreakpoint` class itself and add incoming update requests to the queue.

### How Has This Been Tested: 

- Run Radon IDE Demo and test breakpoints and console.log
- in the same application add a breakpoint before application starts and then check if removing it in vs code actually removes it 
- run Expo 52 test app and check if break points work as expected


