### PR TITLE
Implement Source Request as for debug adapter protocol standard 

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -487,6 +487,32 @@ export class DebugAdapter extends DebugSession {
     this.sendResponse(response);
   }
 
+  protected async sourceRequest(
+    response: DebugProtocol.Response & {
+      body: {
+        sourceURL: string;
+        lineNumber1Based: number;
+        columnNumber0Based: number;
+        scriptURL: string;
+      };
+    },
+    args: DebugProtocol.SourceArguments & {
+      fileName: string;
+      line0Based: number;
+      column0Based: number;
+    },
+    request?: DebugProtocol.Request
+  ) {
+    response.body = {
+      ...this.sourceMapRegistry.findOriginalPosition(
+        args.fileName,
+        args.line0Based,
+        args.column0Based
+      ),
+    };
+    this.sendResponse(response);
+  }
+
   protected async variablesRequest(
     response: DebugProtocol.Response,
     args: DebugProtocol.VariablesArguments

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -82,6 +82,14 @@ export class DebugSession implements Disposable {
     return false;
   }
 
+  public async getOriginalSource(
+    fileName: string,
+    line0Based: number,
+    column0Based: number
+  ): Promise<{ sourceURL: string; lineNumber1Based: number; columnNumber0Based: number }> {
+    return await this.session.customRequest("source", { fileName, line0Based, column0Based });
+  }
+
   public resumeDebugger() {
     this.session.customRequest("continue");
   }


### PR DESCRIPTION
This PR implements `SourceRequest` in debug adapter, it is not not currently in use but might be necessary in the future, if we ever get generated source on the extension side. 

### How Has This Been Tested: 

-run `expo-52-eas`
-run `react-native-78`
-the change does not break any of the applications



