### PR TITLE
Fix vscode-js-debug submodule initialization

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -453,7 +453,7 @@
     "format": "prettier --write --list-different src",
     "build:tests": "tsc --project tsconfig.test.json",
     "test": "npm run build:extension-code && npm run build:webview && npm run build:tests && vscode-test",
-    "preinstall": "cd ../vscode-js-debug && git submodule update && npm install && npm exec tsc"
+    "preinstall": "cd ../vscode-js-debug && git submodule update --init && npm install && npm exec tsc"
   },
   "devDependencies": {
     "vscode-js-debug": "file:../vscode-js-debug",


### PR DESCRIPTION
This PR fixes an issue that occurred on fresh clones of the repository. In  #846 we added a new submodule `vscode-js-debug` along with preinstall actions that should build it. This PR adds initialization to that flow so the command works on fresh clones as well.  

### How Has This Been Tested: 

run:
- `git clone git@github.com:software-mansion/radon-ide.git` 
- `cd packages/vscode-extension`
- `npm i` 

everything should work 


