### PR TITLE
Add switch for device frame visibility

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -12,6 +12,7 @@ import "./shared/SwitchGroup.css";
 
 import Label from "./shared/Label";
 import { useProject } from "../providers/ProjectProvider";
+import { useWorkspaceConfig } from "../providers/WorkspaceConfigProvider";
 import { AppPermissionType, DeviceSettings } from "../../common/Project";
 import { DeviceLocationView } from "../views/DeviceLocationView";
 import { useModal } from "../providers/ModalProvider";
@@ -50,6 +51,7 @@ const resetOptionsAndroid: Array<{ label: string; value: AppPermissionType; icon
 
 function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownProps) {
   const { project, deviceSettings, projectState } = useProject();
+  const { showDeviceFrame, update } = useWorkspaceConfig();
   const { openModal } = useModal();
 
   const resetOptions =
@@ -179,11 +181,23 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             Show Touches
             <Switch.Root
               className="switch-root small-switch"
-              id="enable-replays"
+              id="show-touches"
               onCheckedChange={(checked) =>
                 project.updateDeviceSettings({ ...deviceSettings, showTouches: checked })
               }
               defaultChecked={deviceSettings.showTouches}
+              style={{ marginLeft: "auto" }}>
+              <Switch.Thumb className="switch-thumb" />
+            </Switch.Root>
+          </div>
+          <div className="dropdown-menu-item">
+            <span className="codicon codicon-device-mobile" />
+            Show Device Frame
+            <Switch.Root
+              className="switch-root small-switch"
+              id="show-device-frame"
+              onCheckedChange={(checked) => update("showDeviceFrame", checked)}
+              defaultChecked={showDeviceFrame}
               style={{ marginLeft: "auto" }}>
               <Switch.Thumb className="switch-thumb" />
             </Switch.Root>


### PR DESCRIPTION
This PR introduces a switch for controlling the visibility of the device frame in the IDE panel.

### How This Has Been Tested:
- Toggled the switch to verify that the `Show Device Frame` setting updates correctly and that the device frame visibility is changed accordingly.
- Changed the `Show Device Frame` setting through the VSCode settings and checked if the device settings dropdown reflects this setting correctly after reopening.

Screenshots:

|off|on|
|-|-|
|![Screenshot 2024-11-22 at 16 35 33](https://github.com/user-attachments/assets/f430e927-d90b-4af6-ba6e-52e76e30de21)|![Screenshot 2024-11-22 at 16 35 39](https://github.com/user-attachments/assets/fb5108aa-5bc0-4615-84c1-d18f92283ec7)|
