### PR TITLE
Add license registration

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -8,6 +8,9 @@
       "name": "react-native-ide",
       "version": "0.0.25",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "react-hook-form": "^7.53.2"
+      },
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
         "@expo/fingerprint": "^0.10.3",
@@ -7218,7 +7221,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7432,7 +7434,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8602,7 +8603,6 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -8621,6 +8621,21 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
+      "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -8,9 +8,6 @@
       "name": "react-native-ide",
       "version": "0.0.25",
       "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "react-hook-form": "^7.53.2"
-      },
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
         "@expo/fingerprint": "^0.10.3",
@@ -71,6 +68,7 @@
         "re-resizable": "^6.9.16",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.53.2",
         "rollup": "^4.18.1",
         "semver": "^7.6.2",
         "sinon": "^18.0.0",
@@ -7221,6 +7219,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7434,6 +7433,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8603,6 +8603,7 @@
     },
     "node_modules/react": {
       "version": "18.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -8627,6 +8628,7 @@
       "version": "7.53.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
       "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "dev": true,
       "engines": {
         "node": ">=18.0.0"
       },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -524,5 +524,8 @@
     "vscode-test": "^1.5.0",
     "ws": "^8.14.2",
     "xml2js": "^0.6.2"
+  },
+  "dependencies": {
+    "react-hook-form": "^7.53.2"
   }
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -512,6 +512,7 @@
     "re-resizable": "^6.9.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.53.2",
     "rollup": "^4.18.1",
     "semver": "^7.6.2",
     "sinon": "^18.0.0",
@@ -524,8 +525,5 @@
     "vscode-test": "^1.5.0",
     "ws": "^8.14.2",
     "xml2js": "^0.6.2"
-  },
-  "dependencies": {
-    "react-hook-form": "^7.53.2"
   }
 }

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -105,6 +105,7 @@ export interface ProjectEventMap {
   log: { type: string };
   projectStateChanged: ProjectState;
   deviceSettingsChanged: DeviceSettings;
+  licenseActivationChanged: boolean;
   navigationChanged: { displayName: string; id: string };
   needsNativeRebuild: void;
 }
