### PR TITLE
Add license activation confirmation

### DIFF
--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 8px;
   align-items: left;
+  margin: 0 2px 2px 0;
 }
 
 .license-input {

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -25,9 +25,7 @@ export function ActivateLicenseView() {
     const activationPromise = project.activateLicense(data?.target[0].value);
 
     activationPromise.then((activationResult) => {
-      if (activationResult === ActivateDeviceResult.succeeded) {
-        closeModal();
-      } else {
+      if (activationResult !== ActivateDeviceResult.succeeded) {
         setActivateDeviceResult(activationResult);
       }
       setIsLoading(false);

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -25,9 +25,7 @@ export function ActivateLicenseView() {
     const activationPromise = project.activateLicense(data?.target[0].value);
 
     activationPromise.then((activationResult) => {
-      if (activationResult !== ActivateDeviceResult.succeeded) {
-        setActivateDeviceResult(activationResult);
-      }
+      setActivateDeviceResult(activationResult);
       setIsLoading(false);
     });
   };

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.tsx
@@ -47,7 +47,7 @@ export function ActivateLicenseView() {
   return (
     <form className="container" onSubmit={handleSubmit(onSubmit)}>
       <div className="info-row">
-        {!activateDeviceResult && (
+        {activateDeviceResult === null && (
           <div className="info-text">
             You can find your license key on the{" "}
             <a href="https://portal.ide.swmansion.com/" target="_blank" rel="noopener noreferrer">
@@ -109,19 +109,30 @@ export function ActivateLicenseView() {
             </a>
           </div>
         )}
+        {activateDeviceResult === ActivateDeviceResult.succeeded && (
+          <div className="info-text">Your license has been successfully activated.</div>
+        )}
       </div>
-      <input
-        {...register("licenseKey")}
-        ref={inputRef}
-        className="license-input"
-        type="text"
-        onChange={onChange}
-        placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
-      />
+      {activateDeviceResult !== ActivateDeviceResult.succeeded && (
+        <input
+          {...register("licenseKey")}
+          ref={inputRef}
+          className="license-input"
+          type="text"
+          onChange={onChange}
+          placeholder="XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX"
+        />
+      )}
       <div className="submit-row">
-        <Button type="secondary" disabled={disableSubmit || isLoading}>
-          Activate
-        </Button>
+        {activateDeviceResult !== ActivateDeviceResult.succeeded ? (
+          <Button type="secondary" disabled={disableSubmit || isLoading}>
+            Activate
+          </Button>
+        ) : (
+          <Button type="secondary" onClick={closeModal}>
+            Ok
+          </Button>
+        )}
       </div>
     </form>
   );


### PR DESCRIPTION
This PR introduces a confirmation for successful license activation and fixes the box-shadow cut in the "Activate" button's right bottom corner.

### How Has This Been Tested: 
- Tested by activating the license using both correct and incorrect keys to ensure the system responded properly in each scenario.

Screenshots:

<img width="510" alt="Screenshot 2024-12-02 at 16 55 50" src="https://github.com/user-attachments/assets/101f7259-377d-4f53-b26d-bc0032fabbda">
<img width="510" alt="Screenshot 2024-12-02 at 16 33 37" src="https://github.com/user-attachments/assets/24ec406c-73c2-451d-b5bb-571315e7edd3">

Before:
<img width="510" alt="Screenshot 2024-12-02 at 17 04 06" src="https://github.com/user-attachments/assets/c78a4db8-acbc-4692-ab77-b1330bd5dcf6">
