### PR TITLE
Don't show dev tools panels before activation

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -357,6 +357,7 @@ export class Project
     this.fileWatcher.dispose();
     this.licenseWatcher.dispose();
     this.licenseUpdater.dispose();
+    this.toolsManager.dispose();
   }
 
   private async reloadMetro() {


### PR DESCRIPTION
This PR adds missing dispose to the project, object the lack of which was causing devtools panels to be visible before app was ready, if the IDE panel was closed and then opened again in one session 

### How Has This Been Tested: 

- run `react-native-78` app and check if it works properly now 



