### PR TITLE
Fix VS code ui showing script url instead of source url when debugger poused

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -342,7 +342,7 @@ export class DebugAdapter extends DebugSession {
             const genColumn1Based = parseInt(
               stackObjProperties.find((v) => v.name === "column")?.value || "0"
             );
-            const { sourceURL, lineNumber1Based, columnNumber0Based, scriptURL } =
+            const { sourceURL, lineNumber1Based, columnNumber0Based } =
               this.sourceMapRegistry.findOriginalPosition(
                 genUrl,
                 genLine1Based,


### PR DESCRIPTION
This PR replaces a name of source property with original `sourceURL` instead of `scriptURL`, which is the generated script url. This change fixes an issue with console.log sources showing "ugly" names if an error occurred straight after logging. It seems that DAP combines some of its events and if the newest one shows incorrect source name it shows it for older messages as well. 

Fixes #801

### How Has This Been Tested: 

run expo-52 test app and add `throw new Error()` after console.log() it shows correct source in the debug console.

Interesting note: 
the reproduction from #801 will not work if before adding the `throw new Error()` we triggered  console.log and its message is the newest one in debug console, in that scenario new logs are just stacked with the previous one and the source name stays as it was. To cause the problem in this scenario we have to trigger a different console.log and return to the original one, then the source name passed from "unhandled error" instead of  console.log


