### PR TITLE
Add log count animation, make buttons always round, improve no-device UI

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -98,7 +98,7 @@
   padding-bottom: 6px;
 }
 
-@media (width <= 350px) {
+@media (width <= 360px) {
   .url-select-trigger {
     min-width: 0;
   }

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -98,7 +98,7 @@
   padding-bottom: 6px;
 }
 
-@media (width <= 360px) {
+@media (width <= 385px) {
   .url-select-trigger {
     min-width: 0;
   }

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -98,7 +98,7 @@
   padding-bottom: 6px;
 }
 
-@media (width <= 385px) {
+@media (width <= 425px) {
   .url-select-trigger {
     min-width: 0;
   }

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -100,6 +100,12 @@
 
 @media (width <= 425px) {
   .url-select-trigger {
+    min-width: 80px;
+  }
+}
+
+@media (width <= 385px) {
+  .url-select-trigger {
     min-width: 0;
   }
 }

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -1,5 +1,6 @@
 .icon-button {
   text-align: center;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -12,6 +13,10 @@
   color: var(--swm-button);
   transition: all 200ms 0ms ease-in-out;
   flex-shrink: 0;
+}
+
+.icon-button-icon {
+  transition: transform 200ms ease-in-out;
 }
 
 .icon-button:disabled {
@@ -60,13 +65,22 @@
 }
 
 .icon-button-counter {
-  position: relative;
-  top: -8px;
-  left: 2px;
   border: 0px solid transparent;
   border-radius: 4px;
   color: var(--swm-button-counter);
   background-color: var(--swm-button-counter-background);
   padding: 2px 4px;
   font-size: 11px;
+  position: absolute;
+  top: 20%;
+  right: 0px;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: right 200ms ease-in-out, opacity 200ms ease-in-out;
+}
+
+.icon-button-counter.visible {
+  top: 20%;
+  right: 0px;
+  opacity: 1;
 }

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -11,6 +11,7 @@
   border-radius: 36px;
   color: var(--swm-button);
   transition: all 200ms 0ms ease-in-out;
+  flex-shrink: 0;
 }
 
 .icon-button:disabled {

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
@@ -32,6 +32,8 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
     className = "",
     ...rest
   } = props;
+
+  const showCounter = Boolean(counter);
   const button = (
     <button
       onClick={onClick}
@@ -45,8 +47,18 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
       )}
       {...rest}
       ref={ref}>
-      {children}
-      {Boolean(counter) && <span className="icon-button-counter">{counter}</span>}
+      <span
+        className="icon-button-icon"
+        style={{
+          transform: showCounter ? "translateX(-5px)" : "translateX(0)",
+        }}>
+        {children}
+      </span>
+      {counter !== null && (
+        <span className={classnames("icon-button-counter", showCounter && "visible")}>
+          {counter}
+        </span>
+      )}
     </button>
   );
 

--- a/packages/vscode-extension/src/webview/views/DevicesNotFoundView.css
+++ b/packages/vscode-extension/src/webview/views/DevicesNotFoundView.css
@@ -36,8 +36,8 @@
 }
 
 .devices-not-found-icon > svg {
-  width: 60px;
-  height: 60px;
+  width: 120px;
+  height: 120px;
 }
 
 .devices-not-found-button-spinner {
@@ -45,32 +45,22 @@
   height: 16px;
 }
 
-@media (min-height: 400px) {
-  .devices-not-found-icon > svg {
-    width: 120px;
-    height: 120px;
-  }
-}
-
 @media (max-height: 500px) {
-  .devices-not-found-container {
-    transform: scale(0.6);
+  .devices-not-found-title {
+    margin: 10px;
   }
-
-    .devices-not-found-button-group {
-      width: 70%;
-      gap: 10px;
+    .devices-not-found-subtitle {
+      margin: 20px;
     }
-}
-/* 
-@media (max-height: 600px) {
-  .devices-not-found-container {
-    transform: scale(0.7);
+  .devices-not-found-icon {
+    padding: 12px;
+  }
+  .devices-not-found-icon > svg {
+    width: 60px;
+    height: 60px;
+  }
+  .devices-not-found-button-group {
+    width: 70%;
+    gap: 10px;
   }
 }
-
-@media (max-height: 500px) {
-  .devices-not-found-container {
-    transform: scale(0.6);
-  }
-} */

--- a/packages/vscode-extension/src/webview/views/DevicesNotFoundView.css
+++ b/packages/vscode-extension/src/webview/views/DevicesNotFoundView.css
@@ -36,11 +36,41 @@
 }
 
 .devices-not-found-icon > svg {
-  width: 120px;
-  height: 120px;
+  width: 60px;
+  height: 60px;
 }
 
 .devices-not-found-button-spinner {
   width: 16px;
   height: 16px;
 }
+
+@media (min-height: 400px) {
+  .devices-not-found-icon > svg {
+    width: 120px;
+    height: 120px;
+  }
+}
+
+@media (max-height: 500px) {
+  .devices-not-found-container {
+    transform: scale(0.6);
+  }
+
+    .devices-not-found-button-group {
+      width: 70%;
+      gap: 10px;
+    }
+}
+/* 
+@media (max-height: 600px) {
+  .devices-not-found-container {
+    transform: scale(0.7);
+  }
+}
+
+@media (max-height: 500px) {
+  .devices-not-found-container {
+    transform: scale(0.6);
+  }
+} */

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.css
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.css
@@ -23,11 +23,12 @@
   margin-bottom: 5px;
 }
 
