### PR TITLE
Don't prefer Android Studio's JDK over java from PATH

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -3,7 +3,7 @@ import path from "path";
 import semver from "semver";
 import { OutputChannel } from "vscode";
 import { getNativeABI } from "../utilities/common";
-import { ANDROID_HOME, JAVA_HOME } from "../utilities/android";
+import { ANDROID_HOME, findJavaHome } from "../utilities/android";
 import { Logger } from "../Logger";
 import { exec, lineReader } from "../utilities/subprocess";
 import { CancelToken } from "./cancelToken";
@@ -155,6 +155,7 @@ export async function buildAndroid(
     );
   }
   Logger.debug("Starting Android build");
+  const JAVA_HOME = await findJavaHome(env);
   const buildProcess = cancelToken.adapt(
     exec("./gradlew", gradleArgs, {
       cwd: androidSourceDir,

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -155,11 +155,11 @@ export async function buildAndroid(
     );
   }
   Logger.debug("Starting Android build");
-  const JAVA_HOME = await findJavaHome(env);
+  const JAVA_HOME = await findJavaHome();
   const buildProcess = cancelToken.adapt(
     exec("./gradlew", gradleArgs, {
       cwd: androidSourceDir,
-      env: { ...env, JAVA_HOME, ANDROID_HOME },
+      env: { JAVA_HOME, ANDROID_HOME, ...env },
       buffer: false,
     })
   );

--- a/packages/vscode-extension/src/utilities/android.ts
+++ b/packages/vscode-extension/src/utilities/android.ts
@@ -11,7 +11,7 @@ export const ANDROID_HOME =
     windows: path.join(os.homedir(), "AppData\\Local\\Android\\Sdk"),
   });
 
-export async function findJavaHome(env?: Record<string, string>) {
+export async function findJavaHome() {
   // When java is available in the PATH, we return undefined as android tooling doesn't
   // require JAVA_HOME variable to be set in that case. However, when JAVA_HOME is provided
   // it takes precedence over the java in the PATH. Finally, when JAVA_HOME is not set, and
@@ -20,7 +20,7 @@ export async function findJavaHome(env?: Record<string, string>) {
   // where the first one is used in newer distributions and the second one in older ones.
 
   // 1) we check JAVA_HOME from the provided env object or from process.env
-  const envJavaHome = env?.JAVA_HOME || process.env.JAVA_HOME;
+  const envJavaHome = process.env.JAVA_HOME;
   if (envJavaHome && fs.existsSync(envJavaHome)) {
     return envJavaHome;
   }


### PR DESCRIPTION
This PR changes the logic for obtaining JAVA_HOME location.

We used to select JDK that's bundled with Android Studio when JAVA_HOME wasn't set in the process.env – the reason for this approach was that in many setups people may not have JAVA available at the default location. However after #515 we can reliably say java should be on the PATH if someone can build their project using CLI.

The reason why the version from the PATH should be preferred is that Android Studio now ships with modern versions of JDK 21 which is not compatible with libraries from the ecosystem. React Native docs recommend version 17: https://reactnative.dev/docs/set-up-your-environment

This PR updates the logic such that we test for JAVA_HOME env variables first, later we check if java is available in PATH, and if so, we don't set JAVA_HOME altogether. Finally, when none of the above worked, we use Android Studio's JDK location as JAVA_HOME.

Finally, this change is relatively risk-free, as we can always ask users to set JAVA_HOME in launch configuration. Before this change, setting JAVA_HOME in env variable would never override the one we detected.

Here's a breakdown of changes:
1. We remove static JAVA_HOME, as the new method for obtaining JAVA_HOME uses async command execution
2. We call `findJavaHome` before running gradle and provide its output as JAVA_HOME
3. We reverse the order of applying env variables, such that the env from launch setting can always override the automatically detected location

### How Has This Been Tested: 
1. Install recent update of Android Studio
4. Force rebuild react-conf-app project that includes some expo packages that require java 17
5. Before this change, we'd get compile error "Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21)."


