### PR TITLE
Reduce spaces between icons on top and bottom bars in the IDE panel UI

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSelect.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.css
@@ -11,7 +11,7 @@
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
-  height: 36px;
+  height: var(--swm-button-size);
   border: 0px solid transparent;
   border-radius: 18px;
   gap: 5px;

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -64,7 +64,9 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.Content className="dropdown-menu-content device-settings-content">
+        <DropdownMenu.Content
+          className="dropdown-menu-content device-settings-content"
+          onCloseAutoFocus={(e) => e.preventDefault()}>
           <h4 className="device-settings-heading">Device Settings</h4>
           <form>
             <Label>Device appearance</Label>

--- a/packages/vscode-extension/src/webview/components/IconButtonWithOptions.css
+++ b/packages/vscode-extension/src/webview/components/IconButtonWithOptions.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  font-size: 12px !important;
+  font-size: 10px !important;
   opacity: 1;
   transition: opacity 200ms ease-out;
 }

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.css
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.css
@@ -96,7 +96,7 @@
   line-height: 1;
   overflow: hidden;
   cursor: pointer;
-  height: 36px;
+  height: var(--swm-button-size);
   border: 0px solid transparent;
   border-radius: 18px;
   gap: 5px;

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -34,7 +34,9 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
-        <DropdownMenu.Content className="dropdown-menu-content">
+        <DropdownMenu.Content
+          className="dropdown-menu-content"
+          onCloseAutoFocus={(e) => e.preventDefault()}>
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -12,7 +12,7 @@
   line-height: 1;
   overflow: hidden;
   cursor: pointer;
-  height: 36px;
+  height: var(--swm-button-size);
   border: 0px solid transparent;
   border-radius: 18px;
   gap: 5px;

--- a/packages/vscode-extension/src/webview/components/ZoomControls.css
+++ b/packages/vscode-extension/src/webview/components/ZoomControls.css
@@ -31,7 +31,7 @@
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
-  height: 36px;
+  height: var(--swm-button-size);
   border: 0px solid transparent;
   gap: 5px;
   background-color: var(--swm-zoom-controls-background);

--- a/packages/vscode-extension/src/webview/components/shared/Alert.css
+++ b/packages/vscode-extension/src/webview/components/shared/Alert.css
@@ -1,6 +1,6 @@
 .alert-dialog-content {
   background-color: var(--swm-popover-background);
-  border-radius: 36px;
+  border-radius: var(--swm-button-size);
   display: grid;
   grid-template-columns: 50px 1fr min-content;
   gap: 4px;

--- a/packages/vscode-extension/src/webview/components/shared/Button.css
+++ b/packages/vscode-extension/src/webview/components/shared/Button.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  height: 36px;
+  height: var(--swm-button-size);
   padding: 0 12px;
   background: none;
   border: 0px solid transparent;

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -5,11 +5,11 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  height: 36px;
-  width: 36px;
+  height: var(--swm-button-size);
+  width: var(--swm-button-size);
   background: none;
   border: 0px solid transparent;
-  border-radius: 36px;
+  border-radius: var(--swm-button-size);
   color: var(--swm-button);
   transition: all 200ms 0ms ease-in-out;
   flex-shrink: 0;
@@ -66,7 +66,7 @@
   color: var(--swm-button-counter);
   background-color: var(--swm-button-counter-background);
   padding: 2px 4px;
-  font-size: 11px;
+  font-size: 10px;
   position: absolute;
   top: 20%;
   left: 20px;
@@ -77,6 +77,5 @@
 
 .icon-button-counter.visible {
   top: 20%;
-  left: 25px;
   opacity: 1;
 }

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -347,6 +347,7 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
 
   /* Button */
   --swm-button: var(--swm-default-text);
+  --swm-button-size: 30px;
   --swm-button-disabled: var(--swm-disabled-text);
   --swm-button-hover: var(--background-dark-80);
 

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -3,17 +3,13 @@
   display: flex;
   align-items: center;
   width: 100%;
-  margin: 10px;
+  margin: 8px;
   gap: 4px;
 }
 
 .icons-rewind:before {
   width: 0px;
   margin: -4px;
-}
-
-.button-group-top {
-  margin-bottom: 8px;
 }
 
 .feedback-button {


### PR DESCRIPTION
This PR reduces the amount of margins between buttons in order to make it easier to fit more UI controls while also giving the device preview as much space as possible in the panel.

We've been struggling with fitting all the buttons that we needed in the panel. Specifically after adding screenshots and tools buttons to the top bar. While we may want to eventually group some of the functions (i.e. ones responsible for recording/screenshots) as proposed in #819 it still seems like we're not using our space efficiently enough.

For example, the size of the icons is the same as with all the editor button bars that VSCode renders, while we only add a significantly big paddings around these. The buttons in VSCode are functional and for users who need them to be bigger, can adjust that by changing the font size in VSCode which also impacts the IDE panel UI. Despite the amount of spaces in between the buttons, this change also shaves off some padding above and below the device preview making it bigger when the panel size is limited.

Beside the button size adjustment, we're also changing font size for down-arrow that displays under the "reload" button, otherwise it wouldn't fit the new height. We also change the font size and offset of the badge that gets displayed along with the logs button also to accommodate for the button size change. Finally, this PR also adds `onCloseAutoFocus` to the dropdown menus (panel and device settings) to prevent the buttons from going into a focused mode when the menu is closed.

Before:
<img width="477" alt="image" src="https://github.com/user-attachments/assets/4207f3f5-7678-4bc6-98d7-50272de6f559" />

After:
<img width="486" alt="image" src="https://github.com/user-attachments/assets/3c59eb30-c87b-45cc-9073-040a4f68861f" />


### How Has This Been Tested: 
1. Run IDE on any project
2. Click thought the interface to make sure there are no issues cause by the size changes (i.e. no cropped or overlapping items)
3. Specifically test dialogs, arrow next to reload button and make sure the logs badge goes over to two digit numbers.


