### PR TITLE
Close drop downs on blur 

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -21,6 +21,7 @@ import { KeybindingInfo } from "./shared/KeybindingInfo";
 import { DeviceLocalizationView } from "../views/DeviceLocalizationView";
 import { OpenDeepLinkView } from "../views/OpenDeepLinkView";
 import ReplayIcon from "./icons/ReplayIcon";
+import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
 const contentSizes = [
   "xsmall",
@@ -58,7 +59,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
     projectState.selectedDevice?.platform === "iOS" ? resetOptionsIOS : resetOptionsAndroid;
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenuRoot>
       <DropdownMenu.Trigger asChild disabled={disabled}>
         {children}
       </DropdownMenu.Trigger>
@@ -207,7 +208,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
           <DropdownMenu.Arrow className="dropdown-menu-arrow" />
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+    </DropdownMenuRoot>
   );
 }
 

--- a/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
+++ b/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
@@ -1,0 +1,26 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { PropsWithChildren, useEffect, useState } from "react";
+
+export function DropdownMenuRoot({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const blurListener = () => {
+      setOpen(false);
+    };
+    window.addEventListener("blur", blurListener);
+    return () => {
+      window.removeEventListener("blur", blurListener);
+    };
+  }, []);
+
+  return (
+    <DropdownMenu.Root
+      open={open}
+      onOpenChange={() => {
+        setOpen(!open);
+      }}>
+      {children}
+    </DropdownMenu.Root>
+  );
+}

--- a/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
+++ b/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
@@ -15,9 +15,7 @@ export function DropdownMenuRoot({ children }: PropsWithChildren) {
   }, []);
 
   return (
-    <DropdownMenu.Root
-      open={open}
-      onOpenChange={setOpen}>
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
       {children}
     </DropdownMenu.Root>
   );

--- a/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
+++ b/packages/vscode-extension/src/webview/components/DropdownMenuRoot.tsx
@@ -17,9 +17,7 @@ export function DropdownMenuRoot({ children }: PropsWithChildren) {
   return (
     <DropdownMenu.Root
       open={open}
-      onOpenChange={() => {
-        setOpen(!open);
-      }}>
+      onOpenChange={setOpen}>
       {children}
     </DropdownMenu.Root>
   );

--- a/packages/vscode-extension/src/webview/components/IconButtonWithOptions.tsx
+++ b/packages/vscode-extension/src/webview/components/IconButtonWithOptions.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import classNames from "classnames";
 import IconButton, { IconButtonProps } from "./shared/IconButton";
 import "./IconButtonWithOptions.css";
+import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
 interface IconButtonWithOptions extends IconButtonProps {
   options: Record<string, () => void>;
@@ -27,7 +28,7 @@ export const IconButtonWithOptions = forwardRef<HTMLButtonElement, IconButtonWit
         <IconButton ref={ref} disabled={disabled} {...iconButtonProps}>
           {children}
         </IconButton>
-        <DropdownMenu.Root>
+        <DropdownMenuRoot>
           <DropdownMenu.Trigger asChild disabled={disabled}>
             {
               <div
@@ -47,7 +48,7 @@ export const IconButtonWithOptions = forwardRef<HTMLButtonElement, IconButtonWit
               ))}
             </DropdownMenu.Content>
           </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+        </DropdownMenuRoot>
       </div>
     );
   }

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import "./shared/Dropdown.css";
 import { useModal } from "../providers/ModalProvider";
@@ -13,6 +13,7 @@ import "./shared/SwitchGroup.css";
 import LaunchConfigurationView from "../views/LaunchConfigurationView";
 import { SendFeedbackItem } from "./SendFeedbackItem";
 import { useTelemetry } from "../providers/TelemetryProvider";
+import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
 interface SettingsDropdownProps {
   children: React.ReactNode;
@@ -28,7 +29,7 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
   const { telemetryEnabled } = useTelemetry();
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenuRoot>
       <DropdownMenu.Trigger asChild disabled={disabled}>
         {children}
       </DropdownMenu.Trigger>
@@ -150,7 +151,7 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
           {telemetryEnabled && <SendFeedbackItem />}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+    </DropdownMenuRoot>
   );
 }
 

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import React from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import "./shared/Dropdown.css";
 import { useModal } from "../providers/ModalProvider";

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -8,6 +8,7 @@ import "./ToolsDropdown.css";
 
 import { useProject } from "../providers/ProjectProvider";
 import IconButton from "./shared/IconButton";
+import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
 function DevToolCheckbox({
   label,
@@ -60,7 +61,7 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
   });
 
   return (
-    <DropdownMenu.Root>
+    <DropdownMenuRoot>
       <DropdownMenu.Trigger asChild disabled={disabled}>
         {children}
       </DropdownMenu.Trigger>
@@ -78,7 +79,7 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
           )}
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+    </DropdownMenuRoot>
   );
 }
 


### PR DESCRIPTION
This PR forces dropdown menus to close when focus is taken away from the IDE.

Fixes #908

### How Has This Been Tested: 

Run IDE, open dropdown menu, click outside of the ide


