### PR TITLE
Hide expo-router's internal __EXPO_ROUTER_key from displayURL

### DIFF
--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -17,8 +17,11 @@ function useRouterPluginMainHook({ onNavigationChange }) {
   const pathname = routeInfo?.pathname;
   const params = routeInfo?.params;
 
-  const displayParams = new URLSearchParams(params).toString();
-  const displayName = `${pathname}${displayParams ? `?${displayParams}` : ''}`;
+  const filteredParams = params ?? {};
+  delete filteredParams.__EXPO_ROUTER_key;
+
+  const displayParams = new URLSearchParams(filteredParams).toString();
+  const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
 
   useEffect(() => {
     onNavigationChange({


### PR DESCRIPTION
This PR hides expo-routers internal parameter called __EXPO_ROUTER_key from being used when building the display URL we show in the URL bar.

This parameter is being automatically generated and doesn't carry any meaningful information for the user, hence we can hide it from appearing in the URL bar. The parameter is still kept in router params, so this change doesn't impact the behavior when switching between the routes, it only impacts the representation of that route in the URL bar.

### How Has This Been Tested: 
1. I wasn't able to reproduce this on the project where that option appears, so the testing ewas limited to expo-router examples from test-apps and I verifies that nothing broke there



