### PR TITLE
Hide activation button on windows

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -21,7 +21,7 @@ import {
   RecordingData,
   ZoomLevelType,
 } from "../../common/Project";
-import { useUtils } from "../providers/UtilsProvider";
+import { Platform, useUtils } from "../providers/UtilsProvider";
 import { AndroidSupportedDevices, iOSSupportedDevices } from "../utilities/consts";
 import "./View.css";
 import "./PreviewView.css";
@@ -317,7 +317,7 @@ function PreviewView() {
         />
 
         <div className="spacer" />
-        {!hasActiveLicense && <ActivateLicenseButton />}
+        {Platform.OS === "macos" && !hasActiveLicense && <ActivateLicenseButton />}
         <DeviceSettingsDropdown disabled={devicesNotFound || !isRunning}>
           <IconButton tooltip={{ label: "Device settings", type: "primary" }}>
             <DeviceSettingsIcon


### PR DESCRIPTION
This PR hides activation button on platforms that are not macos




