### PR TITLE
Fix color glitch at the beginning

### DIFF
--- a/packages/vscode-extension/src/webview/App.css
+++ b/packages/vscode-extension/src/webview/App.css
@@ -5,7 +5,14 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
+}
+
+body[data-use-code-theme] #root {
   background-color: var(--swm-preview-background);
+}
+
+body[data-use-code-theme=""] #root {
+  background-color: inherit;
 }
 
 main {

--- a/packages/vscode-extension/src/webview/index.jsx
+++ b/packages/vscode-extension/src/webview/index.jsx
@@ -21,10 +21,10 @@ const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <WorkspaceConfigProvider>
-      <ProjectProvider>
-        <UtilsProvider>
-          <TelemetryProvider>
+    <ProjectProvider>
+      <UtilsProvider>
+        <TelemetryProvider>
+          <WorkspaceConfigProvider>
             <LaunchConfigProvider>
               <DevicesProvider>
                 <DependenciesProvider>
@@ -36,9 +36,9 @@ root.render(
                 </DependenciesProvider>
               </DevicesProvider>
             </LaunchConfigProvider>
-          </TelemetryProvider>
-        </UtilsProvider>
-      </ProjectProvider>
-    </WorkspaceConfigProvider>
+          </WorkspaceConfigProvider>
+        </TelemetryProvider>
+      </UtilsProvider>
+    </ProjectProvider>
   </React.StrictMode>
 );

--- a/packages/vscode-extension/src/webview/index.jsx
+++ b/packages/vscode-extension/src/webview/index.jsx
@@ -25,17 +25,17 @@ root.render(
       <ProjectProvider>
         <UtilsProvider>
           <TelemetryProvider>
-              <LaunchConfigProvider>
-                <DevicesProvider>
-                  <DependenciesProvider>
-                    <ModalProvider>
-                      <AlertProvider>
-                        <App />
-                      </AlertProvider>
-                    </ModalProvider>
-                  </DependenciesProvider>
-                </DevicesProvider>
-              </LaunchConfigProvider>
+            <LaunchConfigProvider>
+              <DevicesProvider>
+                <DependenciesProvider>
+                  <ModalProvider>
+                    <AlertProvider>
+                      <App />
+                    </AlertProvider>
+                  </ModalProvider>
+                </DependenciesProvider>
+              </DevicesProvider>
+            </LaunchConfigProvider>
           </TelemetryProvider>
         </UtilsProvider>
       </ProjectProvider>

--- a/packages/vscode-extension/src/webview/index.jsx
+++ b/packages/vscode-extension/src/webview/index.jsx
@@ -21,24 +21,24 @@ const root = createRoot(container);
 
 root.render(
   <React.StrictMode>
-    <ProjectProvider>
-      <UtilsProvider>
-        <TelemetryProvider>
-          <WorkspaceConfigProvider>
-            <LaunchConfigProvider>
-              <DevicesProvider>
-                <DependenciesProvider>
-                  <ModalProvider>
-                    <AlertProvider>
-                      <App />
-                    </AlertProvider>
-                  </ModalProvider>
-                </DependenciesProvider>
-              </DevicesProvider>
-            </LaunchConfigProvider>
-          </WorkspaceConfigProvider>
-        </TelemetryProvider>
-      </UtilsProvider>
-    </ProjectProvider>
+    <WorkspaceConfigProvider>
+      <ProjectProvider>
+        <UtilsProvider>
+          <TelemetryProvider>
+              <LaunchConfigProvider>
+                <DevicesProvider>
+                  <DependenciesProvider>
+                    <ModalProvider>
+                      <AlertProvider>
+                        <App />
+                      </AlertProvider>
+                    </ModalProvider>
+                  </DependenciesProvider>
+                </DevicesProvider>
+              </LaunchConfigProvider>
+          </TelemetryProvider>
+        </UtilsProvider>
+      </ProjectProvider>
+    </WorkspaceConfigProvider>
   </React.StrictMode>
 );

--- a/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
@@ -24,6 +24,7 @@ const WorkspaceConfigContext = createContext<WorkspaceConfigContextType>({
 });
 
 export default function WorkspaceConfigProvider({ children }: PropsWithChildren) {
+  const [initialized, setInitialized] = useState(false);
   const [config, setConfig] = useState<WorkspaceConfigProps>({
     panelLocation: "tab",
     showDeviceFrame: true,
@@ -33,7 +34,7 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
   useEffect(() => {
     function watchConfigChange(e: WorkspaceConfigProps) {
       document.body.setAttribute("data-use-code-theme", `${e.themeType === "vscode"}`);
-
+      setInitialized(true);
       setConfig(e);
     }
 
@@ -62,6 +63,10 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
     return { ...config, update };
   }, [config, update]);
 
+  if (!initialized) {
+    return null;
+  }
+  
   return (
     <WorkspaceConfigContext.Provider value={contextValue}>
       {children}

--- a/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
@@ -66,7 +66,7 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
   if (!initialized) {
     return null;
   }
-  
+
   return (
     <WorkspaceConfigContext.Provider value={contextValue}>
       {children}


### PR DESCRIPTION
This PR fixes color glitch at the beginning. It's done in two stages: 
- we don't set the background until we have theme selected 
- we don't display rest of the UI until we know which one to display 
 
### How Has This Been Tested: 

- Restart the extension and see if the glitch exists 


