### PR TITLE
Don't force background color when in editor-theme mode

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -294,9 +294,11 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-zoom-select-separator: var(--navy-light-40);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(0deg,
-      rgba(232, 232, 232, 0.9),
-      rgba(185, 185, 185, 0.9));
+  --swm-replay-overlay-backgroud: linear-gradient(
+    0deg,
+    rgba(232, 232, 232, 0.9),
+    rgba(185, 185, 185, 0.9)
+  );
 
   --swm-replay-len-select: var(--swm-default-text);
   --swm-replay-len-select-background: var(--grey-light-60);
@@ -467,12 +469,14 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-zoom-select-separator: var(--background-dark-50);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(0deg,
-      rgba(0, 0, 0, 1),
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.5));
+  --swm-replay-overlay-backgroud: linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 1),
+    rgba(0, 0, 0, 0.5),
+    rgba(0, 0, 0, 0.5),
+    rgba(0, 0, 0, 0.5),
+    rgba(0, 0, 0, 0.5)
+  );
   --swm-replay-len-select: var(--off-white);
   --swm-replay-len-select-background: var(--background-dark-160);
   --swm-replay-len-select-hover-background: var(--background-dark-120);
@@ -651,9 +655,11 @@ body[data-use-code-theme="true"] {
   --swm-zoom-select-separator: var(--vscode-dropdown-border);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(0deg,
-      rgba(232, 232, 232, 0.9),
-      rgba(185, 185, 185, 0.9));
+  --swm-replay-overlay-backgroud: linear-gradient(
+    0deg,
+    rgba(232, 232, 232, 0.9),
+    rgba(185, 185, 185, 0.9)
+  );
 
   --swm-replay-len-select: var(--swm-default-text);
   --swm-replay-len-select-background: var(--grey-light-60);

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -294,11 +294,9 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-zoom-select-separator: var(--navy-light-40);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
-    0deg,
-    rgba(232, 232, 232, 0.9),
-    rgba(185, 185, 185, 0.9)
-  );
+  --swm-replay-overlay-backgroud: linear-gradient(0deg,
+      rgba(232, 232, 232, 0.9),
+      rgba(185, 185, 185, 0.9));
 
   --swm-replay-len-select: var(--swm-default-text);
   --swm-replay-len-select-background: var(--grey-light-60);
@@ -469,14 +467,12 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-zoom-select-separator: var(--background-dark-50);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
-    0deg,
-    rgba(0, 0, 0, 1),
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0.5),
-    rgba(0, 0, 0, 0.5)
-  );
+  --swm-replay-overlay-backgroud: linear-gradient(0deg,
+      rgba(0, 0, 0, 1),
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0.5));
   --swm-replay-len-select: var(--off-white);
   --swm-replay-len-select-background: var(--background-dark-160);
   --swm-replay-len-select-hover-background: var(--background-dark-120);
@@ -494,7 +490,7 @@ body[data-use-code-theme="true"] {
   --deep-link-history-query-match-color: var(--swm-button-background);
 
   --swm-active-item: var(--vscode-list-activeSelectionForeground);
-  --swm-preview-background: var(--vscode-editor-background);
+  --swm-preview-background: none;
 
   --swm-default-text: var(--vscode-foreground);
   --swm-marked-text: var(--vscode-editor-findMatchHighlightBackground);
@@ -655,11 +651,9 @@ body[data-use-code-theme="true"] {
   --swm-zoom-select-separator: var(--vscode-dropdown-border);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
-    0deg,
-    rgba(232, 232, 232, 0.9),
-    rgba(185, 185, 185, 0.9)
-  );
+  --swm-replay-overlay-backgroud: linear-gradient(0deg,
+      rgba(232, 232, 232, 0.9),
+      rgba(185, 185, 185, 0.9));
 
   --swm-replay-len-select: var(--swm-default-text);
   --swm-replay-len-select-background: var(--grey-light-60);


### PR DESCRIPTION
This PR makes the IDE panel adapt the background color depending on its position when in editor-theme mode.

Previously, we'd always use background color that was set to the editor background. However, depending on whether the panel is rendered in editor on in side-panel, the built-in panels have different background colors. This is particularily important in case of side-panel, where in many themes there's no delimited between the editor and side-panel, so the only way to distinguish where the panel starts is by its background color.

Before (no visual indicator when there the panel starts):
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/8ff35bbd-eeac-4deb-a866-5fc9a7674259" />
After (background defins the panel threshold):
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/a55fa119-a204-46d9-a2b7-908726c067c8" />

### How Has This Been Tested: 
1. Test switching between editor theme and Radon theme across different themes and in tab + side-panel modes:

<img width="1701" alt="image" src="https://github.com/user-attachments/assets/652e6f33-2654-4ad3-856b-d941759f3f4c" />
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/9d5132be-bf1c-41fa-87f4-becf59d35975" />
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/0f0ecdb8-ac74-4c0b-990a-40dfc6b65aee" />
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/a55fa119-a204-46d9-a2b7-908726c067c8" />