@@ -139,6 +140,9 @@ export interface ProjectInterface {
   focusDebugConsole(): Promise<void>;
   openNavigation(navigationItemID: string): Promise<void>;
   openDevMenu(): Promise<void>;
+
+  activateLicense(activationKey: string): Promise<boolean>;
+  isLicenseActivated(): Promise<boolean>;
 
   resetAppPermissions(permissionType: AppPermissionType): Promise<void>;
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -101,6 +101,12 @@ export type TouchPoint = {
   yRatio: number;
 };
 
+export enum ActivateDeviceResult {
+  succeeded,
+  notEnoughSeats,
+  unableToVerify,
+}
+
 export interface ProjectEventMap {
   log: { type: string };
   projectStateChanged: ProjectState;
@@ -141,8 +147,8 @@ export interface ProjectInterface {
   openNavigation(navigationItemID: string): Promise<void>;
   openDevMenu(): Promise<void>;
 
-  activateLicense(activationKey: string): Promise<boolean>;
-  isLicenseActivated(): Promise<boolean>;
+  activateLicense(activationKey: string): Promise<ActivateDeviceResult>;
+  hasActiveLicense(): Promise<boolean>;
 
   resetAppPermissions(permissionType: AppPermissionType): Promise<void>;
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -104,6 +104,7 @@ export type TouchPoint = {
 export enum ActivateDeviceResult {
   succeeded,
   notEnoughSeats,
+  keyVerificationFailed,
   unableToVerify,
   connectionFailed,
 }

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -105,6 +105,7 @@ export enum ActivateDeviceResult {
   succeeded,
   notEnoughSeats,
   unableToVerify,
+  connectionFailed,
 }
 
 export interface ProjectEventMap {

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -1,10 +1,9 @@
 import path from "path";
 import { Disposable, workspace } from "vscode";
 import { exec, ChildProcess, lineReader } from "../utilities/subprocess";
-import { extensionContext } from "../utilities/extensionContext";
 import { Logger } from "../Logger";
-import { Platform } from "../utilities/platform";
 import { RecordingData, TouchPoint } from "../common/Project";
+import { simulatorServerBinary } from "../utilities/simulatorServerBinary";
 
 interface VideoRecordingPromiseHandlers {
   resolve: (value: RecordingData) => void;
@@ -55,11 +54,7 @@ export class Preview implements Disposable {
   }
 
   async start() {
-    const simControllerBinary = path.join(
-      extensionContext.extensionPath,
-      "dist",
-      Platform.select({ macos: "simulator-server-macos", windows: "simulator-server-windows.exe" })
-    );
+    const simControllerBinary = simulatorServerBinary();
 
     Logger.debug(`Launch preview ${simControllerBinary} ${this.args}`);
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -5,6 +5,7 @@ import stripAnsi from "strip-ansi";
 import { minimatch } from "minimatch";
 import { isEqual } from "lodash";
 import {
+  ActivateDeviceResult,
   AppPermissionType,
   DeviceSettings,
   InspectData,
@@ -492,13 +493,13 @@ export class Project
   public async activateLicense(activationKey: string) {
     const computerName = os.hostname();
     const activated = await activateDevice(activationKey, computerName);
-    if (activated) {
+    if (activated === ActivateDeviceResult.succeeded) {
       this.eventEmitter.emit("licenseActivationChanged", true);
     }
     return activated;
   }
 
-  public async isLicenseActivated() {
+  public async hasActiveLicense() {
     return !!(await getLicenseToken());
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -32,7 +32,7 @@ import { Devtools } from "./devtools";
 import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { PlatformBuildCache } from "../builders/PlatformBuildCache";
 import { PanelLocation } from "../common/WorkspaceConfig";
-import { activateDevice, getLicenseToken, removeLicenseToken } from "../utilities/license";
+import { activateDevice, getLicenseToken } from "../utilities/license";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
@@ -499,7 +499,6 @@ export class Project
   }
 
   public async isLicenseActivated() {
-    // await removeLicenseToken();
     return !!(await getLicenseToken());
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "stream";
+import os from "os";
 import { Disposable, commands, workspace, window, DebugSessionCustomEvent } from "vscode";
 import stripAnsi from "strip-ansi";
 import { minimatch } from "minimatch";
@@ -31,6 +32,7 @@ import { Devtools } from "./devtools";
 import { AppEvent, DeviceSession, EventDelegate } from "./deviceSession";
 import { PlatformBuildCache } from "../builders/PlatformBuildCache";
 import { PanelLocation } from "../common/WorkspaceConfig";
+import { activateDevice, getLicenseToken, removeLicenseToken } from "../utilities/license";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
@@ -485,6 +487,20 @@ export class Project
 
   public async openDevMenu() {
     await this.deviceSession?.openDevMenu();
+  }
+
+  public async activateLicense(activationKey: string) {
+    const computerName = os.hostname();
+    const activated = await activateDevice(activationKey, computerName);
+    if (activated) {
+      this.eventEmitter.emit("licenseActivationChanged", true);
+    }
+    return activated;
+  }
+
+  public async isLicenseActivated() {
+    // await removeLicenseToken();
+    return !!(await getLicenseToken());
   }
 
   public startPreview(appKey: string) {

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -1,13 +1,17 @@
 import fetch from "node-fetch";
 import { extensionContext } from "./extensionContext";
-import path from "path";
-import { Platform } from "./platform";
 import { exec } from "./subprocess";
+import { Logger } from "../Logger";
+import { simulatorServerBinary } from "./simulatorServerBinary";
+import { ActivateDeviceResult } from "../common/Project";
 
 const TOKEN_KEY = "token_key";
 const BASE_CUSTOMER_PORTAL_URL = "https://portal.ide.swmansion.com/";
 
-export async function activateDevice(licenseKey: string, username: string) {
+export async function activateDevice(
+  licenseKey: string,
+  username: string
+): Promise<ActivateDeviceResult> {
   const url = new URL("/api/create-token", BASE_CUSTOMER_PORTAL_URL);
   const body = {
     fingerprint: await generateDeviceFingerprint(),
@@ -15,34 +19,47 @@ export async function activateDevice(licenseKey: string, username: string) {
     licenseKey,
   };
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  let response;
 
-  let newToken;
-
-  if (response.ok) {
-    const responseBody = await response.json();
-    newToken = responseBody.token as string;
-    extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
-    return true;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    Logger.warn("Creating license token with license key failed", e);
+    return ActivateDeviceResult.unableToVerify;
   }
 
-  return false;
+  const responseBody = await response.json();
+
+  if (response.ok) {
+    const newToken = responseBody.token as string;
+    extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
+    return ActivateDeviceResult.succeeded;
+  }
+
+  if (
+    response.status === 400 &&
+    responseBody.error.startsWith("All seats for a license with a key")
+  ) {
+    return ActivateDeviceResult.notEnoughSeats;
+  }
+
+  return ActivateDeviceResult.unableToVerify;
 }
 
 async function generateDeviceFingerprint() {
-  const simControllerBinary = path.join(
-    extensionContext.extensionPath,
-    "dist",
-    Platform.select({ macos: "simulator-server-macos", windows: "simulator-server-windows.exe" })
-  );
+  const simControllerBinary = simulatorServerBinary();
   const { stdout } = await exec(simControllerBinary, ["fingerprint"]);
   return stdout;
+}
+
+export async function removeLicense() {
+  await extensionContext.secrets.delete(TOKEN_KEY);
 }
 
 export async function getLicenseToken() {

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -13,8 +13,18 @@ export async function activateDevice(
   username: string
 ): Promise<ActivateDeviceResult> {
   const url = new URL("/api/create-token", BASE_CUSTOMER_PORTAL_URL);
+
+  let deviceFingerprint;
+
+  try {
+    deviceFingerprint = await generateDeviceFingerprint();
+  } catch (e) {
+    Logger.error("Error generating device fingerprint", e);
+    return ActivateDeviceResult.unableToVerify;
+  }
+
   const body = {
-    fingerprint: await generateDeviceFingerprint(),
+    fingerprint: deviceFingerprint,
     name: username,
     licenseKey,
   };

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -31,14 +31,14 @@ export async function activateDevice(
     });
   } catch (e) {
     Logger.warn("Creating license token with license key failed", e);
-    return ActivateDeviceResult.unableToVerify;
+    return ActivateDeviceResult.connectionFailed;
   }
 
   const responseBody = await response.json();
 
   if (response.ok) {
     const newToken = responseBody.token as string;
-    extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
+    await extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
     return ActivateDeviceResult.succeeded;
   }
 

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -1,0 +1,61 @@
+import fetch from "node-fetch";
+import { extensionContext } from "./extensionContext";
+import path from "path";
+import { Platform } from "./platform";
+import { exec } from "./subprocess";
+import { Logger } from "../Logger";
+
+const TOKEN_KEY = "token_key";
+const BASE_CUSTOMER_PORTAL_URL = "https://portal.ide.swmansion.com/";
+
+export async function activateDevice(licenseKey: string, username: string) {
+  const url = new URL("/api/create-token", BASE_CUSTOMER_PORTAL_URL);
+  const body = {
+    fingerprint: await generateDeviceFingerprint(),
+    name: username,
+    licenseKey,
+  };
+
+  Logger.debug("Frytki", body, url);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  Logger.debug("Frytki", response.status, await response.json());
+
+  let newToken;
+
+  if (response.ok) {
+    const body = await response.json();
+    newToken = body.token as string;
+    extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
+    return true;
+  }
+
+  return false;
+}
+
+async function generateDeviceFingerprint() {
+  const simControllerBinary = path.join(
+    extensionContext.extensionPath,
+    "dist",
+    Platform.select({ macos: "simulator-server-macos", windows: "simulator-server-windows.exe" })
+  );
+  const { stdout } = await exec(simControllerBinary, ["fingerprint"]);
+  return stdout;
+}
+
+export async function removeLicenseToken() {
+  await extensionContext.secrets.delete(TOKEN_KEY);
+}
+
+export async function getLicenseToken() {
+  const token = await extensionContext.secrets.get(TOKEN_KEY);
+  Logger.debug("Frytki", token);
+  return token;
+}

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -5,7 +5,7 @@ import { Logger } from "../Logger";
 import { simulatorServerBinary } from "./simulatorServerBinary";
 import { ActivateDeviceResult } from "../common/Project";
 
-const TOKEN_KEY = "token_key";
+const TOKEN_KEY = "RNIDE_license_token_key";
 const BASE_CUSTOMER_PORTAL_URL = "https://portal.ide.swmansion.com/";
 
 export async function activateDevice(
@@ -40,6 +40,13 @@ export async function activateDevice(
     const newToken = responseBody.token as string;
     await extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
     return ActivateDeviceResult.succeeded;
+  }
+
+  if (
+    response.status === 404 &&
+    responseBody.error.startsWith("Could not find a subscription associated with license key")
+  ) {
+    return ActivateDeviceResult.keyVerificationFailed;
   }
 
   if (

--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -3,7 +3,6 @@ import { extensionContext } from "./extensionContext";
 import path from "path";
 import { Platform } from "./platform";
 import { exec } from "./subprocess";
-import { Logger } from "../Logger";
 
 const TOKEN_KEY = "token_key";
 const BASE_CUSTOMER_PORTAL_URL = "https://portal.ide.swmansion.com/";
@@ -16,8 +15,6 @@ export async function activateDevice(licenseKey: string, username: string) {
     licenseKey,
   };
 
-  Logger.debug("Frytki", body, url);
-
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -26,13 +23,11 @@ export async function activateDevice(licenseKey: string, username: string) {
     body: JSON.stringify(body),
   });
 
-  Logger.debug("Frytki", response.status, await response.json());
-
   let newToken;
 
   if (response.ok) {
-    const body = await response.json();
-    newToken = body.token as string;
+    const responseBody = await response.json();
+    newToken = responseBody.token as string;
     extensionContext.secrets.store(TOKEN_KEY, newToken ?? "");
     return true;
   }
@@ -50,12 +45,7 @@ async function generateDeviceFingerprint() {
   return stdout;
 }
 
-export async function removeLicenseToken() {
-  await extensionContext.secrets.delete(TOKEN_KEY);
-}
-
 export async function getLicenseToken() {
   const token = await extensionContext.secrets.get(TOKEN_KEY);
-  Logger.debug("Frytki", token);
   return token;
 }

--- a/packages/vscode-extension/src/utilities/simulatorServerBinary.ts
+++ b/packages/vscode-extension/src/utilities/simulatorServerBinary.ts
@@ -1,0 +1,11 @@
+import path from "path";
+import { extensionContext } from "./extensionContext";
+import { Platform } from "./platform";
+
+export function simulatorServerBinary() {
+  return path.join(
+    extensionContext.extensionPath,
+    "dist",
+    Platform.select({ macos: "simulator-server-macos", windows: "simulator-server-windows.exe" })
+  );
+}

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -22,7 +22,7 @@ interface SettingsDropdownProps {
 function SettingsDropdown({ project, isDeviceRunning, children, disabled }: SettingsDropdownProps) {
   const { panelLocation, update } = useWorkspaceConfig();
   const { openModal } = useModal();
-  const { movePanelToNewWindow } = useUtils();
+  const { movePanelToNewWindow, reportIssue } = useUtils();
 
   return (
     <DropdownMenu.Root>
@@ -132,6 +132,16 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
             Launch configuration...
           </DropdownMenu.Item>
           <DropdownMenu.Arrow className="dropdown-menu-arrow" />
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
+            onSelect={() => {
+              reportIssue();
+            }}>
+            <span className="dropdown-menu-item-wraper">
+              <span className="codicon codicon-report" />
+              <div className="dropdown-menu-item-content">Report Issue</div>
+            </span>
+          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenu.Root>

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -8,6 +8,7 @@ interface ProjectContextProps {
   projectState: ProjectState;
   deviceSettings: DeviceSettings;
   project: ProjectInterface;
+  isLicenseActivated: boolean;
 }
 
 const defaultProjectState: ProjectState = {
@@ -35,11 +36,13 @@ const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
   project,
+  isLicenseActivated: false,
 });
 
 export default function ProjectProvider({ children }: PropsWithChildren) {
   const [projectState, setProjectState] = useState<ProjectState>(defaultProjectState);
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings>(defaultDeviceSettings);
+  const [isLicenseActivated, setIsLicenseActivated] = useState(true);
 
   useEffect(() => {
     project.getProjectState().then(setProjectState);
@@ -48,14 +51,18 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     project.getDeviceSettings().then(setDeviceSettings);
     project.addListener("deviceSettingsChanged", setDeviceSettings);
 
+    project.isLicenseActivated().then(setIsLicenseActivated);
+    project.addListener("licenseActivationChanged", setIsLicenseActivated);
+
     return () => {
       project.removeListener("projectStateChanged", setProjectState);
       project.removeListener("deviceSettingsChanged", setDeviceSettings);
+      project.removeListener("licenseActivationChanged", setIsLicenseActivated);
     };
   }, []);
 
   return (
-    <ProjectContext.Provider value={{ projectState, deviceSettings, project }}>
+    <ProjectContext.Provider value={{ projectState, deviceSettings, project, isLicenseActivated }}>
       {children}
     </ProjectContext.Provider>
   );

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -8,7 +8,7 @@ interface ProjectContextProps {
   projectState: ProjectState;
   deviceSettings: DeviceSettings;
   project: ProjectInterface;
-  isLicenseActivated: boolean;
+  hasActiveLicense: boolean;
 }
 
 const defaultProjectState: ProjectState = {
@@ -36,13 +36,13 @@ const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
   project,
-  isLicenseActivated: false,
+  hasActiveLicense: false,
 });
 
 export default function ProjectProvider({ children }: PropsWithChildren) {
   const [projectState, setProjectState] = useState<ProjectState>(defaultProjectState);
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings>(defaultDeviceSettings);
-  const [isLicenseActivated, setIsLicenseActivated] = useState(true);
+  const [hasActiveLicense, setHasActiveLicense] = useState(true);
 
   useEffect(() => {
     project.getProjectState().then(setProjectState);
@@ -51,18 +51,18 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     project.getDeviceSettings().then(setDeviceSettings);
     project.addListener("deviceSettingsChanged", setDeviceSettings);
 
-    project.isLicenseActivated().then(setIsLicenseActivated);
-    project.addListener("licenseActivationChanged", setIsLicenseActivated);
+    project.hasActiveLicense().then(setHasActiveLicense);
+    project.addListener("licenseActivationChanged", setHasActiveLicense);
 
     return () => {
       project.removeListener("projectStateChanged", setProjectState);
       project.removeListener("deviceSettingsChanged", setDeviceSettings);
-      project.removeListener("licenseActivationChanged", setIsLicenseActivated);
+      project.removeListener("licenseActivationChanged", setHasActiveLicense);
     };
   }, []);
 
   return (
-    <ProjectContext.Provider value={{ projectState, deviceSettings, project, isLicenseActivated }}>
+    <ProjectContext.Provider value={{ projectState, deviceSettings, project, hasActiveLicense }}>
       {children}
     </ProjectContext.Provider>
   );

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -143,6 +143,8 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-preview-background: var(--white);
 
   --swm-default-text: var(--navy-light-100);
+  --swm-highlighted-text: var(--navy-light-40);
+  --swm-error-color: var(--red-light-100);
   --swm-secondary-text: var(--navy-light-60);
   --swm-disabled-text: var(--navy-light-20);
 
@@ -302,6 +304,8 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-preview-background: var(--background-dark-100);
 
   --swm-default-text: var(--off-white);
+  --swm-highlighted-text: black;
+  --swm-error-color: var(--red-dark-100);
   --swm-secondary-text: var(--background-dark-10);
   --swm-disabled-text: var(--background-dark-40);
 

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
@@ -1,0 +1,51 @@
+.container {
+  flex: 1;
+  gap: 8px;
+  align-items: left;
+}
+
+.license-input {
+  flex: 1;
+  background-color: var(--swm-input-background);
+  color: var(--swm-default-text);
+  width: 100%;
+  padding: 7px;
+  border: 1px;
+  text-align: center;
+  font-size: 18px;
+  border-radius: 4px;
+  line-height: 1;
+  box-shadow: var(--swm-input-shadow);
+}
+
+.info-row {
+  width: 100%;
+
+  padding-right: 8px;
+  padding-bottom: 20px;
+  flex: 1;
+  align-items: left;
+}
+
+.submit-row {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.error-text {
+  color: var(--swm-error-color);
+  font-size: 14px;
+}
+
+.info-text {
+  font-size: 14px;
+  color: var(--swm-default-text);
+}
+
+.info-text a,
+.error-text a {
+  color: var(--swm-default-text);
+  text-decoration: underline;
+}

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
 import "./ActivateLicenseView.css";
-import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import Button from "../components/shared/Button";
 import { useProject } from "../providers/ProjectProvider";
 import { useModal } from "../providers/ModalProvider";
@@ -63,14 +62,30 @@ export function ActivateLicenseView() {
         )}
         {activateDeviceResult === ActivateDeviceResult.unableToVerify && (
           <div className="error-text">
-            Unable to verify the key. Please ensure your license key is correct. Check this{" "}
+            We were unable to verify the license key at this point. Please consult the{" "}
             <a
               href="https://ide.swmansion.com/docs/guides/activation-manual"
               target="_blank"
               rel="noopener noreferrer">
-              link
+              license activation instructions
             </a>{" "}
-            for instructions.
+            and try again once you check the provided key is valid.
+          </div>
+        )}
+        {activateDeviceResult === ActivateDeviceResult.keyVerificationFailed && (
+          <div className="error-text">
+            Provided key is not a valid license key. You can find your key on the{" "}
+            <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
+              Radon IDE customer portal
+            </a>
+            . Please follow the{" "}
+            <a
+              href="https://ide.swmansion.com/docs/guides/activation-manual"
+              target="_blank"
+              rel="noopener noreferrer">
+              license activation instructions
+            </a>{" "}
+            if you need further assistance.
           </div>
         )}
         {activateDeviceResult === ActivateDeviceResult.notEnoughSeats && (
@@ -85,7 +100,14 @@ export function ActivateLicenseView() {
         )}
         {activateDeviceResult === ActivateDeviceResult.connectionFailed && (
           <div className="error-text">
-            We ware unable to register your device due to the connection failing.
+            Activating license key requires a network connection. Make sure you are connected and
+            try activating the key again. In case of any issues please consult our
+            <a
+              href="https://ide.swmansion.com/docs/guides/activation-manual"
+              target="_blank"
+              rel="noopener noreferrer">
+              license activation instructions
+            </a>
           </div>
         )}
       </div>
@@ -98,13 +120,9 @@ export function ActivateLicenseView() {
         placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
       />
       <div className="submit-row">
-        {isLoading ? (
-          <VSCodeProgressRing />
-        ) : (
-          <Button type="secondary" disabled={disableSubmit}>
-            Activate
-          </Button>
-        )}
+        <Button type="secondary" disabled={disableSubmit || isLoading}>
+          Activate
+        </Button>
       </div>
     </form>
   );

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
 import "./ActivateLicenseView.css";
-import { activateDevice } from "../../utilities/license";
 import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
 import Button from "../components/shared/Button";
 import { useProject } from "../providers/ProjectProvider";

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -90,12 +90,11 @@ export function ActivateLicenseView() {
         )}
         {activateDeviceResult === ActivateDeviceResult.notEnoughSeats && (
           <div className="error-text">
-            Your organization does not have any available seats left, you can purchase more on the
-            Radon IDE customer portal (
+            Your license does not have any available seats. Log to the{" "}
             <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
-              link
-            </a>
-            ).
+              Radon IDE customer portal
+            </a>{" "}
+            to manage seats assigned to the license seats or purchase additional seats.
           </div>
         )}
         {activateDeviceResult === ActivateDeviceResult.connectionFailed && (

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -1,0 +1,91 @@
+import { useRef, useState } from "react";
+import { FieldValues, SubmitHandler, useForm } from "react-hook-form";
+import "./ActivateLicenseView.css";
+import { activateDevice } from "../../utilities/license";
+import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react";
+import Button from "../components/shared/Button";
+import { useProject } from "../providers/ProjectProvider";
+import { useModal } from "../providers/ModalProvider";
+
+export function ActivateLicenseView() {
+  const { project } = useProject();
+  const { closeModal } = useModal();
+  const { register, handleSubmit } = useForm();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [disableSubmit, setDisableSubmit] = useState(true);
+  const [wasRejected, setWasRejected] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const onSubmit: SubmitHandler<FieldValues> = (e, data) => {
+    setIsLoading(true);
+
+    const activationPromise = project.activateLicense(data?.target[0].value);
+
+    activationPromise.then((success) => {
+      if (success) {
+        closeModal();
+      } else {
+        setWasRejected(true);
+      }
+      setIsLoading(false);
+    });
+  };
+
+  const onChange = () => {
+    const newInput = inputRef.current?.value;
+    if (newInput) {
+      const isValidKey = /^[0-9A-F]{4}(?:-[0-9A-F]{4}){7}$/.test(newInput);
+      setDisableSubmit(!isValidKey);
+      return;
+    }
+    setDisableSubmit(true);
+  };
+
+  return (
+    <form className="container" onSubmit={handleSubmit(onSubmit)}>
+      <div className="info-row">
+        {wasRejected ? (
+          <div className="error-text">
+            Unable to verify the key. Please ensure your license key is correct. You can find a
+            license activation manual{" "}
+            <a
+              href="https://ide.swmansion.com/docs/guides/activation-manual"
+              target="_blank"
+              rel="noopener noreferrer">
+              here
+            </a>
+            .
+          </div>
+        ) : (
+          <div className="info-text">
+            Your license should be available in the customer portal, or shared to you by your
+            company administration. If you don't have a license you can{" "}
+            <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
+              get it here
+            </a>
+            .
+          </div>
+        )}
+      </div>
+      <input
+        {...register("licenseKey")}
+        ref={inputRef}
+        className="license-input"
+        type="text"
+        onChange={onChange}
+        placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+      />
+      <div className="submit-row">
+        {isLoading ? (
+          <VSCodeProgressRing />
+        ) : (
+          <Button type="secondary" disabled={disableSubmit}>
+            Submit
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -14,8 +14,9 @@ export function ActivateLicenseView() {
 
   const [isLoading, setIsLoading] = useState(false);
   const [disableSubmit, setDisableSubmit] = useState(true);
-  const [wasRejected, setWasRejected] = useState(false);
-  const [wasEnoughSeats, setWasEnoughSeats] = useState(true);
+  const [activateDeviceResult, setActivateDeviceResult] = useState<ActivateDeviceResult | null>(
+    null
+  );
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -28,10 +29,7 @@ export function ActivateLicenseView() {
       if (activationResult === ActivateDeviceResult.succeeded) {
         closeModal();
       } else {
-        if (activationResult === ActivateDeviceResult.notEnoughSeats) {
-          setWasEnoughSeats(false);
-        }
-        setWasRejected(true);
+        setActivateDeviceResult(activationResult);
       }
       setIsLoading(false);
     });
@@ -50,7 +48,7 @@ export function ActivateLicenseView() {
   return (
     <form className="container" onSubmit={handleSubmit(onSubmit)}>
       <div className="info-row">
-        {!wasRejected && (
+        {!activateDeviceResult && (
           <div className="info-text">
             You can find your license key on the Radon IDE customer portal (
             <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
@@ -63,7 +61,7 @@ export function ActivateLicenseView() {
             .
           </div>
         )}
-        {wasRejected && wasEnoughSeats && (
+        {activateDeviceResult === ActivateDeviceResult.unableToVerify && (
           <div className="error-text">
             Unable to verify the key. Please ensure your license key is correct. Check this{" "}
             <a
@@ -75,14 +73,19 @@ export function ActivateLicenseView() {
             for instructions.
           </div>
         )}
-        {!wasEnoughSeats && (
+        {activateDeviceResult === ActivateDeviceResult.notEnoughSeats && (
           <div className="error-text">
-            Your organization does not any available seats left, you can purchase more on the Radon
-            IDE customer portal (
+            Your organization does not have any available seats left, you can purchase more on the
+            Radon IDE customer portal (
             <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
               link
             </a>
             ).
+          </div>
+        )}
+        {activateDeviceResult === ActivateDeviceResult.connectionFailed && (
+          <div className="error-text">
+            We ware unable to register your device due to the connection failing.
           </div>
         )}
       </div>

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -92,4 +92,16 @@
 
 .activate-license-button {
   color: var(--swm-error-color);
+  animation: ping 2s ease-out infinite;
+}
+@keyframes ping {
+  0% {
+    border: 0px solid transparent;
+  }
+  50% {
+    border: 1px solid var(--swm-error-color);
+  }
+  100% {
+    border: 0px solid transparent;
+  }
 }

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -92,16 +92,4 @@
 
 .activate-license-button {
   color: var(--swm-error-color);
-  animation: ping 2s ease-out infinite;
-}
-@keyframes ping {
-  0% {
-    border: 0px solid transparent;
-  }
-  50% {
-    border: 1px solid var(--swm-error-color);
-  }
-  100% {
-    border: 0px solid transparent;
-  }
 }

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -89,3 +89,7 @@
   border-radius: 50%;
   margin-right: 6px;
 }
+
+.activate-license-button {
+  color: var(--swm-error-color);
+}

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -89,7 +89,3 @@
   border-radius: 50%;
   margin-right: 6px;
 }
-
-.activate-license-button {
-  color: var(--swm-error-color);
-}

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -27,6 +27,7 @@ import "./View.css";
 import "./PreviewView.css";
 import ReplayIcon from "../components/icons/ReplayIcon";
 import RecordingIcon from "../components/icons/RecordingIcon";
+import { ActivateLicenseView } from "./ActivateLicenseView";
 
 const MAX_RECORDING_TIME_SEC = 10 * 60;
 
@@ -51,8 +52,19 @@ function LoadingComponent({ finishedInitialLoad, devicesNotFound }: LoadingCompo
   );
 }
 
+function ActivateLicenseButton() {
+  const { openModal } = useModal();
+  return (
+    <Button
+      className="activate-license-button"
+      onClick={() => openModal("Activate License", <ActivateLicenseView />)}>
+      Activate License
+    </Button>
+  );
+}
+
 function PreviewView() {
-  const { projectState, project, deviceSettings } = useProject();
+  const { projectState, project, deviceSettings, isLicenseActivated } = useProject();
   const { reportIssue, showDismissableError } = useUtils();
 
   const [isInspecting, setIsInspecting] = useState(false);
@@ -83,10 +95,6 @@ function PreviewView() {
 
   const { openModal } = useModal();
   const { openFileAt, saveVideoRecording } = useUtils();
-
-  const extensionVersion = document.querySelector<HTMLMetaElement>(
-    "meta[name='radon-ide-version']"
-  )?.content;
 
   useEffect(() => {
     function incrementLogCounter() {
@@ -309,9 +317,7 @@ function PreviewView() {
         />
 
         <div className="spacer" />
-        <Button className="feedback-button" onClick={() => reportIssue()}>
-          {extensionVersion || "Beta"}: Report issue
-        </Button>
+        {!isLicenseActivated && <ActivateLicenseButton />}
         <DeviceSettingsDropdown disabled={devicesNotFound || !isRunning}>
           <IconButton tooltip={{ label: "Device settings", type: "primary" }}>
             <DeviceSettingsIcon

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -64,7 +64,7 @@ function ActivateLicenseButton() {
 }
 
 function PreviewView() {
-  const { projectState, project, deviceSettings, isLicenseActivated } = useProject();
+  const { projectState, project, deviceSettings, hasActiveLicense } = useProject();
   const { showDismissableError } = useUtils();
 
   const [isInspecting, setIsInspecting] = useState(false);
@@ -317,7 +317,7 @@ function PreviewView() {
         />
 
         <div className="spacer" />
-        {!isLicenseActivated && <ActivateLicenseButton />}
+        {!hasActiveLicense && <ActivateLicenseButton />}
         <DeviceSettingsDropdown disabled={devicesNotFound || !isRunning}>
           <IconButton tooltip={{ label: "Device settings", type: "primary" }}>
             <DeviceSettingsIcon

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -65,7 +65,7 @@ function ActivateLicenseButton() {
 
 function PreviewView() {
   const { projectState, project, deviceSettings, isLicenseActivated } = useProject();
-  const { reportIssue, showDismissableError } = useUtils();
+  const { showDismissableError } = useUtils();
 
   const [isInspecting, setIsInspecting] = useState(false);
   const [inspectFrame, setInspectFrame] = useState<Frame | null>(null);


### PR DESCRIPTION
This PR adds a way for the user to register device, using a license key, by adding an an "Activate license" button in place of "report issue" button on the main screen. 

Additionally we add a new report issue button to the settings dropdown.

### How Has This Been Tested: 

- An account was created on customer portal and the license was activated. 



