### PR TITLE
Cleanup dev plugins architecture along with redux plugin

### DIFF
--- a/packages/vscode-extension/lib/expo_dev_plugins.js
+++ b/packages/vscode-extension/lib/expo_dev_plugins.js
@@ -1,3 +1,3 @@
 export function register(pluginName) {
-  global.__RNIDE_register_expo_dev_plugin && global.__RNIDE_register_expo_dev_plugin(pluginName);
+  global.__RNIDE_register_dev_plugin && global.__RNIDE_register_dev_plugin(pluginName);
 }

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -72,7 +72,7 @@ function wrapConsole(logFunctionKey) {
     }
 
     const location = stack[stackOffset];
-    location &&  args.push(location.file, location.lineNumber, location.column);
+    location && args.push(location.file, location.lineNumber, location.column);
     return origLogFunc.apply(origLogObject, args);
   };
 }
@@ -89,8 +89,8 @@ global.__RNIDE_register_navigation_plugin = function (name, plugin) {
   require("__RNIDE_lib__/wrapper.js").registerNavigationPlugin(name, plugin);
 };
 
-global.__RNIDE_register_expo_dev_plugin = function (name) {
-  require("__RNIDE_lib__/wrapper.js").registerExpoDevPlugin(name);
+global.__RNIDE_register_dev_plugin = function (name) {
+  require("__RNIDE_lib__/wrapper.js").registerDevtoolPlugin(name);
 };
 
 AppRegistry.setWrapperComponentProvider((appParameters) => {

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -11,7 +11,6 @@ const {
   findNodeHandle,
 } = require("react-native");
 const { storybookPreview } = require("./storybook_helper");
-const { useReduxDevTools, isReduxDevToolsReady } = require("./plugins/redux-devtools");
 
 // https://github.com/facebook/react/blob/c3570b158d087eb4e3ee5748c4bd9360045c8a26/packages/react-reconciler/src/ReactWorkTags.js#L62
 const OffscreenComponentReactTag = 22;
@@ -21,11 +20,11 @@ export function registerNavigationPlugin(name, plugin) {
   navigationPlugins.push({ name, plugin });
 }
 
-const expoDevPlugins = new Set();
-let expoDevPluginsChanged = undefined;
-export function registerExpoDevPlugin(name) {
-  expoDevPlugins.add(name);
-  expoDevPluginsChanged?.();
+const devtoolPlugins = new Set(["network"]);
+let devtoolPluginsChanged = undefined;
+export function registerDevtoolPlugin(name) {
+  devtoolPlugins.add(name);
+  devtoolPluginsChanged?.();
 }
 
 let navigationHistory = new Map();
@@ -34,6 +33,16 @@ const InternalImports = {
   get PREVIEW_APP_KEY() {
     return require("./preview").PREVIEW_APP_KEY;
   },
+  get enableNetworkInspect() {
+    return require("./network").enableNetworkInspect;
+  },
+  get reduxDevtoolsExtensionCompose() {
+    return require("./plugins/redux-devtools").compose;
+  },
+};
+
+window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = function (...args) {
+  return InternalImports.reduxDevtoolsExtensionCompose(...args);
 };
 
 const RNInternals = {
@@ -203,8 +212,6 @@ export function AppWrapper({ children, initialProps, fabric }) {
   const [devtoolsAgent, setDevtoolsAgent] = useState(null);
   const [hasLayout, setHasLayout] = useState(false);
   const mainContainerRef = useRef();
-  
-  useReduxDevTools(devtoolsAgent);
 
   const mountCallback = initialProps?.__RNIDE_onMount;
   useEffect(() => {
@@ -344,6 +351,15 @@ export function AppWrapper({ children, initialProps, fabric }) {
     [showStorybookStory]
   );
 
+  useAgentListener(
+    devtoolsAgent,
+    "RNIDE_enableNetworkInspect",
+    (payload) => {
+      InternalImports.enableNetworkInspect(devtoolsAgent, payload);
+    },
+    []
+  );
+
   useEffect(() => {
     if (devtoolsAgent) {
       LogBox.uninstall();
@@ -379,21 +395,16 @@ export function AppWrapper({ children, initialProps, fabric }) {
         appKey,
         navigationPlugins: navigationPlugins.map((plugin) => plugin.name),
       });
-      devtoolsAgent._bridge.send("RNIDE_expoDevPluginsChanged", {
-        plugins: Array.from(expoDevPlugins.values()),
+      devtoolsAgent._bridge.send("RNIDE_devtoolPluginsChanged", {
+        plugins: Array.from(devtoolPlugins.values()),
       });
-      expoDevPluginsChanged = () => {
-        devtoolsAgent._bridge.send("RNIDE_expoDevPluginsChanged", {
-          plugins: Array.from(expoDevPlugins.values()),
+      devtoolPluginsChanged = () => {
+        devtoolsAgent._bridge.send("RNIDE_devtoolPluginsChanged", {
+          plugins: Array.from(devtoolPlugins.values()),
         });
       };
-      devtoolsAgent._bridge.send("RNIDE_pluginsChanged", {
-        plugins: [
-          isReduxDevToolsReady() && "RNIDE-redux-devtools",
-        ].filter(Boolean),
-      });
       return () => {
-        expoDevPluginsChanged = undefined;
+        devtoolPluginsChanged = undefined;
       };
     }
   }, [!!devtoolsAgent && hasLayout]);

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -20,7 +20,7 @@ export function registerNavigationPlugin(name, plugin) {
   navigationPlugins.push({ name, plugin });
 }
 
-const devtoolPlugins = new Set(["network"]);
+const devtoolPlugins = new Set();
 let devtoolPluginsChanged = undefined;
 export function registerDevtoolPlugin(name) {
   devtoolPlugins.add(name);
@@ -32,9 +32,6 @@ let navigationHistory = new Map();
 const InternalImports = {
   get PREVIEW_APP_KEY() {
     return require("./preview").PREVIEW_APP_KEY;
-  },
-  get enableNetworkInspect() {
-    return require("./network").enableNetworkInspect;
   },
   get reduxDevtoolsExtensionCompose() {
     return require("./plugins/redux-devtools").compose;

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -28,14 +28,6 @@ function initializeReduxDevPlugin() {
 export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
   const webViewProvider = initializeReduxDevPlugin();
 
-  function devtoolsListener(event: string, payload: any) {
-    if (event === "RNIDE_pluginsChanged") {
-      const availablePlugins = new Set(payload.plugins);
-      plugin.available = availablePlugins.has(plugin.id);
-      toolsManager.handleStateChange();
-    }
-  }
-
   let proxyDevtoolsListener: null | ((event: string, payload: any) => void) = null;
   webViewProvider?.setListener((webview) => {
     proxyDevtoolsListener = (event: string, payload: any) => {
@@ -59,11 +51,9 @@ export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
   function dispose() {
     if (!disposed) {
       if (proxyDevtoolsListener) {
-        toolsManager.devtools.removeListener(devtoolsListener);
+        toolsManager.devtools.removeListener(proxyDevtoolsListener);
       }
-
-      toolsManager.devtools.removeListener(devtoolsListener);
-      disposed = false;
+      disposed = true;
     }
   }
 
@@ -82,10 +72,6 @@ export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
     },
     dispose,
   };
-
-  // Listen for events passed via devtools that indicate which plugins are loaded
-  // by the app.
-  toolsManager.devtools.addListener(devtoolsListener);
 
   return plugin;
 };

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -7,7 +7,6 @@ import {
   createExpoDevPluginTools,
   ExpoDevPluginToolName,
 } from "../plugins/expo-dev-plugins/expo-dev-plugins";
-import { NetworkPlugin, NetworkPluginToolName } from "../plugins/network/network-plugin";
 import {
   REDUX_PLUGIN_ID,
   createReduxDevtools,
@@ -15,7 +14,7 @@ import {
 
 const TOOLS_SETTINGS_KEY = "tools_settings";
 
-export type ToolKey = ExpoDevPluginToolName | NetworkPluginToolName | typeof REDUX_PLUGIN_ID;
+export type ToolKey = ExpoDevPluginToolName | typeof REDUX_PLUGIN_ID;
 
 export interface ToolPlugin extends Disposable {
   id: ToolKey;
@@ -42,8 +41,6 @@ export class ToolsManager implements Disposable {
     }
     const reduxPlugin = createReduxDevtools(this);
     this.plugins.set(reduxPlugin.id, reduxPlugin);
-
-    this.plugins.set("network", new NetworkPlugin(devtools));
 
     devtools.addListener(this.devtoolsListener);
     this.handleStateChange();


### PR DESCRIPTION
In #931 we introduces a buil-in support for redux plugin that doesn't rely on expo dev plugins package. This PR however brought a few potential issues to the codebase, so here we're refactoring it aiming to fix those problems while also preparing for more steamlined support for other tools:

1) removing console log statements introduced in #931 that were polluting the app output
2) clearing up redux registration such that it only relies on the "compose" callback and doesn't require subsequent calls for setting devtools agent nor hook-based integration. This is done by accessing the devtools agent in the same way we do that in the wrapper component.
3) getting rid of direct imports of devtools related code – this for unknown reason turns out to be causing issues with metro as direct imports would impact the order in which modules are loaded and hence may impact the app behavior.
4) we're refactoring module registration such that it is no longer specific to expo. Before we had registry for expo-related plugins and now in #931 a separate registration process was introduced for redux plugin specifically. We're making it more generic and porting both expo plugins and the redux plugin to use it.

### How Has This Been Tested: 
1. Fire up example app with plugins
2. Test redux plugin shows up on the list when redux is used and doesn't show up otherwise.
3. Test scenario from #931


