### PR TITLE
Update CTAs 

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -89,10 +89,10 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
-      announcementBar: {
-        id: `product-hunt-launch-banner`,
-        content: `🎉  Radon IDE just launched on Product Hunt! <a href="https://www.producthunt.com/posts/radon-ide" target="_blank">Upvote!</a>`,
-      },
+      // announcementBar: {
+      //   id: `product-hunt-launch-banner`,
+      //   content: `🎉  Radon IDE just launched on Product Hunt! <a href="https://www.producthunt.com/posts/radon-ide" target="_blank">Upvote!</a>`,
+      // },
       metadata: [
         {
           name: "google-site-verification",

--- a/packages/docs/src/components/CloseIcon/index.tsx
+++ b/packages/docs/src/components/CloseIcon/index.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+export default function CloseIcon(props) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+      <path
+        stroke="#001A72"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="m5.833 5.833 16.333 16.334m-16.333 0L22.166 5.833"
+      />
+    </svg>
+  );
+}

--- a/packages/docs/src/components/CloseIcon/index.tsx
+++ b/packages/docs/src/components/CloseIcon/index.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 export default function CloseIcon(props) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width={28} height={28} fill="none" {...props}>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={16}
+      height={16}
+      fill="none"
+      viewBox="0 0 24 24"
+      {...props}>
       <path
         stroke="#001A72"
         strokeLinecap="round"

--- a/packages/docs/src/components/FaqList/FaqItem/styles.module.css
+++ b/packages/docs/src/components/FaqList/FaqItem/styles.module.css
@@ -65,3 +65,15 @@
 .faqItemExpanded {
   background-color: var(--swm-green-light-60);
 }
