### PR TITLE
Fix breakpoints set in between JS reloads when using new debugger

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPBreakpoint.ts
+++ b/packages/vscode-extension/src/debugging/CDPBreakpoint.ts
@@ -75,9 +75,12 @@ export class CDPBreakpoint extends Breakpoint {
   };
 
   private deleteWithCDP = async () => {
-    await this.cdpSession.sendCDPMessage("Debugger.removeBreakpoint", {
-      breakpointId: this.cdpId,
-    });
+    if (this.cdpId !== undefined && this.verified) {
+      await this.cdpSession.sendCDPMessage("Debugger.removeBreakpoint", {
+        breakpointId: this.cdpId,
+      });
+    }
+    this.cdpId = undefined;
     this.verified = false;
   };
 

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -66,7 +66,11 @@ export class DebugAdapter extends DebugSession {
       configuration.sourceMapAliases
     );
 
-    this.breakpointsController = new BreakpointsController(this.sourceMapRegistry, this.cdpSession);
+    this.breakpointsController = new BreakpointsController(
+      this.sourceMapRegistry,
+      this.cdpSession,
+      configuration.breakpointsAreRemovedOnContextCleared
+    );
   }
 
   private handleIncomingCDPMethodCalls = async (message: any) => {
@@ -119,7 +123,7 @@ export class DebugAdapter extends DebugSession {
         const allThreads = this.threads;
         this.threads = [];
         this.sourceMapRegistry.clearSourceMaps();
-        this.breakpointsController.resetBreakpoints();
+        this.breakpointsController.onContextCleared();
         this.variableStore.clearReplVariables();
         this.variableStore.clearCDPVariables();
 

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -47,7 +47,8 @@ export class DebugSession implements Disposable {
     }
 
     let sourceMapAliases: Array<[string, string]> = [];
-    if (this.metro.isUsingNewDebugger && this.metro.watchFolders.length > 0) {
+    const isUsingNewDebugger = this.metro.isUsingNewDebugger;
+    if (isUsingNewDebugger && this.metro.watchFolders.length > 0) {
       // first entry in watchFolders is the project root
       sourceMapAliases.push(["/[metro-project]/", this.metro.watchFolders[0]]);
       this.metro.watchFolders.forEach((watchFolder, index) => {
@@ -64,6 +65,7 @@ export class DebugSession implements Disposable {
         websocketAddress: websocketAddress,
         sourceMapAliases,
         expoPreludeLineCount: this.metro.expoPreludeLineCount,
+        breakpointsAreRemovedOnContextCleared: isUsingNewDebugger ? false : true, // new debugger properly keeps all breakpoints in between JS reloads
       },
       {
         suppressDebugStatusbar: true,


### PR DESCRIPTION
This PR fixes the issue when breakpoints set before JS reloads on the new debugger would be effectively set twice and we wouldn't have a way of deleting them later on. This issue is a regression introduced in #755

The issue stems from a difference in behavior between old and new debugger. The old debugger, when JS is reloaded, looses all the information about the previously set breakpoints. Thanks to that, we can forget all the breakpoints in our Debug Adapter and rely on VSCode to request setting them again when new context is instantiated (we send InitializedRequest).

On the other hand, the new debugger keeps the breakpoints in between reloads. Therefore, resetting the list of breakpoints in our registry would lead to the cases where we'd set a single breakpoint for the second time with CDP after reload. As a consequence, we wouldn't be able to delete the breakpoint that was set at the beginning.

This PR adds a new parameter that indicates whether the breakpoints get cleared on context reload. We only set that flag for the old debugger.

### How Has This Been Tested: 
The below is the scenario that was failing:
1. Open app and set breakpoint
2. Reload JS
3. Unset breakpoint
4. Before this change the VM would still be stopping at the breakpoint that is no longer set with the new debugger.

This scenario was tested in RN 76 and RN 74 projects.



