### PR TITLE
Fix vertical centering of phone screen in narrow IDE window

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -21,7 +21,7 @@
   max-width: 100%;
   max-height: 100%;
   min-height: 350px;
-  align-self: start;
+  align-self: center;
   /* object-fit: scale-down; */
 }
 


### PR DESCRIPTION
This PR addresses the issue where the phone screen was not centered vertically within narrow IDE window.

|Before|After|
|-|-|
|![Screenshot 2024-12-13 at 11 09 57](https://github.com/user-attachments/assets/50c3eacd-5fb2-4675-b1d4-568474480aaa)|![Screenshot 2024-12-13 at 11 09 51](https://github.com/user-attachments/assets/b6521d20-c032-4d0a-98e0-699dde3870fd)|


