### PR TITLE
Improve marketplace readme

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -25,13 +25,13 @@ Radon IDE aims to work with all sorts of React Native and Expo projects (see [pr
 ### Logging console with jump-to-source functionality
 
 <div align="center">
-<img width="600" src="../../packages/docs/static/img/docs/ide_jump_from_logs.png"/>
+<img width="600" src="https://github.com/software-mansion/radon-ide/raw/main/packages/docs/static/img/docs/ide_jump_from_logs.png"/>
 </div>
 
 ### Device settings adjustments for theme, text size, location, system language, and more...
 
 <div align="center">
-<img width="600" src="../../packages/docs/static/img/docs/ide_device_settings_1_0.png"/>
+<img width="600" src="https://github.com/software-mansion/radon-ide/raw/main/packages/docs/static/img/docs/ide_device_settings_1_0.png"/>
 </div>
 
 ### Screen recording and screen replays

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,7 +1,68 @@
-# Radon IDE
-
 ![RadonIDE banner](https://github.com/user-attachments/assets/14fd4413-c518-4ead-915a-2020c4f4f981)
 
-Radon IDE is an extension for VSCode and Cursor that turns the code editor into a fully fledged IDE.
+# [Radon IDE](https://ide.swmansion.com)
 
-For documentation, support and instructions, please visit our webside at [ide.swmansion.com](https://ide.swmansion.com).
+[Radon IDE](https://ide.swmansion.com) is an extension for VSCode and Cursor that turns your code editors into fully-featured IDEs for developing React Native and Expo apps.
+
+Once you have the IDE installed, you can check our [Getting Started Guide](https://ide.swmansion.com/docs/getting-started/launching) on how to launch and start using the extension.
+
+### ✨ What does it do
+
+Radon IDE aims to work with all sorts of React Native and Expo projects (see [project compatibility](https://ide.swmansion.com/docs/getting-started/compatibility) page for details), and without any extra configuration, will build and launch your projects, providing an integrated simulator preview right in the editor and enabling a set of integrations that can accelerate the development process, including but not limited to:
+
+### Element inspector with component hierarchy
+
+<div align="center">
+<video src="https://github.com/user-attachments/assets/0f9d36b9-1843-4ae6-99b4-e633bea0b032" width="600" />
+</div>
+
+### Debugger integrated with source code
+
+<div align="center">
+<video src="https://github.com/user-attachments/assets/6a08c375-1a40-40c3-bc95-d6ce6c1cda10" width="600" />
+</div>
+
+### Logging console with jump-to-source functionality
+
+<div align="center">
+<img width="600" src="../../packages/docs/static/img/docs/ide_jump_from_logs.png"/>
+</div>
+
+### Device settings adjustments for theme, text size, location, system language, and more...
+
+<div align="center">
+<img width="600" src="../../packages/docs/static/img/docs/ide_device_settings_1_0.png"/>
+</div>
+
+### Screen recording and screen replays
+
+<div align="center">
+<video src="https://github.com/user-attachments/assets/5b31d461-5d2a-4e85-a1a1-ba0e2c5d41f3" width="600" />
+</div>
+
+### Component preview functionality
+
+<div align="center">
+<video src="https://github.com/user-attachments/assets/e5c91548-3f75-4008-9cad-5fd4fdeadb9f" width="600" />
+</div>
+
+Visit the [Feature Highlights](https://ide.swmansion.com/docs/getting-started/feature-highlight) documentation page, where we showcase the most important features of the extension.
+
+### 💼 License
+
+Radon IDE is available under a commercial license that can be purchased on our website: [ide.swmansion.com](https://ide.swmansion.com/pricing).
+You can use our Free Trial License to evaluate whether the extension works for your project and use cases.
+
+Once you purchase your license, you can follow our [License Activation Guide](https://ide.swmansion.com/docs/guides/activation-manual) to activate it using the IDE Panel in VSCode or Cursor.
+
+### 🐛 Troubleshooting
+
+For troubleshooting and a guide on reporting issues, please visit our [Troubleshooting Docs](https://ide.swmansion.com/docs/guides/troubleshooting).
+
+### 🔗 Links
+
+Visit the [Radon IDE website](https://ide.swmansion.com).
+
+Radon IDE is built by [Software Mansion](https://swmansion.com)
+
+[![swm](https://logo.swmansion.com/logo?color=white&variant=desktop&width=150&tag=react-native-ide-github 'Software Mansion')](https://swmansion.com)

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -4,7 +4,12 @@
   "description": "Extension turning VSCode into a full-featured IDE for React Native and Expo",
   "publisher": "swmansion",
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Debuggers"
+  ],
+  "keywords": [
+    "react-native",
+    "expo"
   ],
   "icon": "assets/logo.png",
   "pricing": "Trial",


### PR DESCRIPTION
Fixes #911

Our README on VSCode Market looks very empty and generic. This PR reuses our README from GitHub with skipped unrelated parts (as installation guide, contributing), and the license is moved lower to highlight the extension's features. 

<img width="1960" alt="image" src="https://github.com/user-attachments/assets/18d701b5-0639-4956-96a8-f24245ef3b4c" />

### How Has This Been Tested: 

- `npm run vscode:package`
- install created extension 

Tested on: VSCode, Cursor, Windsurf 



