### PR TITLE
Fix compatibility table responsiveness

### DIFF
--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -145,6 +145,10 @@ div[class^="announcementBar_"] {
     font-size: 15px;
     height: 32px;
   }
+
+  .compatibility table {
+    table-layout: auto;
+  }
 }
 
 .shadow-image {


### PR DESCRIPTION
Compatibility tables were unreadable on mobile devices.

## Before

https://github.com/user-attachments/assets/2c53f9ec-ac03-462b-8a92-2dbb2f7096f6


## After

https://github.com/user-attachments/assets/205274a4-fd0b-4b7f-91e0-272d59142220

