### PR TITLE
Fix Path Set Up Process

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -22,7 +22,10 @@ async function getPathEnv(appRoot: string) {
     "-i",
     "-c",
     `cd "${appRoot}" && echo "${RNIDE_PATH_DELIMITER}$PATH${RNIDE_PATH_DELIMITER}"`,
-  ]);
+  ],{
+    extendEnv:false,
+    env:{}
+  });
   const path = stdout.split(RNIDE_PATH_DELIMITER)[1].trim();
   Logger.debug("Obtained PATH environment variable:", path);
   return path;


### PR DESCRIPTION
This PR fixes a problem with extension not being able to refresh node version after it was changed by nvm. Even when the extension was deactivated and activated again. This would in turn lead to user frustration when the node version they ware using was in initially incorrect and applied user solution would not take effect. 

The issue was triggered when the following conditions were met: 
- process vscode was either not restarted completely, or was opened from terminal that would hold the old configuration
- the `$HOME/.nvm/versions/node/{NODE_VERSION}/bin` path was the first one in vscodes path

Because we would open a new shell with vscode processes path passed as an env variable it wouldn't start completely fresh and nvm scripts located in `.zshrc` files  responsible for aliasing seem to have an optimization to not  change the version path if it was already the newest one, causing as receiving the old path to node still living in vscode process.

The solution is to strip the env of a new shell process and allow it to boot fresh. 

### How Has This Been Tested: 

- run `react-native-78` and set a brakepoint after path was recived, run it in following configurations:
    - run with a node 21 
    - reload after switching the node version in seprate terminal 
    - run from scratch 