### PR TITLE
Fix preview crash after #878

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -383,7 +383,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
         });
       };
       return () => {
-        devtoolsPluginsChanged = undefined;
+        expoDevPluginsChanged = undefined;
       };
     }
   }, [!!devtoolsAgent && hasLayout]);


### PR DESCRIPTION
In #878 we introduced a regression due to some final renaming that wasn't caught. The `devtoolsPluginsChanged` variable got renamed to `expoDevPluginsChanged` but not updated in all the places. This resulted in preview functionality triggering the code with that bug and crashing as a result

### How Has This Been Tested: 
1. Open any project with preview installed
2. Use preview functionality and make sure it doesn't crash


