### PR TITLE
Add support for react native 77 

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -98,7 +98,7 @@ function transformWrapper({ filename, src, ...rest }) {
     // is experimental as it has some performance implications and may be removed in future versions.
     //
     const { version } = requireFromAppDir("react-native/package.json");
-    if (version.startsWith("0.74") || version.startsWith("0.75") || version.startsWith("0.76")) {
+    if (version.startsWith("0.74") || version.startsWith("0.75") || version.startsWith("0.76") || version.startsWith("0.77")) {
       const rendererFileName = filename.split(path.sep).pop();
       src = `module.exports = require("__RNIDE_lib__/rn-renderer/${rendererFileName}");`;
     }

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -345,9 +345,7 @@ export class Metro implements Disposable {
   }
 
   private filterNewDebuggerPages(listJson: CDPTargetDescription[]) {
-    return listJson.filter(
-      (page) => page.reactNative && page.title.startsWith("React Native Bridge")
-    );
+    return listJson.filter((page) => page.reactNative);
   }
 
   private async isActiveExpoGoAppRuntime(webSocketDebuggerUrl: string) {


### PR DESCRIPTION
This PR fixes some issues with how radon IDE interacted with applications using react native 77

1) we add one more version for which we change renderer in `babel_transformer` 
2) we remove unnecessary condition page.title.startsWith("React Native Bridge") from filtering a new debugger websocket URLs. 

### How Has This Been Tested: 

- run a RN 77 application and check if it works correctly 
- run an expo 52 (RN 76) application and check that the changes did not break anything
- run RN 73 application 



