### PR TITLE
Report telemetry events related to tool usage

### DIFF
--- a/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
@@ -9,6 +9,7 @@ import {
 import { IDE } from "../../project/ide";
 import { ExpoDevPluginToolName } from "./expo-dev-plugins";
 import { Logger } from "../../Logger";
+import { reportToolVisibilityChanged } from "../../project/tools";
 
 function generateWebviewContent(pluginName: ExpoDevPluginToolName, metroPort: number): string {
   const iframeURL = `http://localhost:${metroPort}/_expo/plugins/${pluginName}`;
@@ -37,6 +38,10 @@ export class ExpoDevPluginWebviewProvider implements WebviewViewProvider {
       enableScripts: true,
       localResourceRoots: [Uri.joinPath(this.context.extensionUri, "dist")],
     };
+
+    webviewView.onDidChangeVisibility(() =>
+      reportToolVisibilityChanged(this.pluginName, webviewView.visible)
+    );
 
     const metroPort = IDE.getInstanceIfExists()?.project.metro.port;
     if (!metroPort) {

--- a/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
@@ -9,7 +9,7 @@ import {
 import { IDE } from "../../project/ide";
 import { ExpoDevPluginToolName } from "./expo-dev-plugins";
 import { Logger } from "../../Logger";
-import { reportToolVisibilityChanged } from "../../project/tools";
+import { reportToolOpened, reportToolVisibilityChanged } from "../../project/tools";
 
 function generateWebviewContent(pluginName: ExpoDevPluginToolName, metroPort: number): string {
   const iframeURL = `http://localhost:${metroPort}/_expo/plugins/${pluginName}`;
@@ -34,6 +34,7 @@ export class ExpoDevPluginWebviewProvider implements WebviewViewProvider {
     context: WebviewViewResolveContext,
     token: CancellationToken
   ): void {
+    reportToolOpened(this.pluginName);
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [Uri.joinPath(this.context.extensionUri, "dist")],

--- a/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
@@ -7,7 +7,8 @@ import {
   WebviewViewResolveContext,
 } from "vscode";
 import { IDE } from "../../project/ide";
-import { NetworkPlugin } from "./network-plugin";
+import { NETWORK_PLUGIN_ID, NetworkPlugin } from "./network-plugin";
+import { reportToolVisibilityChanged } from "../../project/tools";
 
 export class NetworkDevtoolsWebviewProvider implements WebviewViewProvider {
   constructor(private readonly context: ExtensionContext) {}
@@ -32,6 +33,10 @@ export class NetworkDevtoolsWebviewProvider implements WebviewViewProvider {
     const webviewBase = webview.asWebviewUri(baseUri);
     const inspectorJsUri = webview.asWebviewUri(
       Uri.joinPath(baseUri, "entrypoints", "inspector", "inspector.js")
+    );
+
+    webviewView.onDidChangeVisibility(() =>
+      reportToolVisibilityChanged(NETWORK_PLUGIN_ID, webviewView.visible)
     );
 
     webview.html = /* html */ `

--- a/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode";
 import { IDE } from "../../project/ide";
 import { NETWORK_PLUGIN_ID, NetworkPlugin } from "./network-plugin";
-import { reportToolVisibilityChanged } from "../../project/tools";
+import { reportToolOpened, reportToolVisibilityChanged } from "../../project/tools";
 
 export class NetworkDevtoolsWebviewProvider implements WebviewViewProvider {
   constructor(private readonly context: ExtensionContext) {}
@@ -17,6 +17,7 @@ export class NetworkDevtoolsWebviewProvider implements WebviewViewProvider {
     context: WebviewViewResolveContext,
     token: CancellationToken
   ): void {
+    reportToolOpened(NETWORK_PLUGIN_ID);
     const webview = webviewView.webview;
     const baseUri = Uri.joinPath(this.context.extensionUri, "dist", "network-devtools-frontend");
     webview.options = {

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
@@ -11,6 +11,8 @@ import {
 import { extensionContext } from "../../utilities/extensionContext";
 import { getUri } from "../../utilities/getUri";
 import { getNonce } from "../../utilities/getNonce";
+import { REDUX_PLUGIN_ID } from "./redux-devtools-plugin";
+import { reportToolOpened } from "../../project/tools";
 
 const PATH = "dist/redux-devtools/";
 
@@ -111,6 +113,7 @@ export class ReduxDevToolsPluginWebviewProvider implements WebviewViewProvider {
     context: WebviewViewResolveContext,
     token: CancellationToken
   ): void {
+    reportToolOpened(REDUX_PLUGIN_ID);
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [Uri.joinPath(this.context.extensionUri, PATH)],

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -1,5 +1,5 @@
-import { commands, window } from "vscode";
-import { ToolPlugin, ToolsManager } from "../../project/tools";
+import { commands, window, Disposable } from "vscode";
+import { reportToolVisibilityChanged, ToolPlugin, ToolsManager } from "../../project/tools";
 import { extensionContext } from "../../utilities/extensionContext";
 import { ReduxDevToolsPluginWebviewProvider } from "./ReduxDevToolsPluginWebviewProvider";
 
@@ -27,9 +27,14 @@ function initializeReduxDevPlugin() {
 
 export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
   const webViewProvider = initializeReduxDevPlugin();
+  let disposables: Disposable[] = [];
+  let disposed = false;
 
   let proxyDevtoolsListener: null | ((event: string, payload: any) => void) = null;
   webViewProvider?.setListener((webview) => {
+    if (disposed) {
+      return;
+    }
     proxyDevtoolsListener = (event: string, payload: any) => {
       if (event === REDUX_PLUGIN_ID) {
         webview.webview.postMessage({
@@ -41,18 +46,26 @@ export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
 
     toolsManager.devtools.addListener(proxyDevtoolsListener);
 
-    webview.webview.onDidReceiveMessage((message) => {
-      const { scope, ...data } = message;
-      toolsManager.devtools.send(scope, data);
-    });
+    disposables.push(
+      webview.webview.onDidReceiveMessage((message) => {
+        const { scope, ...data } = message;
+        toolsManager.devtools.send(scope, data);
+      })
+    );
+    disposables.push(
+      webview.onDidChangeVisibility(() =>
+        reportToolVisibilityChanged(REDUX_PLUGIN_ID, webview.visible)
+      )
+    );
   });
 
-  let disposed = false;
   function dispose() {
     if (!disposed) {
       if (proxyDevtoolsListener) {
         toolsManager.devtools.removeListener(proxyDevtoolsListener);
       }
+      disposables.forEach((d) => d.dispose());
+      disposables = [];
       disposed = true;
     }
   }

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -2,6 +2,7 @@ import { commands, window, Disposable } from "vscode";
 import { reportToolVisibilityChanged, ToolPlugin, ToolsManager } from "../../project/tools";
 import { extensionContext } from "../../utilities/extensionContext";
 import { ReduxDevToolsPluginWebviewProvider } from "./ReduxDevToolsPluginWebviewProvider";
+import { disposeAll } from "../../utilities/disposables";
 
 export const REDUX_PLUGIN_ID = "RNIDE-redux-devtools";
 const REDUX_PLUGIN_PREFIX = "RNIDE.Tool.ReduxDevTools";
@@ -64,8 +65,7 @@ export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
       if (proxyDevtoolsListener) {
         toolsManager.devtools.removeListener(proxyDevtoolsListener);
       }
-      disposables.forEach((d) => d.dispose());
-      disposables = [];
+      disposeAll(disposables);
       disposed = true;
     }
   }

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -27,6 +27,11 @@ export interface ToolPlugin extends Disposable {
   openTool?(): void;
 }
 
+export function reportToolVisibilityChanged(toolName: ToolKey, visible: boolean) {
+  const visibility = visible ? "visible" : "hidden";
+  getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:visibility:${visibility}`);
+}
+
 export class ToolsManager implements Disposable {
   private toolsSettings: Partial<Record<ToolKey, boolean>> = {};
   private plugins: Map<ToolKey, ToolPlugin> = new Map();

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -32,6 +32,10 @@ export function reportToolVisibilityChanged(toolName: ToolKey, visible: boolean)
   getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:visibility:${visibility}`);
 }
 
+export function reportToolOpened(toolName: ToolKey) {
+  getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:opened`);
+}
+
 export class ToolsManager implements Disposable {
   private toolsSettings: Partial<Record<ToolKey, boolean>> = {};
   private plugins: Map<ToolKey, ToolPlugin> = new Map();

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -12,6 +12,7 @@ import {
   REDUX_PLUGIN_ID,
   createReduxDevtools,
 } from "../plugins/redux-devtools-plugin/redux-devtools-plugin";
+import { getTelemetryReporter } from "../utilities/telemetry";
 
 const TOOLS_SETTINGS_KEY = "tools_settings";
 
@@ -113,6 +114,7 @@ export class ToolsManager implements Disposable {
     if (this.plugins.has(toolName)) {
       this.toolsSettings[toolName] = enabled;
       extensionContext.workspaceState.update(TOOLS_SETTINGS_KEY, this.toolsSettings);
+      this.reportToolEnabled(toolName, enabled);
       this.handleStateChange();
     }
   }
@@ -121,6 +123,12 @@ export class ToolsManager implements Disposable {
     const plugin = this.plugins.get(toolName);
     if (plugin && this.toolsSettings[toolName] && this.activePlugins.has(plugin)) {
       plugin.openTool?.();
+      getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:opened`);
     }
+  }
+
+  private reportToolEnabled(toolName: ToolKey, enabled: boolean) {
+    const enabledString = enabled ? "enabled" : "disabled";
+    getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:${enabledString}`);
   }
 }

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -128,7 +128,6 @@ export class ToolsManager implements Disposable {
     const plugin = this.plugins.get(toolName);
     if (plugin && this.toolsSettings[toolName] && this.activePlugins.has(plugin)) {
       plugin.openTool?.();
-      getTelemetryReporter().sendTelemetryEvent(`tools:${toolName}:opened`);
     }
   }
 


### PR DESCRIPTION
Reports telemetry events related to tool usage:
- enable/disable tool
- opening from tools dropdown
- toggling webview visibility
### How Has This Been Tested: 
By placing breakpoints on `getTelemetryReporter` calls and toggling/opening/hiding the tools


