### PR TITLE
Fix monorepo structure not triggering activation in VSCode

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -9,12 +9,12 @@
   "icon": "assets/logo.png",
   "pricing": "Trial",
   "activationEvents": [
-    "workspaceContains:node_modules/react-native",
-    "workspaceContains:app.json",
-    "workspaceContains:metro.config.js",
-    "workspaceContains:metro.config.ts",
-    "workspaceContains:app.config.js",
-    "workspaceContains:app.config.ts"
+    "workspaceContains:**/node_modules/react-native",
+    "workspaceContains:**/app.json",
+    "workspaceContains:**/metro.config.js",
+    "workspaceContains:**/metro.config.ts",
+    "workspaceContains:**/app.config.js",
+    "workspaceContains:**/app.config.ts"
   ],
   "version": "1.0.0",
   "engines": {


### PR DESCRIPTION
Fixes #821

Currently, we look for different files in the root of the workspace to recognize if VSCode should activate the extension, this doesn't work in monorepo, as those files might be deeper in the file tree. This pr adds `**/` before each pattern to fix that. 

### How Has This Been Tested: 

- Open nx-monorepo 
- Confirm the "Open IDE Panel" is visible 
- Repeat for any other repo


