### PR TITLE
Fix UrlSelect trigger value reset for non expo router projects

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -3,6 +3,7 @@ import { useProject } from "../providers/ProjectProvider";
 import UrlSelect, { UrlItem } from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";
 import IconButton from "./shared/IconButton";
+import { useDependencies } from "../providers/DependenciesProvider";
 
 function ReloadButton({ disabled }: { disabled: boolean }) {
   const { project } = useProject();
@@ -29,6 +30,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
 
 function UrlBar({ disabled }: { disabled?: boolean }) {
   const { project } = useProject();
+  const { dependencies } = useDependencies();
 
   const MAX_URL_HISTORY_SIZE = 20;
   const MAX_RECENT_URL_SIZE = 5;
@@ -79,6 +81,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
     return [...urlList].sort((a, b) => a.name.localeCompare(b.name));
   }, [urlList]);
 
+  const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
+
   return (
     <>
       <IconButton
@@ -86,7 +90,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={disabled || urlHistory.length < 2}
+        disabled={disabled || !isExpoRouterProject || urlHistory.length < 2}
         onClick={() => {
           setUrlHistory((prevUrlHistory) => {
             const newUrlHistory = prevUrlHistory.slice(1);
@@ -116,7 +120,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         recentItems={recentUrlList}
         items={sortedUrlList}
         value={urlList[0]?.id}
-        disabled={disabled || urlList.length < 2}
+        disabled={disabled || urlList.length < (isExpoRouterProject ? 2 : 1)}
       />
     </>
   );

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -39,6 +39,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const [urlList, setUrlList] = useState<UrlItem[]>([]);
   const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
   const [urlHistory, setUrlHistory] = useState<string[]>([]);
+  const [urlSelectKey, setUrlSelectKey] = useState<number>(0);
+  const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id);
 
   useEffect(() => {
     function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {
@@ -78,7 +80,9 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   }, [recentUrlList, urlHistory, backNavigationPath]);
 
   const sortedUrlList = useMemo(() => {
-    return [...urlList].sort((a, b) => a.name.localeCompare(b.name));
+    const sorted = [...urlList].sort((a, b) => a.name.localeCompare(b.name));
+    setUrlSelectValue(urlList[0]?.id);
+    return sorted;
   }, [urlList]);
 
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
@@ -105,6 +109,12 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
       <IconButton
         onClick={() => {
           project.goHome("/{}");
+          if (!isExpoRouterProject) {
+            // this sets the trigger value of UrlSelect to a placeholder,
+            // forcing the Radix Select component to fully re-render
+            setUrlSelectKey(urlSelectKey + 1);
+            setUrlSelectValue("");
+          }
         }}
         tooltip={{
           label: "Go to main screen",
@@ -119,7 +129,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         }}
         recentItems={recentUrlList}
         items={sortedUrlList}
-        value={urlList[0]?.id}
+        key={urlSelectKey}
+        value={urlSelectValue}
         disabled={disabled || urlList.length < (isExpoRouterProject ? 2 : 1)}
       />
     </>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -39,7 +39,6 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const [urlList, setUrlList] = useState<UrlItem[]>([]);
   const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
   const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectKey, setUrlSelectKey] = useState<number>(0);
   const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id);
 
   useEffect(() => {
@@ -112,8 +111,6 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           project.goHome("/{}");
           if (!isExpoRouterProject) {
             // this sets the trigger value of UrlSelect to a placeholder,
-            // forcing the Radix Select component to fully re-render
-            setUrlSelectKey(urlSelectKey + 1);
             setUrlSelectValue("");
           }
         }}
@@ -130,7 +127,6 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         }}
         recentItems={recentUrlList}
         items={sortedUrlList}
-        key={urlSelectKey}
         value={urlSelectValue}
         disabled={disabledAlsoWhenStarting || urlList.length < (isExpoRouterProject ? 2 : 1)}
       />

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -110,8 +110,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         onClick={() => {
           project.goHome("/{}");
           if (!isExpoRouterProject) {
-            // this sets the trigger value of UrlSelect to a placeholder,
-            setUrlSelectValue("");
+            setUrlSelectValue(""); // sets UrlSelect trigger to a placeholder
           }
         }}
         tooltip={{

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -15,6 +15,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.Sel
 );
 
 interface UrlSelectProps {
+  key: number;
   value: string;
   onValueChange: (newValue: string) => void;
   recentItems: UrlItem[];
@@ -22,7 +23,7 @@ interface UrlSelectProps {
   disabled?: boolean;
 }
 
-function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSelectProps) {
+function UrlSelect({ onValueChange, recentItems, items, key, value, disabled }: UrlSelectProps) {
   // We use two lists for URL selection: one with recently used URLs and another
   // with all available URLs. Since recentItems is a subset of items, each recentItems's
   // value is prefixed to differentiate their origins when presented in the Select
@@ -35,7 +36,7 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
   };
 
   return (
-    <Select.Root onValueChange={handleValueChange} value={value} disabled={disabled}>
+    <Select.Root onValueChange={handleValueChange} key={key} value={value} disabled={disabled}>
       <Select.Trigger className="url-select-trigger">
         <Select.Value placeholder="/" aria-label={value} />
       </Select.Trigger>

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -15,7 +15,6 @@ const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.Sel
 );
 
 interface UrlSelectProps {
-  key: number;
   value: string;
   onValueChange: (newValue: string) => void;
   recentItems: UrlItem[];
@@ -23,7 +22,7 @@ interface UrlSelectProps {
   disabled?: boolean;
 }
 
-function UrlSelect({ onValueChange, recentItems, items, key, value, disabled }: UrlSelectProps) {
+function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSelectProps) {
   // We use two lists for URL selection: one with recently used URLs and another
   // with all available URLs. Since recentItems is a subset of items, each recentItems's
   // value is prefixed to differentiate their origins when presented in the Select
@@ -36,7 +35,7 @@ function UrlSelect({ onValueChange, recentItems, items, key, value, disabled }: 
   };
 
   return (
-    <Select.Root onValueChange={handleValueChange} key={key} value={value} disabled={disabled}>
+    <Select.Root onValueChange={handleValueChange} value={value} disabled={disabled}>
       <Select.Trigger className="url-select-trigger">
         <Select.Value placeholder="/" aria-label={value} />
       </Select.Trigger>


### PR DESCRIPTION
This PR changes the UrlBar behaviour in projects not using Expo Router navigation.
When the user intends to close the preview by pressing the goHome button (or reload), the UrlSelect's trigger value needs to be reset to a placeholder ("/"). 

Additionally, this update disables the `goBack` button for projects that do not use Expo Router.

### How Has This Been Tested: 
- Tested on expo-router and react-native-76 apps.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/3fa5b50a-c5c3-4f70-b184-f7a1853f101b" />|<video src="https://github.com/user-attachments/assets/051577d3-5f43-454c-92b8-eefdd1d37426" />|
