### PR TITLE
Fix debugger overlay styles when editor theme is used

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -636,10 +636,10 @@ body[data-use-code-theme="true"] {
   --swm-url-select-separator: var(--vscode-dropdown-border);
 
   /* Debugger */
-  --swm-debugger-label: var(--off-white);
-  --swm-debugger-button-group: var(--white);
-  --swm-debugger-button-group-background: var(--navy-light-20);
-  --swm-debugger-button-group-border: 1px solid var(--navy-light-40);
+  --swm-debugger-label: var(--vscode-foreground);
+  --swm-debugger-button-group: var(--vscode-foreground);
+  --swm-debugger-button-group-background: var(--vscode-dropdown-background);
+  --swm-debugger-button-group-border: 1px solid var(--vscode-dropdown-border);
 
   /* Zoom controls */
   --swm-zoom-controls-background: var(--vscode-menu-background);


### PR DESCRIPTION
This PR fixes issue with styles of debugger overlay in editor-match mode after #874

Before:
<img width="465" alt="image" src="https://github.com/user-attachments/assets/49767965-b2c3-4887-9d25-6ee67d537e9f" />

After:
<img width="470" alt="image" src="https://github.com/user-attachments/assets/878cbb1f-1e15-49d9-b494-18520688fc37" />
<img width="467" alt="image" src="https://github.com/user-attachments/assets/b42c75ee-3a03-4c16-975c-af78119a2c93" />

### How Has This Been Tested: 
1. Make the debugger pause and observe the styles


