### PR TITLE
Prevent creating multiple devices

### DIFF
--- a/packages/vscode-extension/src/webview/views/DevicesNotFoundView.tsx
+++ b/packages/vscode-extension/src/webview/views/DevicesNotFoundView.tsx
@@ -64,7 +64,6 @@ function findNewestIosRuntime(runtimes: IOSRuntimeInfo[]) {
 
 function DevicesNotFoundView() {
   const { openModal, closeModal } = useModal();
-  const [isCreating, setIsCreating] = useState(false);
   const { iOSRuntimes, androidImages, deviceManager } = useDevices();
   const [isIOSCreating, withIosCreating] = useLoadingState();
   const [isAndroidCreating, withAndroidCreating] = useLoadingState();


### PR DESCRIPTION
This PR reuses the loading state to disable the button while creating a device. This prevents accidentally creating multiple  same devices. 

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/82af04bb-0066-4635-8c0a-fb92e15130ce" />|<video src="https://github.com/user-attachments/assets/28dfe6d9-7eff-4d8c-b80e-bf614c76ac8d" />| 

### How Has This Been Tested: 

- Remove all devices
- Quickly press multiple times "Add Android" or "Add iPhone" button
- Only one device should be created


