### PR TITLE
Fix sourcemap RangeError issue by properly freeing source map consumers

### DIFF
--- a/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
+++ b/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
@@ -24,6 +24,7 @@ export class SourceMapsRegistry {
   ) {}
 
   public clearSourceMaps() {
+    this.sourceMaps.forEach(([_, __, consumer]) => consumer.destroy());
     this.sourceMaps = [];
     this.sourceMapFilePaths.clear();
   }


### PR DESCRIPTION
This PR fixes exception reported by a number of users and also seen in telemetry:
`RangeError: Start offset -2033400168 is outside the bounds of the buffer`

The root cause of this issue was in misuse of [source-map](https://github.com/mozilla/source-map) package which requires destroy method to be called on `SourceMapConsumer` instances when they are no longer used.

The reason why `destroy` call is necessary, is that source-map package uses wasm under the hood where it allocates data structures that allows for fast processing of source map translation queries. Since the wasm memory space is limited, when too many maps were loaded in the memory, the allocate call from [parseMappings](https://github.com/mozilla/source-map/blob/3cb92cc3b73bfab27c146bae4ef2bc09dbb4e5ed/lib/source-map-consumer.js#L312) would return negative values indicating a failed alloc attempt (and that's the number that'd show up in the logs).

Thanks to the help from community members we managed to isolate and narrow down the issue providing a reproducible scenario. In order to get this issue one would need to reload JS several times (in some instances I had to reload more than 20 times, but eventually would start getting this issue).

The fix is to call `destroy` on `SourceMapConsumer` instances when clearing JS execution context. This is called specifically when reloading JS and after that point the stored source maps are no longer in use.

### How Has This Been Tested: 
1. Open any test project
2. Reload JS several times
3. Before this change at some point you'd start seeing RangeError in logs and invalid line numbers would show up in console tab + breakpoints would no longer work. After this change the error never happens even after a significant number of reloads.