### PR TITLE
Improve the reloading experience

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -36,7 +36,13 @@ export class DebugSession implements Disposable {
   }
 
   public dispose() {
-    this.session && debug.stopDebugging(this.session);
+    let sessionExists = false;
+    try {
+      sessionExists = Boolean(this.session);
+    } catch {
+      // ignore errors as we are only interested if the session exists
+    }
+    sessionExists && debug.stopDebugging(this.session);
     this.debugEventsListener.dispose();
   }
 

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -36,13 +36,7 @@ export class DebugSession implements Disposable {
   }
 
   public dispose() {
-    let sessionExists = false;
-    try {
-      sessionExists = Boolean(this.session);
-    } catch {
-      // ignore errors as we are only interested if the session exists
-    }
-    sessionExists && debug.stopDebugging(this.session);
+    this.vscSession && debug.stopDebugging(this.vscSession);
     this.debugEventsListener.dispose();
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -358,7 +358,7 @@ export class Project
   }
 
   public async reload(type: ReloadAction): Promise<boolean> {
-    this.updateProjectState({ status: "starting" });
+    this.updateProjectState({ status: "starting", startupMessage: StartupMessage.Restarting });
 
     // this action needs to be handled outside of device session as it resets the device session itself
     if (type === "reboot") {

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -22,7 +22,7 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
   useEffect(() => {
     if (projectState.startupMessage === StartupMessage.Restarting) {
-      setProgress(100);
+      setProgress(0);
     } else {
       const currentIndex = StartupStageWeight.findIndex(
         (item) => item.StartupMessage === projectState.startupMessage


### PR DESCRIPTION
This PR solves an issue with reload, clean rebuild and clear metro cache functionality when debugger was not attached. 
Because the above methods caused debug session to be disposed be triggered a session getter which throws error when debugger does not exist, breaking the flow of the reboot. To solve that issue we use `this.vscSession` instead. 

Additionally debugging this issue reveled that initial state of the `reload` functionality is trigering initially startup message "attaching debugger" because that is the last one that was set by initial startup process. To fix that we immediately set it to "restarting" similarly to how we did it in `restart` method. 

To avoid progress bar jumping back and forth we set the progress of "restarting" to 0.

### How Has This Been Tested: 
- add `return undefind` at the beginning of `lookupWsAddressForNewDebugger` method to simulate debugger not attaching and check restart functionality after fully booting IDE first.



