### PR TITLE
Adapt radon to RN 78 debugger

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -41,6 +41,7 @@ export class CDPSession {
     // expect in some setups to fail
     const ignoreError = () => {};
     await this.sendCDPMessage("FuseboxClient.setClientMetadata", {}).catch(ignoreError);
+    await this.sendCDPMessage("ReactNativeApplication.enable", {}).catch(ignoreError);
     await this.sendCDPMessage("Runtime.enable", {});
     await this.sendCDPMessage("Debugger.enable", { maxScriptsCacheSize: 100000000 });
     await this.sendCDPMessage("Debugger.setPauseOnExceptions", { state: "none" });


### PR DESCRIPTION
Because of changes introduced to react native in this [PR](https://github.com/facebook/react-native/commit/1a9780f0e3714ac18ffae34cb67376c711b0e031) we need to call `ReactNativeApplication.enable` through the cdp on debug session start.


### How Has This Been Tested: 

-run `react-native-78` app (For testing You'll need to disable `useReduxDevTools, isReduxDevToolsReady`  in `wrapper.js`  by hand it will be fixed by #[943](https://github.com/software-mansion/radon-ide/pull/943))



