### PR TITLE
Fix console logs coming from worklets

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -72,7 +72,7 @@ function wrapConsole(logFunctionKey) {
     }
 
     const location = stack[stackOffset];
-    args.push(location.file, location.lineNumber, location.column);
+    location &&  args.push(location.file, location.lineNumber, location.column);
     return origLogFunc.apply(origLogObject, args);
   };
 }

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -228,7 +228,7 @@ export class DebugAdapter extends DebugSession {
         column: this.columnsStartAt1 ? columnNumber0Based + 1 : columnNumber0Based,
       };
     } else {
-      const variablesRefDapID = this.createVariableForOutputEvent(message.params.args);
+      const variablesRefDapID = await this.createVariableForOutputEvent(message.params.args);
 
       const formattedOutput = await this.formatDefaultString(message.params.args);
 


### PR DESCRIPTION
This PR fixes an issue with console.logs used inside a worklet causing  unhandled exception.
The exception was caused by stack generated on the JS side not having location, line and column information. To solve it we just don't send that information to debugger if it does not exist. 

Additionally solving this problem reviled missing await in `handleConsoleAPICall` method in debagAdapter in case that can only be reached if debugger does not receive the above information so we fix that problem.

### How Has This Been Tested: 

Run `react-native-reanimated` fabric-example and play `useFrameCallback` test