+
+@media (max-width: 430px) {
+  .question,
+  .answer {
+    font-size: 16px;
+  }
+
+  .faqItemQuestion,
+  .answer {
+    padding: 10px 16px;
+  }
+}

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -15,6 +15,7 @@ const StartScreen = () => {
 
   const handleDialogOpen = () => {
     dialogRef.current?.showModal();
+    track("Secondary CTA");
   };
 
   const handleDialogClose = () => {
@@ -23,22 +24,6 @@ const StartScreen = () => {
 
   return (
     <>
-      <dialog ref={dialogRef} onClick={handleDialogClose}>
-        <button onClick={handleDialogClose} className={styles.dialogCloseButton}>
-          <CloseIcon />
-        </button>
-        <iframe
-          className={styles.responsiveIframe}
-          width="1280"
-          height="720"
-          src="https://www.youtube.com/embed/07Un9EfE8D4?si=h1-7o5e3StOjRZf8"
-          title="YouTube video player"
-          // @ts-ignore it's a valid attribute & type, typescript is wrong
-          allowFullScreen="0"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          referrerpolicy="strict-origin-when-cross-origin"></iframe>
-      </dialog>
       <section className={styles.hero}>
         <motion.div
           className={styles.heroImageContainer}
@@ -113,6 +98,23 @@ const StartScreen = () => {
           </motion.div>
         </div>
       </section>
+      <dialog ref={dialogRef} onClick={handleDialogClose}>
+        <button onClick={handleDialogClose} className={styles.dialogCloseButton}>
+          <CloseIcon />
+        </button>
+        <iframe
+          className={styles.responsiveIframe}
+          width="1280"
+          height="720"
+          loading="lazy"
+          src="https://www.youtube.com/embed/07Un9EfE8D4?si=h1-7o5e3StOjRZf8"
+          title="YouTube video player"
+          // @ts-ignore it's a valid attribute & type, typescript is wrong
+          allowFullScreen="0"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerpolicy="strict-origin-when-cross-origin"></iframe>
+      </dialog>
     </>
   );
 };

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -2,85 +2,118 @@ import React from "react";
 import styles from "./styles.module.css";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import HomepageButton from "@site/src/components/HomepageButton";
-import InfoIcon from "@site/static/img/info-circle.svg";
 import { motion } from "motion/react";
 import { track } from "@vercel/analytics";
+import SecondaryButton from "../../SecondaryButton";
+import CloseIcon from "../../CloseIcon";
 
 const StartScreen = () => {
+  const dialogRef = React.useRef<HTMLDialogElement>(null);
   const handleCTAClick = () => {
     track("Main CTA");
   };
 
+  const handleDialogOpen = () => {
+    dialogRef.current?.showModal();
+  };
+
+  const handleDialogClose = () => {
+    dialogRef.current?.close();
+  };
+
   return (
-    <section className={styles.hero}>
-      <motion.div
-        className={styles.heroImageContainer}
-        initial={{ x: 16 }}
-        animate={{ x: 0 }}
-        transition={{ duration: 0.5 }}>
-        <div className={styles.heroImageWrapper}>
-          <img className={styles.heroImage} src={useBaseUrl("/img/hero.png")} draggable={false} />
-        </div>
-      </motion.div>
-      <div className={styles.heading}>
+    <>
+      <dialog ref={dialogRef} onClick={handleDialogClose}>
+        <button onClick={handleDialogClose} className={styles.dialogCloseButton}>
+          <CloseIcon />
+        </button>
+        <iframe
+          className={styles.responsiveIframe}
+          width="1280"
+          height="720"
+          src="https://www.youtube.com/embed/07Un9EfE8D4?si=h1-7o5e3StOjRZf8"
+          title="YouTube video player"
+          // @ts-ignore it's a valid attribute & type, typescript is wrong
+          allowFullScreen="0"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerpolicy="strict-origin-when-cross-origin"></iframe>
+      </dialog>
+      <section className={styles.hero}>
         <motion.div
-          className={styles.poweredBy}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}>
-          <img src={useBaseUrl("/img/logo.svg")} alt="Radon IDE logo" className={styles.logo} />
-          <p>by</p>
-          <a href="https://swmansion.com" target="_blank" className={styles.swmLogoWrapper}>
-            <img
-              src={useBaseUrl("/img/swm-logo.svg")}
-              alt="Software Mansion"
-              className={styles.swmLogo}
-            />
-          </a>
+          className={styles.heroImageContainer}
+          initial={{ x: 16 }}
+          animate={{ x: 0 }}
+          transition={{ duration: 0.5 }}>
+          <div className={styles.heroImageWrapper}>
+            <img className={styles.heroImage} src={useBaseUrl("/img/hero.png")} draggable={false} />
+          </div>
         </motion.div>
-        <motion.h1
-          className={styles.headingLabel}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.1 }}>
-          An <span>IDE</span> for&nbsp;React Native
+        <div className={styles.heading}>
           <motion.div
-            initial={{ x: 0, opacity: 0 }}
-            animate={{ opacity: [0, 1, 1, 1, 0], x: 500 }}
-            transition={{ delay: 0.8, duration: 0.8 }}
-            className={styles.headingSwoosh}
-          />
-        </motion.h1>
-        <motion.h2
-          className={styles.subheadingLabel}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2 }}>
-          Radon IDE is a VSCode and Cursor extension that turns your editor into a fully featured IDE for React
-          Native and Expo.
-        </motion.h2>
-        <div className={styles.buttonContainer}>
-          <motion.div
+            className={styles.poweredBy}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}>
+            <img src={useBaseUrl("/img/logo.svg")} alt="Radon IDE logo" className={styles.logo} />
+            <p>by</p>
+            <a href="https://swmansion.com" target="_blank" className={styles.swmLogoWrapper}>
+              <img
+                src={useBaseUrl("/img/swm-logo.svg")}
+                alt="Software Mansion"
+                className={styles.swmLogo}
+              />
+            </a>
+          </motion.div>
+          <motion.h1
+            className={styles.headingLabel}
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.3 }}>
-            <HomepageButton
-              target="_blank"
-              href="https://marketplace.visualstudio.com/items?itemName=swmansion.react-native-ide"
-              title="Download from VSCode marketplace"
-              onClick={handleCTAClick}
+            transition={{ delay: 0.1 }}>
+            An <span>IDE</span> for&nbsp;React Native
+            <motion.div
+              initial={{ x: 0, opacity: 0 }}
+              animate={{ opacity: [0, 1, 1, 1, 0], x: 500 }}
+              transition={{ delay: 0.8, duration: 0.8 }}
+              className={styles.headingSwoosh}
             />
