### PR TITLE
Hide scrollbar in narrow IDE window with hidden device frame

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -165,8 +165,8 @@
   transform: translate(0px, 21px);
 }
 
-@media (width <= 450px) {
-  .phone-content {
+@media (width <=415px) {
+  .phone-wrapper {
     overflow: hidden;
   }
 }

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -164,3 +164,9 @@
 .button-group-left:has(.zoom-controls.select-open) {
   transform: translate(0px, 21px);
 }
+
+@media (width <= 450px) {
+  .phone-content {
+    overflow: hidden;
+  }
+}

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -3,7 +3,7 @@
   display: flex;
   justify-content: safe center;
   align-items: safe center;
-  overflow: auto;
+  overflow: hidden;
   width: 100%;
   position: relative;
   user-select: none;
@@ -163,10 +163,4 @@
 .button-group-left-wrapper:hover .button-group-left,
 .button-group-left:has(.zoom-controls.select-open) {
   transform: translate(0px, 21px);
-}
-
-@media (width <=415px) {
-  .phone-wrapper {
-    overflow: hidden;
-  }
 }

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -165,8 +165,8 @@
   transform: translate(0px, 21px);
 }
 
-@media (width <= 450px) {
-  .phone-content {
+@media (width <= 415px) {
+  .phone-wrapper {
     overflow: hidden;
   }
 }

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -165,8 +165,8 @@
   transform: translate(0px, 21px);
 }
 
-@media (width <= 415px) {
-  .phone-wrapper {
+@media (width <= 450px) {
+  .phone-content {
     overflow: hidden;
   }
 }


### PR DESCRIPTION
This PR addresses the issue of a scrollbar appearing when the IDE window is narrow and the device frame is hidden.
The scrollbar appeared because the `touch-area` for edge swipe gestures extends beyond the phone content width. To fix this, `overflow: hidden` is applied for windows narrower than 415px to override `overflow: auto` in `phone-wrapper`.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/ed75fdb6-7090-4e6a-a13e-c8bd864df648" />|<video src="https://github.com/user-attachments/assets/c9ba00e3-1ad9-47ab-8182-f31a0d4de055" />|



