### PR TITLE
Fix IDE panel relocation after selecting preview/storybook

### DIFF
--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -60,7 +60,11 @@ export class TabPanel implements Disposable {
   public static render(context: ExtensionContext, fileName?: string, lineNumber?: number) {
     if (TabPanel.currentPanel) {
       // If the webview panel already exists reveal it
-      TabPanel.currentPanel._panel.reveal(ViewColumn.Beside);
+      const activeRNIDEColumn = window.tabGroups.all.find(
+        (group) =>
+          group.activeTab?.label === "React Native IDE" || group.activeTab?.label === "Radon IDE"
+      )?.viewColumn;
+      TabPanel.currentPanel._panel.reveal(activeRNIDEColumn);
     } else {
       // If a webview panel does not already exist create and show a new one
 

--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -60,12 +60,7 @@ export class TabPanel implements Disposable {
   public static render(context: ExtensionContext, fileName?: string, lineNumber?: number) {
     if (TabPanel.currentPanel) {
       // If the webview panel already exists reveal it
-      const activeRNIDEColumn =
-        window.tabGroups.all.find(
-          (group) =>
-            group.activeTab?.label === "React Native IDE" || group.activeTab?.label === "Radon IDE"
-        )?.viewColumn ?? ViewColumn.Beside;
-      TabPanel.currentPanel._panel.reveal(activeRNIDEColumn);
+      TabPanel.currentPanel._panel.reveal();
     } else {
       // If a webview panel does not already exist create and show a new one
 

--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -60,10 +60,11 @@ export class TabPanel implements Disposable {
   public static render(context: ExtensionContext, fileName?: string, lineNumber?: number) {
     if (TabPanel.currentPanel) {
       // If the webview panel already exists reveal it
-      const activeRNIDEColumn = window.tabGroups.all.find(
-        (group) =>
-          group.activeTab?.label === "React Native IDE" || group.activeTab?.label === "Radon IDE"
-      )?.viewColumn;
+      const activeRNIDEColumn =
+        window.tabGroups.all.find(
+          (group) =>
+            group.activeTab?.label === "React Native IDE" || group.activeTab?.label === "Radon IDE"
+        )?.viewColumn ?? ViewColumn.Beside;
       TabPanel.currentPanel._panel.reveal(activeRNIDEColumn);
     } else {
       // If a webview panel does not already exist create and show a new one


### PR DESCRIPTION
This PR resolves the issue where selecting a codeLens with a preview or Storybook's preview unintentionally relocates the IDE panel to the editor column to the side of the active one (`ViewColumn.Beside`). The `showIDEPanel` function has been fixed to ensure that the IDE panel remains in the active column, labeled with our IDE's name.

Fixes #761

### How Has This Been Tested:
- The IDE was opened in the left tab and code with a preview in the right tab. After selecting the codeLens, it was confirmed that the IDE remained in its original position.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/86211141-f8ee-402a-9e65-74681227771e" />|<video src="https://github.com/user-attachments/assets/bdeb37cf-8130-45c9-988d-1c85abb7f75d" />|
