### PR TITLE
Fix home button when closing preview on fabric

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -244,6 +244,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
         initialProps: {
           __RNIDE_onLayout: closePromiseResolve,
         },
+        fabric,
       });
     } else {
       closePromiseResolve();

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -250,7 +250,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
       closePromiseResolve();
     }
     return closePreviewPromise;
-  }, [rootTag]);
+  }, [rootTag, fabric]);
 
   const showStorybookStory = useCallback(
     async (componentTitle, storyName) => {


### PR DESCRIPTION
This PR fixes a bug that occur when using "home" button to close preview on new architecture.

In #712 we fixed previews for new architecture. With the new architecture, it is required for AppRegistry to get `fabric` attribute specified when rendering the app. We began to use it for new architecture when launching previews. However, the "home" button runs a different code paths when use from within the app and when triggered while in preview mode. When in "preview" mode, the home button also uses AppRegistry to launch the main app bundle back again. In #712 we missed that and only been applying fabric prop when launchin preview but not when launching the main bundle. This PR fixes this by adding fabric prop to AppRegistry calls that are triggered when using home button in preview mode.

Fixes #883

### How Has This Been Tested: 
1. Open app that uses new arch
2. Launch preview
3. Use home button. Before it'd get stuck on the preview and the error as described in #883 would appear. Now it properly opens the main app again.