### PR TITLE
Implement GUI for selecting eas build configuration

### DIFF
--- a/packages/vscode-extension/src/common/EasConfig.ts
+++ b/packages/vscode-extension/src/common/EasConfig.ts
@@ -1,3 +1,6 @@
+// Describes the shape of the `eas.json` config file's content.
+// Currently, we only include the parts of the object we care about.
+// See https://docs.expo.dev/eas/json/ for details.
 export interface EasConfig {
   build?: EasBuildConfig;
 }

--- a/packages/vscode-extension/src/common/EasConfig.ts
+++ b/packages/vscode-extension/src/common/EasConfig.ts
@@ -1,0 +1,62 @@
+export interface EasConfig {
+  build?: EasBuildConfig;
+}
+
+export type EasBuildConfig = {
+  [key: string]: EasBuildProfile;
+};
+
+export type EasBuildDistributionType = "internal" | "store";
+
+export interface EasBuildProfileIOSSpecific {
+  simulator?: boolean;
+}
+
+export interface EasBuildProfile {
+  distribution?: EasBuildDistributionType;
+  ios?: EasBuildProfileIOSSpecific;
+}
+
+export function isEasConfig(obj: unknown): obj is EasConfig {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+
+  return !("build" in obj) || obj.build === undefined || isEasBuildConfig(obj.build);
+}
+
+export function isEasBuildConfig(obj: unknown): obj is EasBuildConfig {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+
+  return Object.values(obj).every((v) => v === undefined || isEasBuildProfile(v));
+}
+
+export function isEasBuildProfile(obj: unknown): obj is EasBuildProfile {
+  if (typeof obj !== "object" || obj === null) {
+    return false;
+  }
+
+  if (
+    "distribution" in obj &&
+    (typeof obj.distribution !== "string" || !["internal", "store"].includes(obj.distribution))
+  ) {
+    return false;
+  }
+
+  if ("ios" in obj && obj.ios !== undefined) {
+    if (typeof obj.ios !== "object" || obj.ios === null) {
+      return false;
+    }
+    if (
+      "simulator" in obj.ios &&
+      obj.ios.simulator !== undefined &&
+      !(typeof obj.ios.simulator === "boolean")
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -48,6 +48,7 @@ export interface LaunchConfig {
   getConfig(): Promise<LaunchConfigurationOptions>;
   update: LaunchConfigUpdater;
   getAvailableXcodeSchemes(): Promise<string[]>;
+  getAvailableEasProfiles(): Promise<string[]>;
   addListener<K extends keyof LaunchConfigEventMap>(
     eventType: K,
     listener: LaunchConfigEventListener<LaunchConfigEventMap[K]>

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -1,3 +1,5 @@
+import { EasBuildConfig } from "./EasConfig";
+
 export type EasConfig = { profile: string; buildUUID?: string };
 export type CustomBuild = {
   buildCommand?: string;
@@ -48,7 +50,7 @@ export interface LaunchConfig {
   getConfig(): Promise<LaunchConfigurationOptions>;
   update: LaunchConfigUpdater;
   getAvailableXcodeSchemes(): Promise<string[]>;
-  getAvailableEasProfiles(): Promise<string[]>;
+  getAvailableEasProfiles(): Promise<EasBuildConfig>;
   addListener<K extends keyof LaunchConfigEventMap>(
     eventType: K,
     listener: LaunchConfigEventListener<LaunchConfigEventMap[K]>

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -11,6 +11,7 @@ import { findXcodeProject, findXcodeScheme } from "../utilities/xcode";
 import { Logger } from "../Logger";
 import { getIosSourceDir } from "../builders/buildIOS";
 import { readEasConfig } from "../utilities/eas";
+import { EasBuildConfig } from "../common/EasConfig";
 
 export class LaunchConfigController implements Disposable, LaunchConfig {
   private config: LaunchConfigurationOptions;
@@ -108,11 +109,11 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
     return await findXcodeScheme(xcodeProject);
   }
 
-  async getAvailableEasProfiles(): Promise<string[]> {
+  async getAvailableEasProfiles(): Promise<EasBuildConfig> {
     const appRootFolder = getAppRootFolder();
     const easConfig = await readEasConfig(appRootFolder);
     const easBuildConfig = easConfig?.build ?? {};
-    return Object.keys(easBuildConfig);
+    return easBuildConfig;
   }
 
   async addListener<K extends keyof LaunchConfigEventMap>(

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -10,6 +10,7 @@ import { getAppRootFolder } from "../utilities/extensionContext";
 import { findXcodeProject, findXcodeScheme } from "../utilities/xcode";
 import { Logger } from "../Logger";
 import { getIosSourceDir } from "../builders/buildIOS";
+import { readEasConfig } from "../utilities/eas";
 
 export class LaunchConfigController implements Disposable, LaunchConfig {
   private config: LaunchConfigurationOptions;
@@ -106,6 +107,14 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
     );
     return await findXcodeScheme(xcodeProject);
   }
+
+  async getAvailableEasProfiles(): Promise<string[]> {
+    const appRootFolder = getAppRootFolder();
+    const easConfig = await readEasConfig(appRootFolder);
+    const easBuildConfig = easConfig?.build ?? {};
+    return Object.keys(easBuildConfig);
+  }
+
   async addListener<K extends keyof LaunchConfigEventMap>(
     eventType: K,
     listener: LaunchConfigEventListener<LaunchConfigEventMap[K]>

--- a/packages/vscode-extension/src/utilities/eas.ts
+++ b/packages/vscode-extension/src/utilities/eas.ts
@@ -1,20 +1,5 @@
 import { RelativePattern, Uri, workspace } from "vscode";
-
-export interface EasConfig {
-  build?: EasBuildConfig;
-}
-
-export type EasBuildConfig = {
-  [key: string]: EasBuildProfile;
-};
-
-export interface EasBuildProfile {}
-
-function isEasConfig(obj: unknown): obj is EasConfig {
-  return (
-    typeof obj === "object" && obj !== null && !("build" in obj && typeof obj.build !== "object")
-  );
-}
+import { EasConfig, isEasConfig } from "../common/EasConfig";
 
 export async function readEasConfig(appRootFolder: string | Uri): Promise<EasConfig | null> {
   const easConfigUri = await workspace.findFiles(

--- a/packages/vscode-extension/src/utilities/eas.ts
+++ b/packages/vscode-extension/src/utilities/eas.ts
@@ -1,0 +1,38 @@
+import { RelativePattern, Uri, workspace } from "vscode";
+
+export interface EasConfig {
+  build?: EasBuildConfig;
+}
+
+export type EasBuildConfig = {
+  [key: string]: EasBuildProfile;
+};
+
+export interface EasBuildProfile {}
+
+function isEasConfig(obj: unknown): obj is EasConfig {
+  return (
+    typeof obj === "object" && obj !== null && !("build" in obj && typeof obj.build !== "object")
+  );
+}
+
+export async function readEasConfig(appRootFolder: string | Uri): Promise<EasConfig | null> {
+  const easConfigUri = await workspace.findFiles(
+    new RelativePattern(appRootFolder, "eas.json"),
+    null,
+    1
+  );
+  if (easConfigUri.length === 0) {
+    return null;
+  }
+  try {
+    const easConfigData = await workspace.fs.readFile(easConfigUri[0]);
+    const easConfig = JSON.parse(new TextDecoder().decode(easConfigData));
+    if (isEasConfig(easConfig)) {
+      return easConfig;
+    }
+    return null;
+  } catch (err) {
+    return null;
+  }
+}

--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -20,6 +20,7 @@ const launchConfig = makeProxy<LaunchConfig>("LaunchConfig");
 type LaunchConfigContextType = LaunchConfigurationOptions & {
   update: LaunchConfigUpdater;
   xcodeSchemes: string[];
+  easBuildProfiles: string[];
   eas?: {
     ios?: EasConfig;
     android?: EasConfig;
@@ -29,17 +30,20 @@ type LaunchConfigContextType = LaunchConfigurationOptions & {
 const LaunchConfigContext = createContext<LaunchConfigContextType>({
   update: () => {},
   xcodeSchemes: [],
+  easBuildProfiles: [],
 });
 
 export default function LaunchConfigProvider({ children }: PropsWithChildren) {
   const [config, setConfig] = useState<LaunchConfigurationOptions>({});
   const [xcodeSchemes, setXcodeSchemes] = useState<string[]>([]);
+  const [easBuildProfiles, setEasBuildProfiles] = useState<string[]>([]);
 
   useEffect(() => {
     launchConfig.getConfig().then(setConfig);
     launchConfig.addListener("launchConfigChange", setConfig);
 
     launchConfig.getAvailableXcodeSchemes().then(setXcodeSchemes);
+    launchConfig.getAvailableEasProfiles().then(setEasBuildProfiles);
 
     return () => {
       launchConfig.removeListener("launchConfigChange", setConfig);
@@ -59,8 +63,8 @@ export default function LaunchConfigProvider({ children }: PropsWithChildren) {
   );
 
   const contextValue = useMemo(() => {
-    return { ...config, update, xcodeSchemes };
-  }, [config, update, xcodeSchemes]);
+    return { ...config, update, xcodeSchemes, easBuildProfiles };
+  }, [config, update, xcodeSchemes, easBuildProfiles]);
 
   return (
     <LaunchConfigContext.Provider value={contextValue}>{children}</LaunchConfigContext.Provider>

--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -14,13 +14,14 @@ import {
   LaunchConfigUpdater,
   LaunchConfigurationOptions,
 } from "../../common/LaunchConfig";
+import { EasBuildConfig } from "../../common/EasConfig";
 
 const launchConfig = makeProxy<LaunchConfig>("LaunchConfig");
 
 type LaunchConfigContextType = LaunchConfigurationOptions & {
   update: LaunchConfigUpdater;
   xcodeSchemes: string[];
-  easBuildProfiles: string[];
+  easBuildProfiles: EasBuildConfig;
   eas?: {
     ios?: EasConfig;
     android?: EasConfig;
@@ -30,13 +31,13 @@ type LaunchConfigContextType = LaunchConfigurationOptions & {
 const LaunchConfigContext = createContext<LaunchConfigContextType>({
   update: () => {},
   xcodeSchemes: [],
-  easBuildProfiles: [],
+  easBuildProfiles: {},
 });
 
 export default function LaunchConfigProvider({ children }: PropsWithChildren) {
   const [config, setConfig] = useState<LaunchConfigurationOptions>({});
   const [xcodeSchemes, setXcodeSchemes] = useState<string[]>([]);
-  const [easBuildProfiles, setEasBuildProfiles] = useState<string[]>([]);
+  const [easBuildProfiles, setEasBuildProfiles] = useState<EasBuildConfig>({});
 
   useEffect(() => {
     launchConfig.getConfig().then(setConfig);

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -56,7 +56,7 @@ function LaunchConfigurationView() {
 
       {easBuildProfiles.length > 0 && (
         <>
-          <Label>eas Build</Label>
+          <Label>EAS Build</Label>
           <EasBuildConfiguration
             platform="ios"
             eas={eas}
@@ -304,7 +304,7 @@ function EasBuildConfiguration({
 
   const onSchemeChange = (newProfile: string) => {
     if (newProfile === DISABLED) {
-      let newEasConfig: EasConfig | undefined = { ...eas, [platform]: undefined };
+      const newEasConfig: EasConfig | undefined = { ...eas, [platform]: undefined };
       update("eas", newEasConfig);
       return;
     }
@@ -318,7 +318,7 @@ function EasBuildConfiguration({
   };
 
   const onBuildUUIDInputBlur = () => {
-    let newBuildUUID = buildUUIDInputRef.current?.value || undefined;
+    const newBuildUUID = buildUUIDInputRef.current?.value || undefined;
     const platformConfig = eas?.[platform];
     if (platformConfig === undefined) {
       return;


### PR DESCRIPTION
Adds options to the "Launch Configuration" GUI for enabling EAS Build, selecting build profiles and specifying build UUIDs.

### How Has This Been Tested: 
- open [`expo-52-eas`](https://github.com/software-mansion-labs/radon-ide-test-apps/tree/main/expo-52-eas) and open the "Launch Configuration" window
  - the settings for EAS Build should appear
  - changing the settings in GUI should update `launch.config` file appropriately
- open an application without `build` config in `eas.json` (for example, [`react-native-77`](https://github.com/software-mansion-labs/radon-ide-test-apps/tree/main/react-native-77) or remove the `build` entry in `eas.json` in [`expo-52-eas`](https://github.com/software-mansion-labs/radon-ide-test-apps/tree/main/expo-52-eas)) and open the "Launch Configuration" window
  - the settings for EAS Build shouldn't appear

