### PR TITLE
Provide visible feedback when attempting to start preview for non loaaded source file

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -122,7 +122,7 @@ export async function activate(context: ExtensionContext) {
   async function showInlinePreview(fileName: string, lineNumber: number) {
     commands.executeCommand("RNIDE.openPanel");
     if (Project.currentProject) {
-      Project.currentProject.startPreview(`preview:/${fileName}:${lineNumber}`);
+      Project.currentProject.openComponentPreview(fileName, lineNumber);
     } else {
       window.showWarningMessage("Wait for app to load before lunching preview. ", "Dismiss");
     }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -311,8 +311,21 @@ export class DeviceSession implements Disposable {
     await this.metro.openDevMenu();
   }
 
-  public startPreview(previewId: string) {
+  public async startPreview(previewId: string) {
     this.devtools.send("RNIDE_openPreview", { previewId });
+    return new Promise<void>((res, rej) => {
+      let listener = (event: string, payload: any) => {
+        if (event === "RNIDE_openPreviewResult" && payload.previewId === previewId) {
+          this.devtools?.removeListener(listener);
+          if (payload.error) {
+            rej(payload.error);
+          } else {
+            res();
+          }
+        }
+      };
+      this.devtools.addListener(listener);
+    });
   }
 
   public async changeDeviceSettings(settings: DeviceSettings): Promise<boolean> {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -539,8 +539,15 @@ export class Project
     return !!(await getLicenseToken());
   }
 
-  public startPreview(appKey: string) {
-    this.deviceSession?.startPreview(appKey);
+  public async openComponentPreview(fileName: string, lineNumber1Based: number) {
+    try {
+      await this.deviceSession?.startPreview(`preview:/${fileName}:${lineNumber1Based}`);
+    } catch (e) {
+      const relativeFileName = workspace.asRelativePath(fileName, false);
+      const message = `Failed to open component preview. Currently previews only work for files loaded by the main application bundle. Make sure that ${relativeFileName} is loaded by your application code.`;
+      Logger.error(message);
+      window.showErrorMessage(message, "Dismiss");
+    }
   }
 
   public async showStorybookStory(componentTitle: string, storyName: string) {


### PR DESCRIPTION
Currently Radon IDE preview is limited to files that are loaded by the main application bundle. This is because the requested preview component need to register in runtime. While we eventually want to support such a case (have an issue open here #31), currently there's no visible way for the user to tell when they attempt to open not-loaded preview.

This PR adds a way to communicate back an error due to preview not being loaded for specific key and displays an error message in the IDE to indicate the source of the issue.

### How Has This Been Tested: 
1. Open example app with preview installed
2. Make sure the existing prviews work as expected
3. Add new file that isn't loaded by any of the existing files (not a route file either). And add preview there.
4. Use "open preview" in that new file to see the new error message pop up.


