### PR TITLE
Fix Node Modules detection without package.json

### DIFF
--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -124,8 +124,13 @@ async function isNpmModulesInstalled(workspacePath: string): Promise<boolean> {
       cwd: workspacePath,
       quietErrorsOnExit: true,
     });
-    const parsedJson = JSON.parse(stdout);
-    return parsedJson.problems ? false : true;
+    const parsedOutput = JSON.parse(stdout);
+
+    if (!parsedOutput || Object.keys(parsedOutput).length === 0) {
+      return false;
+    }
+
+    return parsedOutput.problems ? false : true;
   } catch (e) {
     return false;
   }
@@ -143,6 +148,10 @@ async function isYarnModulesInstalled(workspacePath: string): Promise<boolean> {
       quietErrorsOnExit: true,
     });
     const parsedOutput = JSON.parse(stdout);
+
+    if (!parsedOutput || Object.keys(parsedOutput).length === 0) {
+      return false;
+    }
 
     // because npm marks packages installed with yarn as "extraneous" we need to check if there are any other problems.
     return (


### PR DESCRIPTION
This PR resolves the incorrect marking of the Node Modules dependency as uninstalled when a project lacks a `package.json` file.

The issue occurred because the functions `isNpmModulesInstalled` and `isYarnModulesInstalled` did not check for an empty parsedOutput, which is the result of the `npm ls --json` command. Previously these functions mistakenly returned true when parsedOutput was empty. Now, they correctly return false if parsedOutput is empty.

### How Has This Been Tested: 
- Tested scenarios with and without a `package.json`, lock files, and the `node_modules` folder  to ensure accurate dependency status.

|Before|After|
|-|-|
|<img width="766" alt="Screenshot 2024-12-10 at 10 00 39" src="https://github.com/user-attachments/assets/b0f82c42-5dda-429c-8924-b0b75844ad6e">|<img width="766" alt="Screenshot 2024-12-10 at 10 00 04" src="https://github.com/user-attachments/assets/1853e7cf-1756-4cd3-8cf3-220fbc090cf5">|

(The "After" comparison showed errors for missing Android and iOS directories because it incorrectly detected the app root folder as `expo-router/no_node_modules/@expo/cli/static/template` instead of the correct `expo-router/`.)