### PR TITLE
Add additional telemetry to better understand the problems with the application

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -16,6 +16,7 @@ import { getReactNativeVersion } from "../utilities/reactNative";
 import { runExternalBuild } from "./customBuild";
 import { fetchEasBuild } from "./eas";
 import { DependencyManager } from "../dependency/DependencyManager";
+import { getTelemetryReporter } from "../utilities/telemetry";
 
 export type AndroidBuildResult = {
   platform: DevicePlatform.Android;
@@ -89,6 +90,9 @@ export async function buildAndroid(
   }
 
   if (customBuild?.android?.buildCommand) {
+    getTelemetryReporter().sendTelemetryEvent("build:custom-build-requested", {
+      platform: DevicePlatform.Android,
+    });
     const apkPath = await runExternalBuild(cancelToken, customBuild.android.buildCommand, env);
     if (!apkPath) {
       throw new Error("Failed to build Android app using custom script.");
@@ -102,6 +106,9 @@ export async function buildAndroid(
   }
 
   if (eas?.android) {
+    getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
+      platform: DevicePlatform.Android,
+    });
     const apkPath = await fetchEasBuild(cancelToken, eas.android, DevicePlatform.Android);
     if (!apkPath) {
       throw new Error("Failed to build Android app using EAS build.");
@@ -115,6 +122,9 @@ export async function buildAndroid(
   }
 
   if (await isExpoGoProject()) {
+    getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
+      platform: DevicePlatform.Android,
+    });
     const apkPath = await downloadExpoGo(DevicePlatform.Android, cancelToken);
     return { apkPath, packageName: EXPO_GO_PACKAGE_NAME, platform: DevicePlatform.Android };
   }

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -12,6 +12,7 @@ import { runExternalBuild } from "./customBuild";
 import { fetchEasBuild } from "./eas";
 import { getXcodebuildArch } from "../utilities/common";
 import { DependencyManager } from "../dependency/DependencyManager";
+import { getTelemetryReporter } from "../utilities/telemetry";
 
 export type IOSBuildResult = {
   platform: DevicePlatform.IOS;
@@ -87,6 +88,9 @@ export async function buildIos(
   }
 
   if (customBuild?.ios?.buildCommand) {
+    getTelemetryReporter().sendTelemetryEvent("build:custom-build-requested", {
+      platform: DevicePlatform.IOS,
+    });
     // We don't autoinstall Pods here to make custom build scripts more flexible
 
     const appPath = await runExternalBuild(cancelToken, customBuild.ios.buildCommand, env);
@@ -102,6 +106,9 @@ export async function buildIos(
   }
 
   if (eas?.ios) {
+    getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
+      platform: DevicePlatform.IOS,
+    });
     const appPath = await fetchEasBuild(cancelToken, eas.ios, DevicePlatform.IOS);
     if (!appPath) {
       throw new Error("Failed to build iOS app using EAS build.");
@@ -115,6 +122,9 @@ export async function buildIos(
   }
 
   if (await isExpoGoProject()) {
+    getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
+      platform: DevicePlatform.IOS,
+    });
     const appPath = await downloadExpoGo(DevicePlatform.IOS, cancelToken);
     return { appPath, bundleID: EXPO_GO_BUNDLE_ID, platform: DevicePlatform.IOS };
   }
@@ -130,6 +140,7 @@ export async function buildIos(
   await installPodsIfNeeded();
 
   const xcodeProject = await findXcodeProject(appRootFolder);
+  ``;
 
   if (!xcodeProject) {
     throw new Error(`Could not find Xcode project files in "${sourceDir}" folder`);

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -140,7 +140,6 @@ export async function buildIos(
   await installPodsIfNeeded();
 
   const xcodeProject = await findXcodeProject(appRootFolder);
-  ``;
 
   if (!xcodeProject) {
     throw new Error(`Could not find Xcode project files in "${sourceDir}" folder`);

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -27,6 +27,8 @@ import { CancelToken } from "../builders/cancelToken";
 import { getAndroidSourceDir } from "../builders/buildAndroid";
 import { Platform } from "../utilities/platform";
 import { requireNoCache } from "../utilities/requireNoCache";
+import { getTelemetryReporter } from "../utilities/telemetry";
+import { DevicePlatform } from "../common/DeviceManager";
 
 export class DependencyManager implements Disposable, DependencyManagerInterface {
   // React Native prepares build scripts based on node_modules, we need to reinstall pods if they change
@@ -176,6 +178,9 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
       await cancelToken.adapt(process);
     } catch (e) {
       Logger.error("Pods not installed", e);
+      getTelemetryReporter().sendTelemetryEvent("build:pod-install-failed", {
+        platform: DevicePlatform.IOS,
+      });
       this.emitEvent("pods", { status: "notInstalled", isOptional: false });
       return;
     }

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -30,6 +30,7 @@ import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { Platform } from "../utilities/platform";
 import { checkXcodeExists } from "../dependency/DependencyManager";
+import { getTelemetryReporter } from "../utilities/telemetry";
 
 const DEVICE_LIST_CACHE_KEY = "device_list_cache";
 
@@ -153,6 +154,11 @@ export class DeviceManager implements DeviceManagerInterface {
     displayName: string,
     systemImage: AndroidSystemImageInfo
   ) {
+    getTelemetryReporter().sendTelemetryEvent("device-manager:create-device", {
+      platform: DevicePlatform.Android,
+      systemName: String(systemImage.apiLevel),
+    });
+
     const emulator = await createEmulator(modelId, displayName, systemImage);
     await this.loadDevices(true);
     return emulator;
@@ -163,6 +169,11 @@ export class DeviceManager implements DeviceManagerInterface {
     displayName: string,
     runtime: IOSRuntimeInfo
   ) {
+    getTelemetryReporter().sendTelemetryEvent("device-manager:create-device", {
+      platform: DevicePlatform.IOS,
+      systemName: String(runtime.version),
+    });
+
     const simulator = await createSimulator(
       deviceType.identifier,
       displayName,
@@ -184,6 +195,11 @@ export class DeviceManager implements DeviceManagerInterface {
   }
 
   public async removeDevice(device: DeviceInfo) {
+    getTelemetryReporter().sendTelemetryEvent("device-manager:remove-device", {
+      platform: device.platform,
+      systemName: String(device.systemName),
+    });
+
     if (device.platform === DevicePlatform.IOS) {
       await removeIosSimulator(device.UDID, SimulatorDeviceSet.RN_IDE);
     }

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -7,6 +7,7 @@ import {
   WorkspaceConfigEventMap,
   WorkspaceConfigEventListener,
 } from "../common/WorkspaceConfig";
+import { getTelemetryReporter } from "../utilities/telemetry";
 
 export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
   private config: WorkspaceConfigProps;
@@ -25,10 +26,27 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
         return;
       }
       const config = workspace.getConfiguration("RadonIDE");
-      this.config = {
+
+      const newConfig = {
         panelLocation: config.get<PanelLocation>("panelLocation")!,
         showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
       };
+
+      if (newConfig.panelLocation !== this.config.panelLocation) {
+        getTelemetryReporter().sendTelemetryEvent(
+          "workspace-configuration:panel-location-changed",
+          { newPanelLocation: newConfig.panelLocation }
+        );
+      }
+
+      if (newConfig.showDeviceFrame !== this.config.showDeviceFrame) {
+        getTelemetryReporter().sendTelemetryEvent(
+          "workspace-configuration:panel-location-changed",
+          { showDeviceFrame: String(newConfig.showDeviceFrame) }
+        );
+      }
+
+      this.config = newConfig;
       this.eventEmitter.emit("configChange", this.config);
     });
   }

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -41,7 +41,7 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
 
       if (newConfig.showDeviceFrame !== this.config.showDeviceFrame) {
         getTelemetryReporter().sendTelemetryEvent(
-          "workspace-configuration:panel-location-changed",
+          "workspace-configuration:show-device-frame-changed",
           { showDeviceFrame: String(newConfig.showDeviceFrame) }
         );
       }


### PR DESCRIPTION
This PR adds more detailed telemetry to the Radon IDE project, we add the following list of events: 

-  `build:expo-go-requested`
-  `build:eas-build-requested`
-  `build:custom-build-requested`
-  `build:pod-install-failed`
-  `device-manager:create-device`
-  `device-manager:remove-device`
-  `workspace-configuration:panel-location-changed`
-  `workspace-configuration:show-device-frame-changed`
-  `recording:start-recording`
-  `recording:capture-and-stop-recording`
-  `replay:capture-replay`
-  `url-bar:reload-requested`
-  `url-bar:go-home`
-  `url-bar:restart-requested`
-  `device-settings:update-device-settings`


### How Has This Been Tested: 

run all the tracked functionality and check if it appears in the data base


