### PR TITLE
Prevent callig hook.off from hook.on callback

### DIFF
--- a/packages/vscode-extension/lib/plugins/redux-devtools.js
+++ b/packages/vscode-extension/lib/plugins/redux-devtools.js
@@ -30,9 +30,6 @@ class RNIDEAppExtensionProxy {
   };
 
   clearDevToolsAgent() {
-    const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-    hook.off("react-devtools", this.setDevtoolsAgent);
-
     if (!this.devtoolsAgent) {
       return;
     }
@@ -63,6 +60,8 @@ class RNIDEAppExtensionProxy {
   }
 
   closeAsync() {
+    const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    hook.off("react-devtools", this.setDevtoolsAgent);
     this.clearDevToolsAgent();
     this.listeners.clear();
   }


### PR DESCRIPTION
This PR fixes issue that under certain conditions would break the devtools connection in Radon and prevent the app from loading as a consequence.

The issue could arise in situations when redux plugin is initialized before the devtools connection is established. When this happens, we rely on "react-devtools" event subscription. We call `hook.on` method to register for the event. The issue is that when the event is called we call `off` immediately from the callback. This prevents the subsequent event callback from being executed as the implementation of `hook.emit` uses `map` call and doesn't account for the fact that the array of listeners may change during iteration:
```js
function emit(event, data) {
  if (listeners[event]) {
    listeners[event].map(function (fn) {
      return fn(data);
    });
  }
}
```

The solution is to avoid calling `hook.off`. This PR moves the `off` call to `closeAsync` method that gets called when the redux plugin requests termination.

### How Has This Been Tested: 
1. This problem is hard to reproduce as it requires specific conditions to arise like delays in connecting devtools and also the moment when redux gets initialized. We could only test this on some projects that we develop for clients where this problem would happen regularly.
2. I also tested some example apps that use redux plugin for possible regressions.


