### PR TITLE
Fix debugger after multiple reloads

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -115,13 +115,13 @@ export class DeviceSession implements Disposable {
     throw new Error("Not implemented " + type);
   }
 
-  private lastLaunchCancelToken: CancelToken | undefined;
+  private launchAppCancelToken: CancelToken | undefined;
 
   private async launchApp(previewReadyCallback?: PreviewReadyCallback) {
-    this.lastLaunchCancelToken && this.lastLaunchCancelToken.cancel();
+    this.launchAppCancelToken && this.launchAppCancelToken.cancel();
 
     const launchCancelToken = new CancelToken();
-    this.lastLaunchCancelToken = launchCancelToken;
+    this.launchAppCancelToken = launchCancelToken;
 
     const launchRequestTime = Date.now();
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -124,7 +124,6 @@ export class DeviceSession implements Disposable {
     this.lastLaunchCancelToken = launchCancelToken;
 
     const launchRequestTime = Date.now();
-    let previewURL: string | undefined;
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
       platform: this.device.platform,
     });
@@ -146,6 +145,7 @@ export class DeviceSession implements Disposable {
     Logger.debug("Will wait for app ready and for preview");
     this.eventDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
 
+    let previewURL: string | undefined;
     if (shouldWaitForAppLaunch) {
       const reportWaitingStuck = setTimeout(() => {
         Logger.info(

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -416,8 +416,8 @@ export class Project
 
       // we first check if the device session hasn't changed in the meantime
       if (deviceSession === this.deviceSession) {
-        const restartSuccess = await this.deviceSession?.perform("restartProcess");
-        if (restartSuccess) {
+        const restartSucceeded = await this.deviceSession?.perform("restartProcess");
+        if (restartSucceeded) {
           this.updateProjectStateForDevice(deviceInfo, {
             status: "running",
           });

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -416,10 +416,12 @@ export class Project
 
       // we first check if the device session hasn't changed in the meantime
       if (deviceSession === this.deviceSession) {
-        await this.deviceSession?.perform("restartProcess");
-        this.updateProjectStateForDevice(deviceInfo, {
-          status: "running",
-        });
+        const restartSuccess = await this.deviceSession?.perform("restartProcess");
+        if (restartSuccess) {
+          this.updateProjectStateForDevice(deviceInfo, {
+            status: "running",
+          });
+        }
       }
     } catch (e) {
       // finally in case of any errors, the last resort is performing project


### PR DESCRIPTION
This PR adreses a problem with multiple debugSessions being held by vscode, after performing multiple reloads in quick succession. This was caused by `debug.stopDebugging(this.vscSession)` not removing the previous session if called in to rapid succession. We trigger the `stopDebugging` method is by dispossessing `debugSession`. Because we dispose of the old `debugSession` every time we create a new one, attempt to create multiple instances of debug session in a row leads to the problem. 

In our current flow multiple instances of `debugSession` might be created after multiple restarts happening before, the previous one finishes. To avoid that we introduce a cancel token to `launchApp` method (which is triggered by the restart)  to exclude parallel execution.

Fixes #860

### How Has This Been Tested: 

Performed reproduction from #860:
- force bundle error 
- reload the app multiple times 
- fix bundle error 
- the debugger should work properly after this fix



