### PR TITLE
Fix preinstall command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -525,7 +525,7 @@
     "format": "prettier --write --list-different src",
     "build:tests": "tsc --project tsconfig.test.json",
     "test": "npm run build:extension && npm run build:webview && npm run build:tests && vscode-test",
-    "preinstall": "cd ../vscode-js-debug && git submodule update --init && npm install && npm exec tsc"
+    "preinstall": "cd ../vscode-js-debug && git submodule update --init ./ && npm install && npm exec tsc"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",


### PR DESCRIPTION
This solves an issue when an external contributor tries to build from a source. This narrows down `git submodule update` to just `vscode-js-debug`

## How to test

- run `npm install` in `packages/vscode-extension`