### PR TITLE
Update wording for theme switcher

### DIFF
--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -162,13 +162,13 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
                 <DropdownMenu.Item
                   className="dropdown-menu-item"
                   onSelect={() => update("themeType", "vscode")}>
-                  VScode theme
+                  Match editor theme
                   {themeType === "vscode" && <span className="codicon codicon-check right-slot" />}
                 </DropdownMenu.Item>
                 <DropdownMenu.Item
                   className="dropdown-menu-item"
                   onSelect={() => update("themeType", "built-in")}>
-                  Built in theme
+                  Use Radon IDE theme
                   {themeType === "built-in" && (
                     <span className="codicon codicon-check right-slot" />
                   )}


### PR DESCRIPTION
After adding theme switch menu option, I found the proposed text to not be indicative enough to what the option mean:
1) We use "VSCode" in the naming while also allow extension to work on Cursor and Windsurf
2) Name "built-in" is misleading as the editor theme can also be built-in

The new proposed wording is as follows:
1) Match editor theme – this makes Radon IDE panel use the same theme as the editor
2) Use Radon IDE theme – this makes the panel use Radon's theme (light or dark depending on the editor setting)

### How Has This Been Tested: 
1) Use theme switcher, make sure it switches between using editor theme and theme from Radon


