### PR TITLE
Fix new debugger detection after #864

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -345,7 +345,12 @@ export class Metro implements Disposable {
   }
 
   private filterNewDebuggerPages(listJson: CDPTargetDescription[]) {
-    return listJson.filter((page) => page.reactNative);
+    return listJson.filter(
+      (page) =>
+        page.reactNative &&
+        (page.title.startsWith("React Native Bridge") ||
+          page.description.endsWith("[C++ connection]"))
+    );
   }
 
   private async isActiveExpoGoAppRuntime(webSocketDebuggerUrl: string) {


### PR DESCRIPTION
In #864 where we tried to address the debugger listing changes in RN 77 we accidently broke debugger connection on older versions of React Native (in particular expo-router example app).

The reason is that we wrongly assumed that the existence of `reactNative` field in the debugger listing is exclusive to the new debugger entries while it still appears with old version of the debugger and on older versions of React Native. As a consequence, older apps (and expo-router in particular) may select a wrong runtime to connect to (which in case of expo-router was the reanimated runtime).

In this PR we partially revert changes from #864 responsible for filtering new debugger entries from debug endpoints list. Instead, for RN 77 specifically we rely on a suffix "[C++ connection]" that has been added to description field: https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.cpp#L167

We likely want to revisit this solution going forward, but for now this PR will unblock the release.

### How Has This Been Tested: 
1. Test debugger on RN 77 example 
2. Test debugger on expo-router example