### PR TITLE
Add package manager to DiagnosticView

### DIFF
--- a/packages/vscode-extension/src/common/DependencyManager.ts
+++ b/packages/vscode-extension/src/common/DependencyManager.ts
@@ -9,6 +9,7 @@ export type Dependency =
   | "xcode"
   | "cocoaPods"
   | "nodejs"
+  | "packageManager"
   | "nodeModules"
   | "android"
   | "ios"
@@ -23,6 +24,7 @@ export type InstallationStatus = "installed" | "notInstalled" | "installing";
 export type DependencyStatus = {
   status: InstallationStatus;
   isOptional: boolean;
+  details?: string;
 };
 
 export type DependenciesStatus = Record<Dependency, DependencyStatus>;

--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -152,7 +152,7 @@ export function dependencyDescription(dependency: Dependency) {
       return {
         info: "Used for managing project dependencies and scripts.",
         error:
-          "Package manager was not found. Make sure to install the package manager used in the project.",
+          "Package manager not found or uninstalled. Make sure to install the package manager used in the project.",
       };
     case "androidEmulator":
       return {

--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -17,6 +17,7 @@ const dependencyManager = makeProxy<DependencyManagerInterface>("DependencyManag
 
 const dependenciesDomain = [
   "nodejs",
+  "packageManager",
   "androidEmulator",
   "xcode",
   "cocoaPods",
@@ -125,6 +126,7 @@ function getErrors(statuses: DependencyRecord) {
           setFirstError(dependency, "emulator");
           break;
         case "nodejs":
+        case "packageManager":
         case "nodeModules":
           setFirstError(dependency, "common");
           break;
@@ -145,6 +147,12 @@ export function dependencyDescription(dependency: Dependency) {
       return {
         info: "Used for running scripts and getting dependencies.",
         error: "Node.js was not found. Make sure to [install Node.js](https://nodejs.org/en).",
+      };
+    case "packageManager":
+      return {
+        info: "Used for managing project dependencies and scripts.",
+        error:
+          "Package manager was not found. Make sure to install the package manager used in the project.",
       };
     case "androidEmulator":
       return {

--- a/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
+++ b/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
@@ -19,6 +19,11 @@ function DiagnosticView() {
     <div className="diagnostic-container">
       <Label>Common</Label>
       <DiagnosticItem label="Node.js" name="nodejs" info={dependencies.nodejs} />
+      <DiagnosticItem
+        label={`Package manager`}
+        name="packageManager"
+        info={dependencies.packageManager}
+      />
       <DiagnosticItem label="Node Modules" name="nodeModules" info={dependencies.nodeModules} />
       <div className="diagnostic-section-margin" />
 
@@ -94,11 +99,13 @@ function DiagnosticItem({ label, name, info, action }: DiagnosticItemProps) {
     description = messages.info;
   }
 
+  const details = info?.details ? `: ${info?.details}` : "";
+
   return (
     <div className="diagnostic-item-wrapper">
       <div className="diagnostic-item">
         <div className="diagnostic-icon">{icon}</div>
-        <p className="diagnostic-item-text">{label}</p>
+        <p className="diagnostic-item-text">{`${label}${details}`}</p>
         {description && (
           <Tooltip label={description} type="secondary" instant>
             <span className="diagnostic-item-info-icon codicon codicon-info" />


### PR DESCRIPTION
This PR adds a package manager status info to the DiagnosticView, this update will help identify issues from using the wrong package manager, especially when multiple lock files are present in a workspace.

It also introduces a new `details` field to the DependencyStatus type. This field stores the name of the detected package manager and can also hold version numbers or other relevant details for future needs.
 
### How Has This Been Tested: 

- Tested on project with various package manager configurations (supported, unsupported, installed, uninstalled) set in the launch settings.
- Tested on project without package manager lock files and with different lock files (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, `bun.lockb`).
- Verified that an error is displayed in the Diagnostic view when no package manager is installed.

Screenshots:

<img width="533" alt="Screenshot 2024-12-09 at 23 44 58" src="https://github.com/user-attachments/assets/d7e14f5b-9e65-4af5-b260-4fddda6df818">
<img width="533" alt="Screenshot 2024-12-09 at 23 45 38" src="https://github.com/user-attachments/assets/59459105-12f9-4250-9be5-0c99e7943479">
<img width="526" alt="Screenshot 2024-12-09 at 23 46 31" src="https://github.com/user-attachments/assets/a2a86dbd-8d0a-414b-8dea-090378a0de03">
