### PR TITLE
Add support for Bun's text-based lockfile in packageManager.ts

### DIFF
--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -79,6 +79,7 @@ export async function resolvePackageManager(): Promise<PackageManagerInfo | unde
         "yarn.lock": "yarn",
         "package-lock.json": "npm",
         "pnpm-lock.yaml": "pnpm",
+        "bun.lock": "bun",
         "bun.lockb": "bun",
       } as const)
     );


### PR DESCRIPTION
In Bun v1.1.39, a new text-based lockfile  (`bun.lock`) was introduced: https://bun.sh/blog/bun-lock-text-lockfile

Without this change, when the text-based lock file is used, Radon would pick up npm as the package manager. It would then generate a `package-lock.json`.

A workaround is to keep the old `bun.lockb` file even with the new text-based lockfile.

### How Has This Been Tested: 

1. On a bun project, run `bun install --save-text-lockfile`.
2. Remove the `bun.lockb` file.
3. `Clean rebuild` on Radon.

Without this change, a `package-lock.json` file will be generated.

Followed the instructions [here](https://ide.swmansion.com/docs/guides/development) and verified that the `package-lock.json` is not being populated.