### PR TITLE
Catch source-map errors when calculating generated location

### DIFF
--- a/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
+++ b/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
@@ -91,7 +91,7 @@ export class SourceMapsRegistry {
             sourceColumn0Based = pos.column;
           }
         } catch (e) {
-          Logger.error("Error while translating source map position", e);
+          Logger.error("Error while translating source map to file position", e);
         }
       }
     });
@@ -121,15 +121,19 @@ export class SourceMapsRegistry {
     let position: NullablePosition = { line: null, column: null, lastColumn: null };
     let originalSourceURL: string = "";
     this.sourceMaps.forEach(([sourceURL, scriptId, consumer, lineOffset]) => {
-      const pos = consumer.generatedPositionFor({
-        source: sourceMapFilePath,
-        line: lineNumber1Based,
-        column: columnNumber0Based,
-        bias: SourceMapConsumer.LEAST_UPPER_BOUND,
-      });
-      if (pos.line !== null) {
-        originalSourceURL = sourceURL;
-        position = { ...pos, line: pos.line + lineOffset };
+      try {
+        const pos = consumer.generatedPositionFor({
+          source: sourceMapFilePath,
+          line: lineNumber1Based,
+          column: columnNumber0Based,
+          bias: SourceMapConsumer.LEAST_UPPER_BOUND,
+        });
+        if (pos.line !== null) {
+          originalSourceURL = sourceURL;
+          position = { ...pos, line: pos.line + lineOffset };
+        }
+      } catch (e) {
+        Logger.error("Error while translating file to source map position", e);
       }
     });
     if (position.line === null) {


### PR DESCRIPTION
This PR adds try/catch block around source map consumer call. These calls seem to throw a lot of exception, while in some cases it is possible for the code to recover from those errors. The method where we add try/catch would still return `null` indicating the position couldn't be translated. This would result in breakpoints not getting verified and at least giving some visual clues for the users as opposed to just resulting in uncaught exception.

### How Has This Been Tested: 
We don't have a good reproducer for the case where source map methods throw this type of exceptions, so this change hasn't been tested apart from just checking that breakpoints continue to work in normal settings.



