### PR TITLE
increase recording buffer to support 10 minute videos

### DIFF
--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -141,7 +141,7 @@ export class Preview implements Disposable {
   }
 
   public startRecording() {
-    this.sendCommandOrThrow(`video recording start -m -b 50\n`); // 50MB buffer for in-memory video
+    this.sendCommandOrThrow(`video recording start -b 2000\n`); // 2000MB buffer for on-disk video
   }
 
   public captureAndStopRecording() {


### PR DESCRIPTION
This PR increases the recording buffer size from 50MB to 2000MB and switches from in-memory to on-disk storage to support up to 10 minutes of video recordings. 

Thanks to @balins, we've established that in a worst-case scenario, video sizes are approximately 125MB/minute on Pixel 7 and 150MB/minute on iPhone 15, ensuring that 2000MB provides a safe margin.

### How Has This Been Tested:
- Ensured that recording functionality remains stable after these updates.
