### PR TITLE
Fix device android native logs not working when multiple devices are available 

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -387,7 +387,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     const extractPidFromLogcat = async (cancelToken: CancelToken) =>
       new Promise<string>((resolve, reject) => {
         const regexString = `Start proc ([0-9]{4}):${build.packageName}`;
-        const process = exec(ADB_PATH, ["logcat", "-e", regexString, "-T", "1"]);
+        const process = exec(ADB_PATH, ["-s", this.serial!, "logcat", "-e", regexString, "-T", "1"]);
         cancelToken.adapt(process);
 
         lineReader(process).onLineRead((line) => {
@@ -422,7 +422,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
     this.nativeLogsOutputChannel.clear();
     const pid = await extractPidFromLogcat(this.nativeLogsCancelToken);
-    const process = exec(ADB_PATH, ["logcat", "--pid", pid]);
+    const process = exec(ADB_PATH, ["-s", this.serial!, "logcat", "--pid", pid]);
     this.nativeLogsCancelToken.adapt(process);
 
     lineReader(process).onLineRead(this.nativeLogsOutputChannel.appendLine);

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -387,7 +387,15 @@ export class AndroidEmulatorDevice extends DeviceBase {
     const extractPidFromLogcat = async (cancelToken: CancelToken) =>
       new Promise<string>((resolve, reject) => {
         const regexString = `Start proc ([0-9]{4}):${build.packageName}`;
-        const process = exec(ADB_PATH, ["-s", this.serial!, "logcat", "-e", regexString, "-T", "1"]);
+        const process = exec(ADB_PATH, [
+          "-s",
+          this.serial!,
+          "logcat",
+          "-e",
+          regexString,
+          "-T",
+          "1",
+        ]);
         cancelToken.adapt(process);
 
         lineReader(process).onLineRead((line) => {


### PR DESCRIPTION
When running IDE with Android device and another Android Emulator, the logcat commands fail on `error: more than one device/emulator`. This PR adds selecting a proper device with `-s <serial>` adb param. Similar pattern is used for other adb executions. 

### How Has This Been Tested: 

- Run a standalone Android emulator 
- Run project with IDE using an Android device 
- The native logs should appear



