### PR TITLE
Fix startup theme glitch

### DIFF
--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, ExtensionMode, Webview, Uri } from "vscode";
+import { ExtensionContext, ExtensionMode, Webview, Uri, workspace } from "vscode";
 import { getUri } from "../utilities/getUri";
 import { getNonce } from "../utilities/getNonce";
 import { Platform } from "../utilities/platform";
@@ -21,6 +21,8 @@ export function generateWebviewContent(
   webview: Webview,
   extensionUri: Uri
 ) {
+  const config = workspace.getConfiguration("RadonIDE");
+  const useCodeTheme = config.get("themeType") === "vscode";
   const IS_DEV = context.extensionMode === ExtensionMode.Development;
 
   // The JS file from the React build output
@@ -59,7 +61,7 @@ export function generateWebviewContent(
         <link rel="stylesheet" type="text/css" href="webview.css" />`
         }
       </head>
-      <body>
+      <body data-use-code-theme="${useCodeTheme}">
         <div id="root"></div>
         <script nonce="${nonce}">window.RNIDE_hostOS = "${Platform.OS}";</script>
         <script type="module" nonce="${nonce}" src="${scriptUri}" />

--- a/packages/vscode-extension/src/webview/App.css
+++ b/packages/vscode-extension/src/webview/App.css
@@ -5,14 +5,7 @@ body,
   height: 100%;
   margin: 0;
   padding: 0;
-}
-
-body[data-use-code-theme] #root {
   background-color: var(--swm-preview-background);
-}
-
-body[data-use-code-theme=""] #root {
-  background-color: inherit;
 }
 
 main {

--- a/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/WorkspaceConfigProvider.tsx
@@ -24,7 +24,6 @@ const WorkspaceConfigContext = createContext<WorkspaceConfigContextType>({
 });
 
 export default function WorkspaceConfigProvider({ children }: PropsWithChildren) {
-  const [initialized, setInitialized] = useState(false);
   const [config, setConfig] = useState<WorkspaceConfigProps>({
     panelLocation: "tab",
     showDeviceFrame: true,
@@ -34,7 +33,6 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
   useEffect(() => {
     function watchConfigChange(e: WorkspaceConfigProps) {
       document.body.setAttribute("data-use-code-theme", `${e.themeType === "vscode"}`);
-      setInitialized(true);
       setConfig(e);
     }
 
@@ -62,10 +60,6 @@ export default function WorkspaceConfigProvider({ children }: PropsWithChildren)
   const contextValue = useMemo(() => {
     return { ...config, update };
   }, [config, update]);
-
-  if (!initialized) {
-    return null;
-  }
 
   return (
     <WorkspaceConfigContext.Provider value={contextValue}>


### PR DESCRIPTION
This PR improves upon  #938. 

Instead of the CSS trick for empty attribute and holding the rendering, we just provide the **proper** initial value in the html. This seems to be the smoother solution. 

I'm using `workspace.getConfiguration("RadonIDE");` instead of `IDE.getInstance` as IDE is not attached at this point yet. 

### How Has This Been Tested: 

- Restart the extension and see if the glitch exists 


