### PR TITLE
Add exception handler for source-map originalPositionFor calls

### DIFF
--- a/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
+++ b/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
@@ -76,18 +76,22 @@ export class SourceMapsRegistry {
       // than localhost because it has a virtual network interface. Hence we need to unify the URL:
       if (id === scriptIdOrURL || compareIgnoringHost(url, scriptIdOrURL)) {
         scriptURL = url;
-        const pos = consumer.originalPositionFor({
-          line: lineNumber1Based - lineOffset,
-          column: columnNumber0Based,
-        });
-        if (pos.source !== null) {
-          sourceURL = pos.source;
-        }
-        if (pos.line !== null) {
-          sourceLine1Based = pos.line;
-        }
-        if (pos.column !== null) {
-          sourceColumn0Based = pos.column;
+        try {
+          const pos = consumer.originalPositionFor({
+            line: lineNumber1Based - lineOffset,
+            column: columnNumber0Based,
+          });
+          if (pos.source !== null) {
+            sourceURL = pos.source;
+          }
+          if (pos.line !== null) {
+            sourceLine1Based = pos.line;
+          }
+          if (pos.column !== null) {
+            sourceColumn0Based = pos.column;
+          }
+        } catch (e) {
+          Logger.error("Error while looking for original position in source map:", e);
         }
       }
     });


### PR DESCRIPTION
This PR adds try/catch block around `originalPositionFor` calls. From telemetry we see this method throwing unhandled exceptions. While we don't yet understand the reason for those errors, we can always fallback to using non-translated lines. This will still degrade the experience when this error happen, but at least wouldn't prevent logs from appearing in the console tab, will offload our telemetry as we're likely missing some important signals because of this exception, and may hopefully allow us to troubleshoot the root cause of this issue.

### How Has This Been Tested: 
This hasn't been tested as we're not able to reproduce the problem with invalid source map


