### PR TITLE
Avoid invoking getAvailableXcodeSchemes on Windows

### DIFF
--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -13,6 +13,7 @@ import {
   LaunchConfigUpdater,
   LaunchConfigurationOptions,
 } from "../../common/LaunchConfig";
+import { Platform } from "./UtilsProvider";
 
 const launchConfig = makeProxy<LaunchConfig>("LaunchConfig");
 
@@ -38,7 +39,9 @@ export default function LaunchConfigProvider({ children }: PropsWithChildren) {
     launchConfig.getConfig().then(setConfig);
     launchConfig.addListener("launchConfigChange", setConfig);
 
-    launchConfig.getAvailableXcodeSchemes().then(setXcodeSchemes);
+    if (Platform.OS === "macos") {
+      launchConfig.getAvailableXcodeSchemes().then(setXcodeSchemes);
+    }
 
     return () => {
       launchConfig.removeListener("launchConfigChange", setConfig);


### PR DESCRIPTION
This PR resolves the error `Could not find Xcode project files in ...` which was caused by calling the getAvailableXcodeSchemes function on Windows.

The issue was exposed in #820, where additionally findPackageManager does not provide actual package manager correctly. It probably is caused by calling getLaunchConfiguration inside findPackageManager. Therefore this PR is likely to fix also #820.

### Test plan (UNTESTED): 
- Run the test apps ensuring that the error "Could not find Xcode project files in... " does not occur on a Windows.
- Verify that the findPackageManager function correctly identifies and uses the correct package manager (#820) on a Windows.

Testing has not been performed yet as we currently do not have access to a functioning Windows setup.