### PR TITLE
Align KeybindingInfo to the right edge in settings

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -56,6 +56,7 @@ button {
 
 .dropdown-menu-item-wraper {
   display: flex;
+  width: 100%;
   align-items: center;
   gap: 5px;
 }


### PR DESCRIPTION
This PR ensures the `KeybindingInfo` component is consistently aligned to the right within the `.dropdown-menu-item-content` container.

|Before|After|
|-|-|
|![Screenshot 2024-11-22 at 17 09 34](https://github.com/user-attachments/assets/f2026644-dcd9-45ad-b539-fa3cc8f6d091)![Screenshot 2024-11-22 at 17 09 23](https://github.com/user-attachments/assets/410dfdcb-c299-4342-a785-005b87d39972)|![Screenshot 2024-11-22 at 17 08 39](https://github.com/user-attachments/assets/fe6e186a-7441-4cde-b434-34ade68469b1)![Screenshot 2024-11-22 at 17 09 03](https://github.com/user-attachments/assets/3b3c0945-e6aa-4318-92a9-3d0404dc84a0)|