### PR TITLE
fix(docs): Change support for Linux in compatibility table

### DIFF
--- a/packages/docs/docs/getting-started/compatibility.md
+++ b/packages/docs/docs/getting-started/compatibility.md
@@ -73,13 +73,10 @@ Due to the complexity and a non-standard nature of the brownfield development th
 |         | iOS    | Android                  |
 | ------- | ------ | ------------------------ |
 | macOS   | <Yes/> | <Yes/>                   |
+| Linux   | <No/>  | <Yes/>                   |
 | Windows | <No/>  | <Maybe label="In Beta"/> |
-| Linux   | <No/>  | <No/>                    |
 
 </div>
 You can use Radon IDE on Windows using free Beta license.
 <br/>
 <br/>
-
-While running Radon IDE on Linux is technically possible, we do not have enough development capacity to add it.
-If you want to contribute the support for Linux please consult [this issue](https://github.com/software-mansion/radon-ide/issues/688).


### PR DESCRIPTION
Since we've added a support of Radon IDE for Linux (https://github.com/software-mansion/radon-ide/pull/829), it's time to change its support in compatibility table 😄 
This PR changes the value of compatibility for Linux, indicating that this system is officially supported from now on.

### How Has This Been Tested: 

Manually, by building the `docs` package and running it in development mode with `yarn start`.


