### PR TITLE
Fix Loading view not disappearing

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -348,7 +348,9 @@ export function AppWrapper({ children, initialProps, fabric }) {
       LoadingView.showMessage = (message) => {
         devtoolsAgent._bridge.send("RNIDE_fastRefreshStarted");
       };
+      const oldHide = LoadingView.hide;
       LoadingView.hide = () => {
+        oldHide();
         devtoolsAgent._bridge.send("RNIDE_fastRefreshComplete");
       };
     }

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -348,9 +348,9 @@ export function AppWrapper({ children, initialProps, fabric }) {
       LoadingView.showMessage = (message) => {
         devtoolsAgent._bridge.send("RNIDE_fastRefreshStarted");
       };
-      const oldHide = LoadingView.hide;
+      const originalHide = LoadingView.hide;
       LoadingView.hide = () => {
-        oldHide();
+        originalHide();
         devtoolsAgent._bridge.send("RNIDE_fastRefreshComplete");
       };
     }


### PR DESCRIPTION
This PR fixes an issue with loading bar not disappearing, for some time after application was already running. 

We caused the issue by overriding `LoadingView.hide`, to fix it we call the OG method in the new one.

### How Has This Been Tested: 

Reload js, restart app process and reload IDE for expo-52 test app



