### PR TITLE
Add a warning for users trying to use android sdks older then selected device

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Select.css
+++ b/packages/vscode-extension/src/webview/components/shared/Select.css
@@ -65,10 +65,15 @@ button {
   color: var(--swm-secondary-text);
   pointer-events: none;
 }
+
 .select-item:hover {
   outline: none;
   background-color: var(--swm-select-item-highlighted-background);
   cursor: pointer;
+}
+
+.select-item-marked {
+  color: var(--swm-marked-text);
 }
 
 .select-label {

--- a/packages/vscode-extension/src/webview/components/shared/Select.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/Select.tsx
@@ -3,20 +3,29 @@ import { PropsWithChildren, ReactNode, forwardRef } from "react";
 import classnames from "classnames";
 import "./Select.css";
 
-const SelectItem = forwardRef<HTMLDivElement, PropsWithChildren<RadixSelect.SelectItemProps>>(
-  ({ children, ...props }, forwardedRef) => {
-    return (
-      <RadixSelect.Item className="select-item" {...props} ref={forwardedRef}>
-        <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
-        <RadixSelect.ItemIndicator className="select-item-indicator">
-          <span className="codicon codicon-check" />
-        </RadixSelect.ItemIndicator>
-      </RadixSelect.Item>
-    );
-  }
-);
+const SelectItem = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<RadixSelect.SelectItemProps & { marked?: boolean }>
+>(({ children, ...props }, forwardedRef) => {
+  return (
+    <RadixSelect.Item
+      className={classnames("select-item", props.marked ? "select-item-marked" : undefined)}
+      {...props}
+      ref={forwardedRef}>
+      <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
+      <RadixSelect.ItemIndicator className="select-item-indicator">
+        <span className="codicon codicon-check" />
+      </RadixSelect.ItemIndicator>
+    </RadixSelect.Item>
+  );
+});
 
-type SelectItemType = { value: string; label: string | ReactNode; disabled?: boolean };
+type SelectItemType = {
+  value: string;
+  label: string | ReactNode;
+  disabled?: boolean;
+  marked?: boolean;
+};
 
 type SelectGroupType = { items: SelectItemType[]; label: string | ReactNode };
 
@@ -40,7 +49,7 @@ function Select({ value, onChange, items, placeholder, className, disabled }: Se
     <RadixSelect.Root value={value} onValueChange={onChange} disabled={disabled}>
       <RadixSelect.Trigger
         className={classnames("select-trigger", className, disabled && "select-trigger-disabled")}>
-        <RadixSelect.Value placeholder={placeholder} />
+        <RadixSelect.Value style={{ color: "red" }} placeholder={placeholder} />
         <RadixSelect.Icon className="select-icon">
           <span className="codicon codicon-chevron-down" />
         </RadixSelect.Icon>
@@ -59,13 +68,18 @@ function Select({ value, onChange, items, placeholder, className, disabled }: Se
                     <SelectItem
                       key={selectItem.value}
                       disabled={selectItem.disabled}
+                      marked={selectItem.marked}
                       value={selectItem.value}>
                       {selectItem.label}
                     </SelectItem>
                   ))}
                 </RadixSelect.Group>
               ) : (
-                <SelectItem key={item.value} disabled={item.disabled} value={item.value}>
+                <SelectItem
+                  key={item.value}
+                  disabled={item.disabled}
+                  value={item.value}
+                  marked={item.marked}>
                   {item.label}
                 </SelectItem>
               )

