### PR TITLE
Fix react-native 73 test app configuration

### DIFF
--- a/test-apps/react-native-73/.vscode/launch.json
+++ b/test-apps/react-native-73/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+   // Use IntelliSense to learn about possible attributes.
+   // Hover to view descriptions of existing attributes.
+   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+   "version": "0.2.0",
+   "configurations": [
+      {
+         "type": "react-native-ide",
+         "request": "launch",
+         "name": "Radon IDE panel",
+         "android": {
+            "buildType": "debug",
+            "productFlavor": "staging"
+         }
+      }
+   ]
+}

--- a/test-apps/react-native-73/ios/Podfile
+++ b/test-apps/react-native-73/ios/Podfile
@@ -34,7 +34,7 @@ target 'RNBoilerplate' do
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and
     # you should disable the next line.
-    :flipper_configuration => flipper_config,
+    # :flipper_configuration => flipper_config,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )


### PR DESCRIPTION
Fixes #775

This PR fixes the configuration of `test-apps/react-native-73`. Two things changed:
- get rid of Flipper as suggested in https://github.com/facebook/react-native/issues/43335
- force added `launch.json`, which was git ignored by `.gitignore` in `radon-ide` root, imo it makes sense to merge it as this is project specific config, and this is the suggested approach in our docs: https://ide.swmansion.com/docs/guides/configuration#creating-configuration-file

### How Has This Been Tested: 

- open `test-apps/react-native-73` using Radon IDE 


