### PR TITLE
Add Linux support for VSCode extension (#688)

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -701,7 +701,11 @@ async function ensureOldEmulatorProcessExited(avdId: string) {
       'powershell.exe "Get-WmiObject Win32_Process | Select-Object ProcessId, CommandLine | ConvertTo-Csv -NoTypeInformation"',
     linux: "ps",
   });
-  const args = Platform.select({ macos: ["-Ao", "pid,command"], windows: [], linux: ["-Ao", "pid,command"] });
+  const args = Platform.select({
+    macos: ["-Ao", "pid,command"],
+    windows: [],
+    linux: ["-Ao", "pid,command"],
+  });
   const subprocess = exec(command, args);
   const regexpPattern = new RegExp(`(\\d+).*qemu.*-avd ${avdId}`);
   lineReader(subprocess).onLineRead(async (line) => {

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -26,6 +26,7 @@ export const EMULATOR_BINARY = path.join(
   Platform.select({
     macos: "emulator",
     windows: "emulator.exe",
+    linux: "emulator",
   })
 );
 const ADB_PATH = path.join(
@@ -34,6 +35,7 @@ const ADB_PATH = path.join(
   Platform.select({
     macos: "adb",
     windows: "adb.exe",
+    linux: "adb",
   })
 );
 const DISPOSE_TIMEOUT = 9000;
@@ -697,8 +699,9 @@ async function ensureOldEmulatorProcessExited(avdId: string) {
     macos: "ps",
     windows:
       'powershell.exe "Get-WmiObject Win32_Process | Select-Object ProcessId, CommandLine | ConvertTo-Csv -NoTypeInformation"',
+    linux: "ps",
   });
-  const args = Platform.select({ macos: ["-Ao", "pid,command"], windows: [] });
+  const args = Platform.select({ macos: ["-Ao", "pid,command"], windows: [], linux: ["-Ao", "pid,command"] });
   const subprocess = exec(command, args);
   const regexpPattern = new RegExp(`(\\d+).*qemu.*-avd ${avdId}`);
   lineReader(subprocess).onLineRead(async (line) => {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -64,7 +64,7 @@ export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
 
   if (Platform.OS !== "macos" && Platform.OS !== "windows" && Platform.OS !== "linux") {
-    window.showErrorMessage("Radon IDE works only on macOS and Windows and Linux.", "Dismiss");
+    window.showErrorMessage("Radon IDE works only on macOS, Windows and Linux.", "Dismiss");
     return;
   }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -63,8 +63,8 @@ export function deactivate(context: ExtensionContext): undefined {
 export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
 
-  if (Platform.OS !== "macos" && Platform.OS !== "windows") {
-    window.showErrorMessage("Radon IDE works only on macOS and Windows.", "Dismiss");
+  if (Platform.OS !== "macos" && Platform.OS !== "windows" && Platform.OS !== "linux") {
+    window.showErrorMessage("Radon IDE works only on macOS and Windows and Linux.", "Dismiss");
     return;
   }
 

--- a/packages/vscode-extension/src/utilities/android.ts
+++ b/packages/vscode-extension/src/utilities/android.ts
@@ -9,6 +9,7 @@ export const ANDROID_HOME =
   Platform.select({
     macos: path.join(os.homedir(), "Library/Android/sdk"),
     windows: path.join(os.homedir(), "AppData\\Local\\Android\\Sdk"),
+    linux: path.join(os.homedir(), "Android/Sdk"),
   });
 
 export async function findJavaHome() {
@@ -36,11 +37,13 @@ export async function findJavaHome() {
   const androidStudioPath = Platform.select({
     macos: "/Applications/Android Studio.app",
     windows: path.join(path.parse(os.homedir()).root, "Program Files\\Android\\Android Studio"),
+    linux: "/usr/local/android-studio",
   });
 
   const jbrPath = Platform.select({
     macos: path.join(androidStudioPath, "Contents/jbr/Contents/Home"),
     windows: path.join(androidStudioPath, "jbr"),
+    linux: path.join(androidStudioPath, "jbr"),
   });
 
   if (fs.existsSync(jbrPath)) {
@@ -50,5 +53,8 @@ export async function findJavaHome() {
   return Platform.select({
     macos: path.join(androidStudioPath, "Contents/jre/Contents/Home"),
     windows: path.join(androidStudioPath, "jre"),
+    // Returning undefined as the Android Studio directory on Linux
+    // might not include a jre directory, preferring jbr instead
+    linux: undefined,
   });
 }

--- a/packages/vscode-extension/src/utilities/platform.ts
+++ b/packages/vscode-extension/src/utilities/platform.ts
@@ -1,19 +1,21 @@
 import os from "os";
 
-const OS: "macos" | "windows" | "unsupported" = (() => {
+const OS: "macos" | "windows" | "linux" | "unsupported" = (() => {
   const platform = os.platform();
   switch (platform) {
     case "darwin":
       return "macos";
     case "win32":
       return "windows";
+    case "linux":
+      return "linux";
     default:
       return "unsupported";
   }
 })();
 export const Platform = {
   OS,
-  select: <R, T>(obj: { macos: R; windows: T }) => {
+  select: <R, T>(obj: { macos: R; windows: T; linux: T }) => {
     // we assume that the 'unsupported' OS type will never occur here
     return Platform.OS !== "unsupported" ? obj[Platform.OS] : obj["macos"];
   },

--- a/packages/vscode-extension/src/utilities/simulatorServerBinary.ts
+++ b/packages/vscode-extension/src/utilities/simulatorServerBinary.ts
@@ -6,6 +6,10 @@ export function simulatorServerBinary() {
   return path.join(
     extensionContext.extensionPath,
     "dist",
-    Platform.select({ macos: "simulator-server-macos", windows: "simulator-server-windows.exe" })
+    Platform.select({
+      macos: "simulator-server-macos",
+      windows: "simulator-server-windows.exe",
+      linux: "simulator-server-linux",
+    })
   );
 }

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -93,7 +93,7 @@ export function exec(
   const subprocess = execa(
     name,
     args,
-    Platform.select({ macos: overrideEnv(options), windows: options })
+    Platform.select({ macos: overrideEnv(options), windows: options, linux: options })
   );
   const allowNonZeroExit = options?.allowNonZeroExit;
   async function printErrorsOnExit() {
@@ -122,7 +122,7 @@ export function execSync(name: string, args?: string[], options?: execa.SyncOpti
   const result = execa.sync(
     name,
     args,
-    Platform.select({ macos: overrideEnv(options), windows: options })
+    Platform.select({ macos: overrideEnv(options), windows: options, linux: options })
   );
   if (result.stderr) {
     Logger.debug("Subprocess", name, args?.join(" "), "produced error output:", result.stderr);
@@ -136,7 +136,7 @@ export function command(
 ) {
   const subprocess = execa.command(
     commandWithArgs,
-    Platform.select({ macos: overrideEnv(options), windows: options })
+    Platform.select({ macos: overrideEnv(options), windows: options, linux: options })
   );
   async function printErrorsOnExit() {
     try {

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -31,6 +31,7 @@ export class Utils implements UtilsInterface {
         Platform.select({
           macos: path.join("Library", "Application Support"),
           windows: path.join("AppDat", "Roaming"),
+          linux: path.join(".config"),
         }),
         ideName,
         "User",
@@ -91,6 +92,7 @@ export class Utils implements UtilsInterface {
     const defaultFolder = Platform.select({
       macos: path.join(homedir(), "Desktop"),
       windows: homedir(),
+      linux: homedir(),
     });
     const defaultUri = Uri.file(path.join(defaultFolder, newFileName));
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -510,6 +510,7 @@ function Preview({
         const isMultiTouchKey = Platform.select({
           macos: e.code === "AltLeft" || e.code === "AltRight",
           windows: e.code === "ControlLeft" || e.code === "ControlRight",
+          linux: e.code === "ControlLeft" || e.code === "ControlRight",
         });
 
         const isPanningKey = e.code === "ShiftLeft" || e.code === "ShiftRight";

--- a/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
@@ -6,13 +6,13 @@ import { UtilsInterface } from "../../common/utils";
 declare global {
   interface Window {
     // set in generateWebviewContent()
-    RNIDE_hostOS: "macos" | "windows";
+    RNIDE_hostOS: "macos" | "windows" | "linux";
   }
 }
 
 export const Platform = {
   OS: window.RNIDE_hostOS,
-  select: <R, T>(obj: { macos: R; windows: T }) => {
+  select: <R, T>(obj: { macos: R; windows: T; linux: T }) => {
     return obj[Platform.OS];
   },
 };

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -32,6 +32,7 @@ function useSupportedDevices() {
             })),
           },
       windows: { label: "", items: [] },
+      linux: { label: "", items: [] },
     }),
     errors?.emulator
       ? { label: "Android – error, check diagnostics", items: [] }


### PR DESCRIPTION
This PR adds Linux support to the VSCode extension, implementing platform-specific paths and configurations. The changes follow patterns established in PR #462 (Windows support) and make the extension functional on Linux systems.

- Add Linux as a supported platform in Platform module
- Implement Linux paths for Android SDK and tooling
- Add Linux-specific configurations for file system and processes
- Update UI components to handle Linux keyboard shortcuts

Fixes #688

### How This Has Been Tested

To ensure the changes in this PR work as expected, the following test plan was carried out:
- Run development version of the extension successfully on my Linux Mint (based on Ubuntu 24.04) machine. 
- Ensure the ANDROID_HOME 
environment variable was correctly set on my system 
- A React Native project was initialized, and the extension managed the building and installing the app on the selected emulator.
- Verified that all extension features, such as the inspector, debugger, device settings, and screen recording worked correctly on Linux.

https://github.com/user-attachments/assets/7a08b927-8ad7-4a3a-96f7-0df5dc4a384d