### PR TITLE
Remove background color

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -140,7 +140,6 @@
 body[data-vscode-theme-kind="vscode-light"],
 body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-active-item: var(--blue-dark-100);
-  --swm-preview-background: var(--white);
 
   --swm-default-text: var(--navy-light-100);
   --swm-marked-text: var(--yellow-dark-120);
@@ -302,7 +301,6 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
 body[data-vscode-theme-kind="vscode-dark"],
 body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-active-item: var(--blue-dark-100);
-  --swm-preview-background: var(--background-dark-100);
 
   --swm-default-text: var(--off-white);
   --swm-marked-text: var(--yellow-dark-100);


### PR DESCRIPTION
Hello IDE team 👋 

This PR simply removes the background color of the IDE panel and uses the default one provided by the selected theme. This approach feels more natural - in my opinion. Here is a comparison video:

**Before**
<video src="https://github.com/user-attachments/assets/5970f39a-995b-4c78-852b-b6b36325085c" />

**After**
<video src="https://github.com/user-attachments/assets/7382a08d-8f93-4bcc-a45d-d5bb5b3ce666" />

This is just a suggestion. Feel free to close this PR if you don't like the changes - no hard feelings 😄
