### PR TITLE
Make fingerprint run less often

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -42,6 +42,8 @@ const DEEP_LINKS_HISTORY_KEY = "deep_links_history";
 
 const DEEP_LINKS_HISTORY_LIMIT = 50;
 
+const FINGERPRINT_THROTTLE_MS = 10 * 1000; // 10 seconds
+
 export class Project
   implements Disposable, MetroDelegate, EventDelegate, DebugSessionDelegate, ProjectInterface
 {
@@ -676,7 +678,7 @@ export class Project
         this.eventEmitter.emit("needsNativeRebuild");
       }
     }
-  }, 1000);
+  }, FINGERPRINT_THROTTLE_MS);
 }
 
 function watchProjectFiles(onChange: () => void) {


### PR DESCRIPTION
This PR updates fingerprint throttling such that it runs less often. In practice it doesn't seem like the delay of several seconds makes for an important difference when detecting native changes. When updating native changes most of the time, the refresh would trigger exception regardless of how soon we're able to detect them based on the fingerprint. What is important is to give a clear indication that this was due to native changes getting updated.

On the other hand, to frequent fingerprint calls are annoying in cases a lot of files are invalidated at the same moment (for example when installing node_modules) in which case this process incurs a significant CPU load.

### How Has This Been Tested: 
1) run one of the test apps
2) add some comments to Podfile
3) see the native changes dialog pop up



