### PR TITLE
Allow tool plugins with no tool panels

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -17,7 +17,7 @@ export type DeviceSettings = {
 };
 
 export type ToolsState = {
-  [key: string]: { enabled: boolean; label: string };
+  [key: string]: { enabled: boolean; panelAvailable: boolean; label: string };
 };
 
 export type ProjectState = {

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -23,7 +23,7 @@ export interface ToolPlugin extends Disposable {
   available: boolean;
   activate(): void;
   deactivate(): void;
-  openTool(): void;
+  openTool?(): void;
 }
 
 export class ToolsManager implements Disposable {
@@ -102,6 +102,7 @@ export class ToolsManager implements Disposable {
         toolsState[id] = {
           label: plugin.label,
           enabled: this.toolsSettings[id] || false,
+          panelAvailable: plugin.openTool !== undefined,
         };
       }
     }
@@ -119,7 +120,7 @@ export class ToolsManager implements Disposable {
   public openTool(toolName: ToolKey) {
     const plugin = this.plugins.get(toolName);
     if (plugin && this.toolsSettings[toolName] && this.activePlugins.has(plugin)) {
-      plugin.openTool();
+      plugin.openTool?.();
     }
   }
 }

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -10,21 +10,25 @@ import { useProject } from "../providers/ProjectProvider";
 import IconButton from "./shared/IconButton";
 import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
+interface DevToolCheckboxProps {
+  label: string;
+  checked: boolean;
+  panelAvailable: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  onSelect: () => void;
+}
+
 function DevToolCheckbox({
   label,
   checked,
+  panelAvailable,
   onCheckedChange,
   onSelect,
-}: {
-  label: string;
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  onSelect: () => void;
-}) {
+}: DevToolCheckboxProps) {
   return (
     <div className="dropdown-menu-item">
       {label}
-      {checked && (
+      {checked && panelAvailable && (
         <IconButton onClick={onSelect}>
           <span className="codicon codicon-link-external" />
         </IconButton>
@@ -49,6 +53,7 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
         key={key}
         label={tool.label}
         checked={tool.enabled}
+        panelAvailable={tool.panelAvailable}
         onCheckedChange={async (checked) => {
           await project.updateToolEnabledState(key, checked);
           if (checked) {


### PR DESCRIPTION
Makes it possible to register tool plugins with no corresponding VSC panel. This is meant to be used by https://github.com/software-mansion/radon-ide/pull/967 

### How Has This Been Tested: 
Remove `openTool` method from one of the tool plugins and verify:
- the project still typechecks
- the tool dropdown does not display the "Open Panel" button

