### PR TITLE
Fix gap in split lines of dimensions in InspectDataMenu

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.css
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.css
@@ -22,6 +22,8 @@
   line-height: 25px;
   padding-left: 5px;
   color: var(--swm-secondary-text);
+  line-height: 16px;
+  margin-bottom: 4px;
 }
 
 .inspect-data-menu-item {

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -65,7 +65,7 @@ export function InspectDataMenu({
       const topComponentHeight = parseFloat((frame.height * device.screenHeight).toFixed(2));
 
       if (topComponentWidth && topComponentHeight) {
-        return `Dimensions: ${topComponentWidth}×${topComponentHeight}`;
+        return `Dimensions: ${topComponentWidth}\u00A0×\u00A0${topComponentHeight}`;
       }
     }
     return "Dimensions: -";

--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -65,7 +65,7 @@ export function InspectDataMenu({
       const topComponentHeight = parseFloat((frame.height * device.screenHeight).toFixed(2));
 
       if (topComponentWidth && topComponentHeight) {
-        return `Dimensions: ${topComponentWidth} × ${topComponentHeight}`;
+        return `Dimensions: ${topComponentWidth}×${topComponentHeight}`;
       }
     }
     return "Dimensions: -";


### PR DESCRIPTION
This PR addresses a gap in the split lines of dimensions in the InspectDataMenu by removing space characters from the displayDimensionsText and reducing the line-height.

Fixes #861 

### Screenshots:
|Before|After|
|-|-|
|<img width="262" alt="Screenshot 2025-01-10 at 10 39 01" src="https://github.com/user-attachments/assets/5654ba28-6322-4056-9c08-36459bbcca57" />|<img width="262" alt="Screenshot 2025-01-10 at 10 38 44" src="https://github.com/user-attachments/assets/f413ddad-b3e9-4e2e-8914-6e6196951ab5" />|

