### PR TITLE
Fix failing to obtain $PATH 

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -23,7 +23,9 @@ async function getPathEnv(appRoot: string) {
     "-c",
     `cd "${appRoot}" && echo "${RNIDE_PATH_DELIMITER}$PATH${RNIDE_PATH_DELIMITER}"`,
   ]);
-  return stdout.split(RNIDE_PATH_DELIMITER)[1].trim();
+  const path = stdout.split(RNIDE_PATH_DELIMITER)[1].trim();
+  Logger.debug("Obtained PATH environment variable:", path);
+  return path;
 }
 
 let pathEnv: string | undefined;

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -18,7 +18,11 @@ async function getPathEnv(appRoot: string) {
 
   // Fish, bash, and zsh all support -i and -c flags.
   const shellPath = process.env.SHELL ?? "/bin/zsh";
-  const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH${PRE_PATH_TOKEN}"`]);
+  const { stdout: path } = await execa(shellPath, [
+    "-i",
+    "-c",
+    `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH${PRE_PATH_TOKEN}"`,
+  ]);
   return path.split(PRE_PATH_TOKEN)[1].trim();
 }
 

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -5,7 +5,6 @@ import { Platform } from "./platform";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
-
 async function getPathEnv(appRoot: string) {
   // We run an interactive shell session to make sure that tool managers (nvm,
   // asdf, mise, etc.) are loaded and PATH is set correctly. Mise in

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -5,6 +5,8 @@ import { Platform } from "./platform";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
+const PRE_PATH_TOKEN = "{RNIDE_PRE_PATH}";
+
 async function getPathEnv(appRoot: string) {
   // We run an interactive shell session to make sure that tool managers (nvm,
   // asdf, mise, etc.) are loaded and PATH is set correctly. Mise in
@@ -16,8 +18,8 @@ async function getPathEnv(appRoot: string) {
 
   // Fish, bash, and zsh all support -i and -c flags.
   const shellPath = process.env.SHELL ?? "/bin/zsh";
-  const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "$PATH"`]);
-  return path.trim();
+  const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH"`]);
+  return path.split(PRE_PATH_TOKEN)[1].trim();
 }
 
 let pathEnv: string | undefined;

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -18,7 +18,7 @@ async function getPathEnv(appRoot: string) {
 
   // Fish, bash, and zsh all support -i and -c flags.
   const shellPath = process.env.SHELL ?? "/bin/zsh";
-  const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH"`]);
+  const { stdout: path } = await execa(shellPath, ["-i", "-c", `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH${PRE_PATH_TOKEN}"`]);
   return path.split(PRE_PATH_TOKEN)[1].trim();
 }
 

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -5,7 +5,6 @@ import { Platform } from "./platform";
 
 export type ChildProcess = ExecaChildProcess<string>;
 
-const PRE_PATH_TOKEN = "{RNIDE_PRE_PATH}";
 
 async function getPathEnv(appRoot: string) {
   // We run an interactive shell session to make sure that tool managers (nvm,
@@ -17,13 +16,15 @@ async function getPathEnv(appRoot: string) {
   // versions based on directory in most managers).
 
   // Fish, bash, and zsh all support -i and -c flags.
+  const RNIDE_PATH_DELIMITER = "{RNIDE_PATH_DELIMITER}";
+
   const shellPath = process.env.SHELL ?? "/bin/zsh";
-  const { stdout: path } = await execa(shellPath, [
+  const { stdout } = await execa(shellPath, [
     "-i",
     "-c",
-    `cd "${appRoot}" && echo "${PRE_PATH_TOKEN}$PATH${PRE_PATH_TOKEN}"`,
+    `cd "${appRoot}" && echo "${RNIDE_PATH_DELIMITER}$PATH${RNIDE_PATH_DELIMITER}"`,
   ]);
-  return path.split(PRE_PATH_TOKEN)[1].trim();
+  return stdout.split(RNIDE_PATH_DELIMITER)[1].trim();
 }
 
 let pathEnv: string | undefined;


### PR DESCRIPTION
Fixes #896 

This PR solves the problem of IDE not being able to obtain $PATH when something is printed at the launch of the shell, by adding unique tokens before and after  `$PATH` value. This way we make sure only $PATH is extracted. 

### How Has This Been Tested: 

- add `echo "SOMETHING"` to your `./zshrc` 
- IDE should be able to obtain $PATH anyway 


