### PR TITLE
Improve user messaging when eas-cli is not installed

### DIFF
--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -8,7 +8,7 @@ import { EasConfig } from "../common/LaunchConfig";
 import { Logger } from "../Logger";
 import { CancelToken } from "./cancelToken";
 import { downloadBinary } from "../utilities/common";
-import { EASBuild, listEasBuilds, viewEasBuild } from "./easCommand";
+import { EASBuild, isEasCliInstalled, listEasBuilds, viewEasBuild } from "./easCommand";
 import { extractTarApp } from "./utils";
 
 export async function fetchEasBuild(
@@ -16,6 +16,12 @@ export async function fetchEasBuild(
   config: EasConfig,
   platform: DevicePlatform
 ): Promise<string | undefined> {
+  if (!(await isEasCliInstalled())) {
+    throw new Error(
+      "Failed to build iOS app using EAS build. Check if eas-cli is installed and available in PATH."
+    );
+  }
+
   const build = await fetchBuild(config, platform);
   if (!build) {
     return undefined;

--- a/packages/vscode-extension/src/builders/easCommand.ts
+++ b/packages/vscode-extension/src/builders/easCommand.ts
@@ -53,6 +53,15 @@ type EASBuildJson = {
   isForIosSimulator: false;
 };
 
+export async function isEasCliInstalled() {
+  try {
+    await exec("eas", ["--version"], { cwd: getAppRootFolder() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function listEasBuilds(platform: DevicePlatform, profile: string) {
   const platformMapping = { [DevicePlatform.Android]: "android", [DevicePlatform.IOS]: "ios" };
 

--- a/packages/vscode-extension/src/common/DependencyManager.ts
+++ b/packages/vscode-extension/src/common/DependencyManager.ts
@@ -17,7 +17,8 @@ export type Dependency =
   | "reactNative"
   | "expo"
   | "expoRouter"
-  | "storybook";
+  | "storybook"
+  | "easCli";
 
 export type InstallationStatus = "installed" | "notInstalled" | "installing";
 

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -29,6 +29,7 @@ import { Platform } from "../utilities/platform";
 import { requireNoCache } from "../utilities/requireNoCache";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { DevicePlatform } from "../common/DeviceManager";
+import { isEasCliInstalled } from "../builders/easCommand";
 
 export class DependencyManager implements Disposable, DependencyManagerInterface {
   // React Native prepares build scripts based on node_modules, we need to reinstall pods if they change
@@ -78,6 +79,7 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
 
     this.checkProjectUsesExpoRouter();
     this.checkProjectUsesStorybook();
+    this.checkEasCliInstallationStatus();
   }
 
   public async checkAndroidDirectoryExits() {
@@ -309,6 +311,15 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
       isOptional: false,
     });
     return !failed;
+  }
+
+  public async checkEasCliInstallationStatus() {
+    const installed = await isEasCliInstalled();
+    this.emitEvent("easCli", {
+      status: installed ? "installed" : "notInstalled",
+      isOptional: true,
+    });
+    return;
   }
 }
 

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -83,7 +83,12 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
     (!!eas?.ios && projectState.selectedDevice?.platform === DevicePlatform.IOS);
 
   if (isEasBuild) {
-    description = "Your Project Eas build has failed, see extension logs to see what went wrong.";
+    if (dependencies.easCli?.status === "notInstalled") {
+      description =
+        "Your project uses EAS build, but eas-cli is not installed. Install it and run the build again.";
+    } else {
+      description = "Your project EAS build has failed, see extension logs to see what went wrong.";
+    }
     actions = <BuildErrorActions logsButtonDestination="extension" />;
   }
 

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -85,7 +85,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
   if (isEasBuild) {
     if (dependencies.easCli?.status === "notInstalled") {
       description =
-        "Your project uses EAS build, but eas-cli is not installed. Install it and run the build again.";
+        "Your project uses EAS build, but eas-cli is not installed. Install it and reload the app.";
     } else {
       description = "Your project EAS build has failed, see extension logs to see what went wrong.";
     }

--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -30,6 +30,7 @@ const dependenciesDomain = [
   "expo",
   "expoRouter",
   "storybook",
+  "easCli",
 ] as const;
 
 type Dependency = typeof dependenciesDomain[number];
@@ -210,6 +211,11 @@ export function dependencyDescription(dependency: Dependency) {
       return {
         info: "Whether Storybook is installed.",
         error: "Storybook is not installed.",
+      };
+    case "easCli":
+      return {
+        info: "Whether eas-cli is installed.",
+        error: "eas-cli is not installed.",
       };
   }
 }

--- a/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
+++ b/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
@@ -57,6 +57,7 @@ function DiagnosticView() {
       <Label>Other</Label>
       <DiagnosticItem label="Expo Router" name="expoRouter" info={dependencies.expoRouter} />
       <DiagnosticItem label="Storybook" name="storybook" info={dependencies.storybook} />
+      <DiagnosticItem label="eas-cli" name="easCli" info={dependencies.easCli} />
       <div className="diagnostic-section-margin" />
 
       <div className="diagnostic-button-container">


### PR DESCRIPTION
- Improves build error messages when trying to use EAS Build without `eas-cli` installed.
- Adds `eas-cli` installation status to the diagnostics window.

### How Has This Been Tested: 
Try to build an EAS Build project without `eas-cli` installed (`eas` executable should not be in `PATH`).
![image](https://github.com/user-attachments/assets/13af218b-7ef4-42d5-9407-bdab1d0c9062)
