### PR TITLE
Add support for PNPM monorepos

### DIFF
--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -17,8 +17,9 @@ export function getDevServerScriptUrl() {
 export function isWorkspaceRoot(dir: string) {
   const packageJsonPath = path.join(dir, "package.json");
   const nxJsonPath = path.join(dir, "nx.json");
+  const pnpmWorkspaceYamlPath = path.join(dir, "pnpm-workspace.yaml");
 
-  if (fs.existsSync(nxJsonPath)) {
+  if (fs.existsSync(nxJsonPath) || fs.existsSync(pnpmWorkspaceYamlPath)) {
     return true;
   }
 


### PR DESCRIPTION
This PR introduces support for PNPM monorepos:
- identifies the monorepo workspace root based on the presence of the `pnpm-workspace.yaml` file
- installs node modules using PNPM if `isPnpmModulesInstalled` detects them as not installed

Resolves: #736 and #837 

### How Has This Been Tested:
- Tested with the new `pnpm-monorepo` test app introduced in [PR](https://github.com/software-mansion-labs/radon-ide-test-apps/pull/2), confirming correct app building both for iOS and Android on macOS.
