### PR TITLE
Fix typo in legal

### DIFF
--- a/packages/docs/src/pages/legal/supporter-terms.mdx
+++ b/packages/docs/src/pages/legal/supporter-terms.mdx
@@ -53,8 +53,8 @@ XI Commercial Division of the National Court Register with KRS number 0000961952
 
 3.2A The Early Access Version Product license will convert into a full version license on December 2, 2024 after and will automatically renew for an additional subscription period of one month (which will then automatically renew each month if not canceled by the Customer), if the Product will be officially launched in its full version; or, in the event of discontinuation of the Product, this license will expire on December 2. The fees for the new subscription period will be discounted - the Customer will receive a -50% discount for a number of months of subscription equal to the number of full months (billing periods) of the Early Access Version Product that the Customer paid for. For example, if the Customer purchased the Early Access Version Product on August 15, 2024:
 
-- the last billing under this License will occur on October 15, 2024;
-- the number of full months of this Early Access Version Product for which the Customer paid is 3;
+- the last billing under this License will occur on November 15, 2024;
+- the number of full months of this Early Access Version Product for which the Customer paid is 4;
 - beginning December 15, 2024, a new billing period will commence, under the Full Version license terms.
 
 However, if the subscription is discontinued by the Customer at any point before the discount is used in full, the accrued discount will be forfeited. Customer authorizes Software Mansion to charge Customer’s payment card automatically on December 2 for additional, monthly subscription period, and in the full amount of $ 19.00 and further discounted as above. For more information on how the payments are processed, please see the Radon IDE Purchase Terms available at: [ide.swmansion.com/purchase-terms](https://ide.swmansion.com/purchase-terms).


### PR DESCRIPTION
Fix continuity error in the provided example in the Supporter's license terms 