--- a/packages/vscode-extension/src/webview/components/shared/Select.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/Select.tsx
@@ -49,7 +49,7 @@ function Select({ value, onChange, items, placeholder, className, disabled }: Se
     <RadixSelect.Root value={value} onValueChange={onChange} disabled={disabled}>
       <RadixSelect.Trigger
         className={classnames("select-trigger", className, disabled && "select-trigger-disabled")}>
-        <RadixSelect.Value style={{ color: "red" }} placeholder={placeholder} />
+        <RadixSelect.Value placeholder={placeholder} />
         <RadixSelect.Icon className="select-icon">
           <span className="codicon codicon-chevron-down" />
         </RadixSelect.Icon>

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -143,6 +143,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-preview-background: var(--white);
 
   --swm-default-text: var(--navy-light-100);
+  --swm-marked-text: var(--yellow-dark-120);
   --swm-highlighted-text: var(--navy-light-40);
   --swm-error-color: var(--red-light-100);
   --swm-secondary-text: var(--navy-light-60);
@@ -304,6 +305,7 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-preview-background: var(--background-dark-100);
 
   --swm-default-text: var(--off-white);
+  --swm-marked-text: var(--yellow-dark-100);
   --swm-highlighted-text: black;
   --swm-error-color: var(--red-dark-100);
   --swm-secondary-text: var(--background-dark-10);

--- a/packages/vscode-extension/src/webview/utilities/consts.ts
+++ b/packages/vscode-extension/src/webview/utilities/consts.ts
@@ -24,6 +24,7 @@ export type DeviceProperties = {
   offsetY: number;
   frameImage: string;
   maskImage: string;
+  minimumAndroidApiLevel?: number;
 };
 
 // Model identifiers for new devices are sourced from 'hw.device.name'
@@ -63,6 +64,7 @@ export const AndroidSupportedDevices: DeviceProperties[] = [
   {
     modelName: "Google Pixel 9",
     modelId: "pixel_9",
+    minimumAndroidApiLevel: 35,
     platform: DevicePlatform.Android,
     screenWidth: 1080,
     screenHeight: 2424,
@@ -76,6 +78,7 @@ export const AndroidSupportedDevices: DeviceProperties[] = [
   {
     modelName: "Google Pixel 8",
     modelId: "pixel_8",
+    minimumAndroidApiLevel: 34,
     platform: DevicePlatform.Android,
     screenWidth: 1080,
     screenHeight: 2400,
@@ -89,6 +92,7 @@ export const AndroidSupportedDevices: DeviceProperties[] = [
   {
     modelName: "Google Pixel 7",
     modelId: "pixel_7",
+    minimumAndroidApiLevel: 33,
     platform: DevicePlatform.Android,
     screenWidth: 1080,
     screenHeight: 2400,
@@ -102,6 +106,7 @@ export const AndroidSupportedDevices: DeviceProperties[] = [
   {
     modelName: "Google Pixel 6a",
     modelId: "pixel_6a",
+    minimumAndroidApiLevel: 32,
     platform: DevicePlatform.Android,
     screenWidth: 1080,
     screenHeight: 2400,

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.css
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.css
@@ -28,6 +28,10 @@
   user-select: none;
 }
 
+.form-filed-marked {
+  color: var(--swm-marked-text);
+}
+
 .dropdown .listbox {
   max-height: 300px !important;
   overflow-y: scroll;
@@ -38,6 +42,15 @@
   margin: 4px 0px;
   height: 1px;
   background-color: var(--swm-separator);
+}
+
+.incompatible-system-warning {
+  display: flex;
+  width: 100%;
+  padding: 10px;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
 }
 
 input.device-name-input {

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import classNames from "classnames";
 import Select from "../components/shared/Select";
 import "./CreateDeviceView.css";
 import { useDevices } from "../providers/DevicesProvider";
@@ -11,7 +12,6 @@ import {
 } from "../utilities/consts";
 import { useDependencies } from "../providers/DependenciesProvider";
 import { Platform } from "../providers/UtilsProvider";
-import classNames from "classnames";
 
 interface CreateDeviceViewProps {
   onCreate: () => void;
@@ -51,8 +51,6 @@ export function formatDisplayName(name: string) {
   const singleSpaced = name.replace(/\s+/g, " ");
   return singleSpaced.replace(/[^a-zA-Z0-9 _-]/g, "");
 }
-
-const min_supported_version_for_device = {};
 
 function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
   const [deviceProperties, setDeviceProperties] = useState<DeviceProperties | undefined>(undefined);

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -187,9 +187,7 @@ function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
         {!isSystemCompatible && (
           <div className="incompatible-system-warning">
             <span className="codicon codicon-warning warning" />{" "}
-            <div>
-              This system image is not compatible with the selected device.
-            </div>
+            <div>This system image is not compatible with the selected device.</div>
           </div>
         )}
       </div>

--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -188,8 +188,7 @@ function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
           <div className="incompatible-system-warning">
             <span className="codicon codicon-warning warning" />{" "}
             <div>
-              System image you've chosen was released before selected device, which might cause some
-              issues.
+              This system image is not compatible with the selected device.
             </div>
           </div>
         )}


### PR DESCRIPTION
This PR adds a warning for users trying to install older versions of android on newer devices, as they may not be compatible.

We opt to still allow users to ignore the warning because android studio allows installing any sdk on any emulator. 

### Example of incompatibility:

- pixel 9 with sdk 35 has a status bar overflowing the device frame

<img width="268" alt="Screenshot 2024-12-04 at 23 42 39" src="https://github.com/user-attachments/assets/58906a2f-2d34-465d-b318-d87ec2783ce5">


### How Has This Been Tested: 

- open manage devices modal and click through possibilities 