+          </motion.h1>
+          <motion.h2
+            className={styles.subheadingLabel}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2 }}>
+            Radon IDE is a VSCode and Cursor extension that turns your editor into a fully featured
+            IDE for React Native and Expo.
+          </motion.h2>
+          <div className={styles.buttonContainer}>
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}>
+              <HomepageButton
+                target="_blank"
+                href="https://marketplace.visualstudio.com/items?itemName=swmansion.react-native-ide"
+                title="Get started for free"
+                onClick={handleCTAClick}
+              />
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.4 }}>
+              <SecondaryButton title="View demo" onClick={handleDialogOpen} />
+            </motion.div>
+          </div>
+          <motion.div
+            className={styles.headingDisclaimer}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5 }}>
+            Free 30-day trial. No credit card required.
           </motion.div>
         </div>
-        <motion.div
-          className={styles.headingDisclaimer}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4 }}>
-          <InfoIcon className={styles.headingDisclaimerIcon} />
-          Works with VSCode 1.86+ and Cursor 0.32 on macOS and Windows
-        </motion.div>
-      </div>
-    </section>
+      </section>
+    </>
   );
 };
 

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -18,6 +18,11 @@ const StartScreen = () => {
     } else if (!dialogRef.current?.open && isOpen) {
       dialogRef.current?.showModal();
     }
+
+    dialogRef.current?.addEventListener("close", handleDialogClose);
+    return () => {
+      dialogRef.current?.removeEventListener("close", handleDialogClose);
+    };
   }, [isOpen]);
 
   const handleCTAClick = () => {

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -110,7 +110,7 @@ const StartScreen = () => {
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.5 }}>
-            Free 30-day trial. No credit card required.
+            Free 30-day trial. No sign up or credit card required.
           </motion.div>
         </div>
       </section>

--- a/packages/docs/src/components/Hero/StartScreen/index.tsx
+++ b/packages/docs/src/components/Hero/StartScreen/index.tsx
@@ -9,17 +9,28 @@ import CloseIcon from "../../CloseIcon";
 
 const StartScreen = () => {
   const dialogRef = React.useRef<HTMLDialogElement>(null);
+  // i need the state to have the iframe unmouted when the dialog is closed to prevent google to track the video
+  // and unnecessarily load a heavy iframe
+  const [isOpen, setOpen] = React.useState(false);
+  React.useEffect(() => {
+    if (dialogRef.current?.open && !isOpen) {
+      dialogRef.current?.close();
+    } else if (!dialogRef.current?.open && isOpen) {
+      dialogRef.current?.showModal();
+    }
+  }, [isOpen]);
+
   const handleCTAClick = () => {
     track("Main CTA");
   };
 
   const handleDialogOpen = () => {
-    dialogRef.current?.showModal();
     track("Secondary CTA");
+    setOpen(true);
   };
 
   const handleDialogClose = () => {
-    dialogRef.current?.close();
+    setOpen(false);
   };
 
   return (
@@ -98,23 +109,25 @@ const StartScreen = () => {
           </motion.div>
         </div>
       </section>
-      <dialog ref={dialogRef} onClick={handleDialogClose}>
-        <button onClick={handleDialogClose} className={styles.dialogCloseButton}>
-          <CloseIcon />
-        </button>
-        <iframe
-          className={styles.responsiveIframe}
-          width="1280"
-          height="720"
-          loading="lazy"
-          src="https://www.youtube.com/embed/07Un9EfE8D4?si=h1-7o5e3StOjRZf8"
-          title="YouTube video player"
-          // @ts-ignore it's a valid attribute & type, typescript is wrong
-          allowFullScreen="0"
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          referrerpolicy="strict-origin-when-cross-origin"></iframe>
-      </dialog>
+      {isOpen && (
+        <dialog ref={dialogRef} onClick={handleDialogClose}>
+          <button onClick={handleDialogClose} className={styles.dialogCloseButton}>
+            <CloseIcon />
+          </button>
+          <iframe
+            className={styles.responsiveIframe}
+            width="1280"
+            height="720"
+            loading="lazy"
+            src="https://www.youtube.com/embed/07Un9EfE8D4?si=h1-7o5e3StOjRZf8"
+            title="YouTube video player"
+            // @ts-ignore it's a valid attribute & type, typescript is wrong
+            allowFullScreen="1"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"></iframe>
+        </dialog>
+      )}
     </>
   );
 };

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -131,7 +131,7 @@
 
 @media (max-width: 2400px) {
   .heroImageWrapper {
-    transform: translateX(55%) translateY(5%);
+    transform: translateX(60%) translateY(5%);
   }
 }
 

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -165,7 +165,7 @@
   }
 }
 
