### PR TITLE
Fix package manager undefined

### DIFF
--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -88,7 +88,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
     for (const file of files) {
       const manager = lockFiles.get(file);
       if (manager) {
-        packageManagerCandidates.push(packageManager);
+        packageManagerCandidates.push(manager);
       }
     }
 


### PR DESCRIPTION
https://github.com/software-mansion/radon-ide/pull/735 uses the `packageManager` variable that comes from launch configuration instead of `manager` that was just matched for the given lock file. This results in packager beeing `undefined`. 

Fixes #760

### How Has This Been Tested: 

- Remove node_modules from expo-go project 
- Run IDE in given project
- The IDE should launch



