### PR TITLE
Fix light theme styles after #893

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -134,6 +134,9 @@
 
   /* Open Deep Link */
   --deep-link-history-query-match-color: #c19420;
+
+  /* Size constants */
+  --swm-button-size: 30px;
 }
 
 /* Light theme */
@@ -347,7 +350,6 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
 
   /* Button */
   --swm-button: var(--swm-default-text);
-  --swm-button-size: 30px;
   --swm-button-disabled: var(--swm-disabled-text);
   --swm-button-hover: var(--background-dark-80);
 


### PR DESCRIPTION
In #893 we updated styles to increase available space for icon buttons and for simulator.

Apparently #893 introduced an error, because the button size constant was only being set for dark theme and not for the light one.

This PR fixes this error by moving the definition of that size variable to the root object instead of keeping it to be theme-specific.

Before:
<img width="548" alt="image" src="https://github.com/user-attachments/assets/a764a0c9-d1ed-497d-b618-09c77b896e04" />

After:
<img width="557" alt="image" src="https://github.com/user-attachments/assets/d401f8dd-3200-4baf-87f7-a4ccbdf5f7bf" />


### How Has This Been Tested: 
1. Open IDE in light mode.
2. Check if it looks good in dark mode too

