### PR TITLE
Use debug level for logs previously logged with Logger.log

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -64,7 +64,7 @@ export class BuildManager {
       if (forceCleanBuild || buildDependenciesChanged) {
         // we reset the cache when force clean build is requested as the newly
         // started build may end up being cancelled
-        Logger.log(
+        Logger.debug(
           "Build cache is being invalidated",
           forceCleanBuild ? "on request" : "due to build dependencies change"
         );
@@ -72,15 +72,17 @@ export class BuildManager {
       } else {
         const cachedBuild = await buildCache.getBuild(currentFingerprint);
         if (cachedBuild) {
-          Logger.log("Skipping native build – using cached");
+          Logger.debug("Skipping native build – using cached");
           getTelemetryReporter().sendTelemetryEvent("build:cache-hit", { platform });
           return cachedBuild;
         } else {
-          Logger.log("Build cache is stale");
+          Logger.debug("Build cache is stale");
         }
       }
 
-      Logger.log("Starting native build – no build cached, cache has been invalidated or is stale");
+      Logger.debug(
+        "Starting native build – no build cached, cache has been invalidated or is stale"
+      );
       getTelemetryReporter().sendTelemetryEvent("build:start", { platform });
 
       let buildResult: BuildResult;

--- a/packages/vscode-extension/src/builders/PlatformBuildCache.ts
+++ b/packages/vscode-extension/src/builders/PlatformBuildCache.ts
@@ -123,7 +123,7 @@ export class PlatformBuildCache {
     const fingerprint = await createFingerprintAsync(getAppRootFolder(), {
       ignorePaths: IGNORE_PATHS,
     });
-    Logger.log("App folder fingerprint", fingerprint.hash);
+    Logger.debug("App folder fingerprint", fingerprint.hash);
     return fingerprint.hash;
   }
 
@@ -141,14 +141,14 @@ export class PlatformBuildCache {
       return undefined;
     }
 
-    Logger.log(`Using custom fingerprint script '${fingerprintCommand}'`);
+    Logger.debug(`Using custom fingerprint script '${fingerprintCommand}'`);
     const fingerprint = await runfingerprintCommand(fingerprintCommand, env);
 
     if (!fingerprint) {
       throw new Error("Failed to generate workspace fingerprint using custom script.");
     }
 
-    Logger.log("Workspace fingerprint", fingerprint);
+    Logger.debug("Workspace fingerprint", fingerprint);
     return fingerprint;
   }
 }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -583,7 +583,7 @@ export class Project
     }
 
     if (device) {
-      Logger.log("Device selected", deviceInfo.displayName);
+      Logger.debug("Device selected", deviceInfo.displayName);
       extensionContext.workspaceState.update(LAST_SELECTED_DEVICE_KEY, deviceInfo.id);
       return device;
     }


### PR DESCRIPTION
This PR updates some Logger statements to use Logger.debug instead of Logger.log

Logger.log are dev-only entries but was likely misused in a few places that this PR updates. When using Logger.debug, users will get additional traces for the log statements which is helpful when troubleshooting issues.

### How Has This Been Tested: 
n/a