-.container {
-  flex: 1;
-
+.launch-configuration-container {
+  display: flex;
+  flex-direction: column;
   padding-right: 5%;
   padding-left: 2.5%;
+  margin: 12px 0 0 0;
 }
 
 .launch-configuration-section-margin {

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -79,7 +79,7 @@ function IosConfiguration({ scheme, configuration, update, xcodeSchemes }: iosCo
   availableXcodeSchemes.push({ value: "Auto", label: "Auto" });
 
   return (
-    <div className="container">
+    <div className="launch-configuration-container">
       <div className="setting-description">Scheme:</div>
       <Select
         value={scheme ?? "Auto"}
@@ -126,7 +126,7 @@ function AndroidConfiguration({ buildType, productFlavor, update }: androidConfi
   };
 
   return (
-    <div className="container">
+    <div className="launch-configuration-container">
       <div className="setting-description">Build Type:</div>
       <input
         ref={buildTypeInputRef}
@@ -164,7 +164,7 @@ function AppRootConfiguration({ appRoot, update }: appRootConfigurationProps) {
   };
 
   return (
-    <div className="container">
+    <div className="launch-configuration-container">
       <div className="setting-description">App Root:</div>
       <input
         ref={appRootInputRef}
@@ -194,7 +194,7 @@ function MetroConfigPathConfiguration({ metroConfigPath, update }: metroPathConf
   };
 
   return (
-    <div className="container">
+    <div className="launch-configuration-container">
       <div className="setting-description">Metro Config Path:</div>
       <input
         ref={metroPathInputRef}
@@ -230,7 +230,7 @@ function IsExpoConfiguration({ isExpo, update }: isExpoConfigurationProps) {
   };
 
   return (
-    <div className="container">
+    <div className="launch-configuration-container">
       <div className="setting-description">Is Expo:</div>
       <Select
         value={isExpo?.toString() ?? "Auto"}

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.css
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.css
@@ -3,11 +3,13 @@
   margin-right: 12px;
 }
 
-.container {
+.manage-devices-container {
   margin: 12px 0 0 0;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  padding-right: 5%;
+  padding-left: 2.5%;
 }
 
 .delete-icon {
@@ -98,4 +100,13 @@
 .create-button-text {
   margin-left: 4px;
   text-wrap: nowrap;
+}
+
+@media (width <= 480px) {
+  .manage-devices-container {
+    padding: 0;
+  }
+  .device-row {
+    padding: 2px 0px 2px 0px;
+  }
 }

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.css
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.css
@@ -17,7 +17,7 @@
 .device-row {
   display: grid;
   grid-template-columns: 32px 1fr 90px;
-  width: 430px;
+  width: 410px;
   align-items: center;
   gap: 10px;
   line-height: 1;
@@ -82,8 +82,8 @@
   justify-content: center;
 }
 .device-button-group .icon-button {
-  min-width: 30px;
-  max-height: 30px;
+  width: 30px;
+  height: 30px;
 }
 
 .warning {

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -164,7 +164,7 @@ function ManageDevicesView() {
   }
 
   return (
-    <div className="container">
+    <div className="manage-devices-container">
       {iosDevices.length > 0 && (
         <>
           <Label>iOS Devices</Label>

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -90,7 +90,7 @@
   margin-right: 6px;
 }
 
-@media (max-width: 380px) {
+@media (max-width: 385px) {
   .button-group-top,
     .button-group-bottom {
       gap: 2px;

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -89,3 +89,10 @@
   border-radius: 50%;
   margin-right: 6px;
 }
+
+@media (max-width: 380px) {
+  .button-group-top,
+    .button-group-bottom {
+      gap: 2px;
+    }
+}

--- a/packages/vscode-extension/src/webview/views/View.css
+++ b/packages/vscode-extension/src/webview/views/View.css
@@ -3,7 +3,7 @@
   display: flex;
   padding: 0px 8px;
   flex-direction: column;
-  justify-content: center;
+  justify-content: start;
   align-items: center;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
This PR includes several updates:
 - improves the responsiveness of DevicesNotFoundView, ensuring that the top group buttons remain visible even when the height of DevicesNotFoundView is reduced
- prevents IconButtons from shrinking, keeping their round shape rather than becoming elliptical as previously occurred in narrow windows
- adds a smooth animation for showing and hiding the log counter
- improves the responsiveness of ManageDevicesView

Fixes #671 

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/d67969cd-e364-4c44-80c5-6b7057c8e67c" />|<video src="https://github.com/user-attachments/assets/d82c9bdd-9ed3-4e14-bb62-6bc960cc3c8c" />|
|<video src="https://github.com/user-attachments/assets/9f8fffd4-1aee-4f72-ac90-b67c0f055d8d" />|<video src="https://github.com/user-attachments/assets/66788827-71af-498c-b1ff-2eb325b3478e" />|
|<img width="148" alt="Screenshot 2024-11-25 at 18 01 38" src="https://github.com/user-attachments/assets/059368b9-d99c-4b73-b87e-2f6f49f64922">|<img width="144" alt="Screenshot 2024-11-25 at 18 12 56" src="https://github.com/user-attachments/assets/69669678-c378-4e2f-b240-8d0d3605f573">|
|<img width="470" alt="Screenshot 2024-11-25 at 18 47 00" src="https://github.com/user-attachments/assets/0be1d675-8e25-47ad-a111-e372b59f1612">|<img width="470" alt="Screenshot 2024-11-25 at 18 46 50" src="https://github.com/user-attachments/assets/e861a72d-5d5e-493f-8c21-6fee6aa0970c">|