-@media (max-width: 420px) {
+@media (max-width: 430px) {
   .hero {
     margin-bottom: 0;
   }
@@ -178,12 +178,12 @@
   }
 
   .heroImageWrapper {
-    border-width: 1rem;
-    border-radius: 2rem;
+    border-width: 8px;
+    border-radius: 16px;
   }
   .heroImage {
-    border-width: 0.5rem;
-    border-radius: 1rem;
+    border-width: 4px;
+    border-radius: 8px;
   }
   .headingDisclaimer {
     align-items: flex-start;

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -207,17 +207,12 @@ dialog {
   overflow: hidden;
   box-sizing: border-box;
   border: none;
-  border-radius: 12px;
   max-width: 1280px;
   width: 100%;
   opacity: 0;
   transform: translateY(0px);
   transition: all 0.3s allow-discrete;
   padding: 2rem;
-}
-
-dialog iframe {
-  border-radius: 8px;
 }
 
 /*   Before-open state  */
@@ -262,9 +257,11 @@ html:has(dialog[open]) {
 
 .dialogCloseButton {
   position: absolute;
-  padding: 5px;
-  top: 0;
-  right: 0px;
+  padding: 6px;
+  height: 32px;
+  width: 32px;
+  top: 3px;
+  right: 3px;
   cursor: pointer;
   background-color: transparent;
   border: none;

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -207,7 +207,7 @@ dialog {
   overflow: hidden;
   box-sizing: border-box;
   border: none;
-  border-radius: 8px;
+  border-radius: 12px;
   max-width: 1280px;
   width: 100%;
   opacity: 0;

--- a/packages/docs/src/components/Hero/StartScreen/styles.module.css
+++ b/packages/docs/src/components/Hero/StartScreen/styles.module.css
@@ -78,11 +78,12 @@
 }
 
 .headingDisclaimer {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   font-size: 16px;
   font-weight: 400;
   display: flex;
   align-items: center;
+  color: var(--swm-navy-light-60);
 }
 
 .headingDisclaimerIcon {
@@ -106,6 +107,7 @@
 .buttonContainer {
   display: flex;
   justify-content: flex-start;
+  gap: 1rem;
 }
 
 @media (min-width: 2920px) {
@@ -189,4 +191,81 @@
   .headingDisclaimer svg {
     margin-top: 2px;
   }
+
+  .buttonContainer {
+    flex-direction: column;
+  }
+}
+
+/*   Open state of the dialog  */
+dialog[open] {
+  opacity: 1;
+}
+
+/*   Closed state of the dialog   */
+dialog {
+  overflow: hidden;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 8px;
+  max-width: 1280px;
+  width: 100%;
+  opacity: 0;
+  transform: translateY(0px);
+  transition: all 0.3s allow-discrete;
+  padding: 2rem;
+}
+
+dialog iframe {
+  border-radius: 8px;
+}
+
+/*   Before-open state  */
+/* Needs to be after the previous dialog[open] rule to take effect,
+    as the specificity is the same */
+@starting-style {
+  dialog[open] {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+}
+
+/* Transition the :backdrop when the dialog modal is promoted to the top layer */
+dialog::backdrop {
+  background-color: rgb(0 0 0 / 0%);
+  transition: all 0.3s allow-discrete;
+  user-select: none;
+}
+
+dialog[open]::backdrop {
+  background-color: rgb(0 0 0 / 25%);
+}
+
+/* This starting-style rule cannot be nested inside the above selector
+because the nesting selector cannot represent pseudo-elements. */
+
+@starting-style {
+  dialog[open]::backdrop {
+    background-color: rgb(0 0 0 / 0%);
+  }
+}
+
+.responsiveIframe {
+  aspect-ratio: 16 / 9;
+  height: 100%;
+  width: 100%;
+}
+
+html:has(dialog[open]) {
+  overflow: hidden;
+}
+
+.dialogCloseButton {
+  position: absolute;
+  padding: 5px;
+  top: 0;
+  right: 0px;
+  cursor: pointer;
+  background-color: transparent;
+  border: none;
 }

--- a/packages/docs/src/components/LearnMore/LearnMoreFooter/index.tsx
+++ b/packages/docs/src/components/LearnMore/LearnMoreFooter/index.tsx
@@ -12,12 +12,12 @@ const LearnMoreFooter = () => {
     <section>
       <div className={styles.learnMoreSectionFooter}>
         <div>
-          <p>Learn more about the Radon IDE features announced at App.js 2024</p>
+          <p>Hundreds of engineers are building better apps with Radon IDE right now.</p>
         </div>
         <HomepageButton
           target="_blank"
-          href="https://www.youtube.com/watch?v=HWGssA55oNc"
-          title="See the video"
+          href="https://marketplace.visualstudio.com/items?itemName=swmansion.react-native-ide"
+          title="Try Radon IDE free"
           onClick={handleBottomCTAClick}
         />
       </div>

--- a/packages/docs/src/components/LearnMore/LearnMoreFooter/styles.module.css
+++ b/packages/docs/src/components/LearnMore/LearnMoreFooter/styles.module.css
@@ -32,7 +32,7 @@
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .learnMoreSectionFooter {
     margin-top: 1.5rem;
   }

--- a/packages/docs/src/components/LearnMore/LearnMoreFooter/styles.module.css
+++ b/packages/docs/src/components/LearnMore/LearnMoreFooter/styles.module.css
@@ -16,11 +16,19 @@
   font-weight: 700;
   font-size: 24px;
   margin-bottom: 0;
+  text-wrap: balance;
+  text-align: center;
 }
 
 @media (max-width: 996px) {
   .learnMoreSectionFooter {
     gap: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .learnMoreSectionFooter p {
+    text-align: left;
   }
 }
 

--- a/packages/docs/src/components/LinkButton/index.tsx
+++ b/packages/docs/src/components/LinkButton/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styles from "./styles.module.css";
+
+import ArrowRight from "@site/static/img/arrow-right-hero.svg";
+
+interface Props {
+  title: string;
+  href: string;
+  onClick?: () => void;
+}
+
+export default function LinkButton({ title, href, onClick }: Props) {
+  return (
+    <span>
+      <a href={href} target="_blank" className={styles.linkButton} onClick={onClick}>
+        {title}
+        <ArrowRight className={styles.linkButtonArrow} />
+      </a>
+    </span>
+  );
+}

--- a/packages/docs/src/components/LinkButton/index.tsx
+++ b/packages/docs/src/components/LinkButton/index.tsx
@@ -11,11 +11,11 @@ interface Props {
 
 export default function LinkButton({ title, href, onClick }: Props) {
   return (
-    <span>
+    <div className={styles.linkButtonWrapper}>
       <a href={href} target="_blank" className={styles.linkButton} onClick={onClick}>
         {title}
         <ArrowRight className={styles.linkButtonArrow} />
       </a>
-    </span>
+    </div>
   );
 }

--- a/packages/docs/src/components/LinkButton/styles.module.css
+++ b/packages/docs/src/components/LinkButton/styles.module.css
@@ -1,0 +1,21 @@
+.linkButton {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  text-decoration-line: underline;
+  text-underline-offset: 5px;
+  font-size: 18px;
+}
+
+.linkButton svg {
+  transition: transform 0.3s;
+}
+
+.linkButton:hover svg {
+  transform: translateX(5px);
+}
+
+.linkButtonArrow {
+  stroke: var(--swm-landing-button-navy);
+}

--- a/packages/docs/src/components/LinkButton/styles.module.css
+++ b/packages/docs/src/components/LinkButton/styles.module.css
@@ -19,3 +19,8 @@
 .linkButtonArrow {
   stroke: var(--swm-landing-button-navy);
 }
+
+.linkButtonWrapper {
+  display: flex;
+  max-height: 32px;
+}

--- a/packages/docs/src/components/Pricing/PricingCard/styles.module.css
+++ b/packages/docs/src/components/Pricing/PricingCard/styles.module.css
@@ -1,6 +1,7 @@
 .item {
   display: block;
   height: 100%;
+  max-width: 420px;
 }
 
 .plan__container {

--- a/packages/docs/src/components/Pricing/PricingPlansList/styles.module.css
+++ b/packages/docs/src/components/Pricing/PricingPlansList/styles.module.css
@@ -83,6 +83,7 @@
   justify-content: center;
   grid-template-columns: 1fr auto 1fr;
   gap: 10px;
+  font-weight: 500;
 }
 
 .plan_pay_annually p {

--- a/packages/docs/src/components/Pricing/styles.module.css
+++ b/packages/docs/src/components/Pricing/styles.module.css
@@ -30,3 +30,9 @@
   margin: 0;
   margin-top: 36px;
 }
+
+@media (max-width: 430px) {
+  .wrapper {
+    max-width: 100%;
+  }
+}

--- a/packages/docs/src/components/SecondaryButton/index.tsx
+++ b/packages/docs/src/components/SecondaryButton/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import styles from "./styles.module.css";
+
+interface Props {
+  title: string;
+  onClick?: () => void;
+}
+
+export default function SecondaryButton({ title, onClick }: Props) {
+  return (
+    <button className={styles.secondaryButton} onClick={onClick}>
+      {title}
+    </button>
+  );
+}

--- a/packages/docs/src/components/SecondaryButton/styles.module.css
+++ b/packages/docs/src/components/SecondaryButton/styles.module.css
@@ -1,0 +1,25 @@
+.secondaryButton {
+  height: 60px;
+  padding: 1rem 1.5rem;
+
+  font-weight: 500;
+  font-size: 20px;
+
+  cursor: pointer;
+
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+
+  text-wrap: balance;
+  border: 1px solid var(--swm-navy-light-100);
+  background-color: transparent;
+  color: var(--swm-navy-light-100);
+}
+
+@media (max-width: 996px) {
+  .secondaryButton {
+    width: 100%;
+  }
+}

--- a/packages/docs/src/components/SecondaryButton/styles.module.css
+++ b/packages/docs/src/components/SecondaryButton/styles.module.css
@@ -16,6 +16,12 @@
   border: 1px solid var(--swm-navy-light-100);
   background-color: transparent;
   color: var(--swm-navy-light-100);
+  transition: all 0.3s;
+}
+
+.secondaryButton:hover {
+  background-color: var(--swm-navy-light-100);
+  color: var(--swm-white);
 }
 
 @media (max-width: 996px) {

--- a/packages/docs/src/components/SecondaryButton/styles.module.css
+++ b/packages/docs/src/components/SecondaryButton/styles.module.css
@@ -23,3 +23,10 @@
     width: 100%;
   }
 }
+
+@media (max-width: 768px) {
+  .secondaryButton {
+    height: 100%;
+    font-size: 18px;
+  }
+}

--- a/packages/docs/src/components/Sections/FAQ/styles.module.css
+++ b/packages/docs/src/components/Sections/FAQ/styles.module.css
@@ -63,7 +63,7 @@
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .faqMain {
     margin-bottom: 3rem;
   }
@@ -71,6 +71,6 @@
     font-size: 24px;
   }
   .faqSubheading {
-    font-size: 20px;
+    font-size: 18px;
   }
 }

--- a/packages/docs/src/components/Sections/Installation/InstallationStep/styles.module.css
+++ b/packages/docs/src/components/Sections/Installation/InstallationStep/styles.module.css
@@ -41,7 +41,7 @@
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .image img {
     border-width: 1rem;
   }

--- a/packages/docs/src/components/Sections/Installation/styles.module.css
+++ b/packages/docs/src/components/Sections/Installation/styles.module.css
@@ -80,7 +80,7 @@
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .installationHeading {
     font-size: 36px;
   }

--- a/packages/docs/src/components/Sections/Overview/OverviewItem/index.tsx
+++ b/packages/docs/src/components/Sections/Overview/OverviewItem/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styles from "./styles.module.css";
+import { track } from "@vercel/analytics";
+import LinkButton from "@site/src/components/LinkButton";
 
 interface Props {
   label: string;
@@ -9,12 +11,20 @@ interface Props {
 }
 
 const OverviewItem = ({ label, title, body, mediaSrc }: Props) => {
+  const handleButtonClick = () => {
+    track("Overview CTA", { section: label });
+  };
   return (
     <>
       <section className={styles.description}>
         <p className={styles.itemLabel}>{label}</p>
         <h2 className={styles.itemTitle}>{title}</h2>
         <p className={styles.itemBody}>{body}</p>
+        <LinkButton
+          title="Get started for free"
+          href="https://marketplace.visualstudio.com/items?itemName=swmansion.react-native-ide"
+          onClick={handleButtonClick}
+        />
       </section>
       <div className={styles.media}>
         <video autoPlay loop muted playsInline>

--- a/packages/docs/src/components/Sections/Overview/OverviewItem/styles.module.css
+++ b/packages/docs/src/components/Sections/Overview/OverviewItem/styles.module.css
@@ -25,7 +25,6 @@
   white-space: pre-wrap;
   font-size: 20px;
   line-height: 1.3;
-  margin: 0;
 }
 
 .itemLabel {

--- a/packages/docs/src/components/Sections/Overview/OverviewItem/styles.module.css
+++ b/packages/docs/src/components/Sections/Overview/OverviewItem/styles.module.css
@@ -45,13 +45,12 @@
   }
   .media video {
     border-width: 1.5rem !important;
-    border-style: solid;
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .media video {
-    border-width: 1rem !important;
+    border-width: 10px !important;
   }
   .itemTitle {
     margin-bottom: 1rem;

--- a/packages/docs/src/components/Sections/Overview/styles.module.css
+++ b/packages/docs/src/components/Sections/Overview/styles.module.css
@@ -79,7 +79,7 @@
 @media (max-width: 996px) {
   .item {
     flex-direction: column !important;
-    gap: 3rem;
+    gap: 1.5rem;
   }
   .overview {
     gap: 3rem;

--- a/packages/docs/src/components/Sections/Overview/styles.module.css
+++ b/packages/docs/src/components/Sections/Overview/styles.module.css
@@ -104,7 +104,7 @@
   }
 }
 
-@media (max-width: 390px) {
+@media (max-width: 430px) {
   .overviewHeading {
     font-size: 36px;
     margin-top: 0;

--- a/packages/docs/src/pages/index.module.css
+++ b/packages/docs/src/pages/index.module.css
@@ -44,3 +44,10 @@
     padding: 2rem;
   }
 }
+
+@media (max-width: 430px) {
+  .container {
+    width: 90%;
+    gap: 3rem;
+  }
+}

--- a/packages/docs/src/pages/legal/index.module.css
+++ b/packages/docs/src/pages/legal/index.module.css
@@ -46,3 +46,9 @@
     width: 85%;
   }
 }
+
+@media (max-width: 430px) {
+  .container {
+    width: 90%;
+  }
+}

--- a/packages/docs/src/pages/pricing.module.css
+++ b/packages/docs/src/pages/pricing.module.css
@@ -28,3 +28,9 @@
     width: 85%;
   }
 }
+
+@media (max-width: 430px) {
+  .container {
+    width: 90%;
+  }
+}


### PR DESCRIPTION
This PR:
- changes the main CTA from `Download from VSCode Marketplace` to `Get started for free`,
- adds `View demo` modal,
- adds `Get started` buttons in the feature overview section under each feature,
- changes the bottom CTA from  `See the video` to `Try Radon IDE free`,
- hides the product hunt announcement bar
- improves styles on mobile


https://github.com/user-attachments/assets/bb5f9603-f086-4f2f-984e-a9ed1f5843c2

