### PR TITLE
Add Platform check when validating EAS builds

### DIFF
--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -64,7 +64,11 @@ async function fetchBuild(config: EasConfig, platform: DevicePlatform) {
 
   const build = maxBy(builds, "completedAt")!;
 
-  if (!build.binaryUrl.endsWith(".apk") && !build.binaryUrl.endsWith(".apex")) {
+  if (
+    platform === DevicePlatform.Android &&
+    !build.binaryUrl.endsWith(".apk") &&
+    !build.binaryUrl.endsWith(".apex")
+  ) {
     Logger.error(
       `EAS build artifact needs to be a development build in .apk or .apex format to work with the Radon IDE, make sure you set up eas to use "development" profile`
     );


### PR DESCRIPTION
This PR fixes a regression introduced in #727, that performed android specific check regardless of the platform, causing iOS builds to fail.

### How Has This Been Tested: 

-run eas development build on ios
-run eas development build on android



