### PR TITLE
improve url experience - get routes based on file based routing

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -360,6 +360,20 @@ export function AppWrapper({ children, initialProps, fabric }) {
     []
   );
 
+  useAgentListener(devtoolsAgent, "RNIDE_loadFileBasedRoutes", (payload) => {
+    // todo: maybe rename it to `navigationState` or something like that because this is not just history anymore.
+    for (const route of payload) {
+      navigationHistory.set(route.id, route);
+    }
+    devtoolsAgent?._bridge.send(
+      "RNIDE_navigationInit",
+      payload.map((route) => ({
+        displayName: route.name,
+        id: route.id,
+      }))
+    );
+  });
+
   useEffect(() => {
     if (devtoolsAgent) {
       LogBox.uninstall();

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -125,6 +125,7 @@ export interface ProjectEventMap {
   needsNativeRebuild: void;
   replayDataCreated: MultimediaData;
   isRecording: boolean;
+  navigationInit: { displayName: string; id: string }[];
 }
 
 export interface ProjectEventListener<T> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -352,7 +352,7 @@ async function findAppRootCandidates(): Promise<string[]> {
   return candidates;
 }
 
-async function findAppRootFolder() {
+export async function findAppRootFolder() {
   const launchConfiguration = getLaunchConfiguration();
   const appRootFromLaunchConfig = launchConfiguration.appRoot;
   if (appRootFromLaunchConfig) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -26,6 +26,7 @@ export type AppEvent = {
   navigationChanged: { displayName: string; id: string };
   fastRefreshStarted: undefined;
   fastRefreshComplete: undefined;
+  navigationInit: { displayName: string; id: string }[];
 };
 
 export type EventDelegate = {
@@ -78,6 +79,9 @@ export class DeviceSession implements Disposable {
           break;
         case "RNIDE_navigationChanged":
           this.eventDelegate.onAppEvent("navigationChanged", payload);
+          break;
+        case "RNIDE_navigationInit":
+          this.eventDelegate.onAppEvent("navigationInit", payload);
           break;
         case "RNIDE_fastRefreshStarted":
           this.eventDelegate.onAppEvent("fastRefreshStarted", undefined);

--- a/packages/vscode-extension/src/utilities/getFileBasedRoutes.ts
+++ b/packages/vscode-extension/src/utilities/getFileBasedRoutes.ts
@@ -1,0 +1,84 @@
+import path from "path";
+import fs from "fs";
+import { findAppRootFolder } from "../extension";
+
+// assuming that people may put them in the app folder
+const DIRS_TO_SKIP = ["components", "(components)", "utils", "hooks"];
+
+function computeRouteIdentifier(pathname: string, params = {}) {
+  return pathname + JSON.stringify(params);
+}
+
+export type Route = {
+  name: string;
+  pathname: string;
+  params: Record<string, any>;
+  id: string;
+};
+
+function createRoute(pathname: string): Route {
+  pathname = pathname.replace(/\/?\([^)]*\)/g, "");
+  return {
+    id: computeRouteIdentifier(pathname),
+    pathname,
+    name: pathname,
+    params: {},
+  };
+}
+
+function handleIndexRoute(basePath: string): Route {
+  const pathname = basePath || "/";
+  return createRoute(pathname);
+}
+
+function handleParameterizedRoute(basePath: string, route: string): Route {
+  const pathname = `${basePath}/${route}`;
+  return createRoute(pathname);
+}
+
+function handleRegularRoute(basePath: string, route: string): Route {
+  const pathname = `${basePath}/${route}`;
+  return createRoute(pathname);
+}
+
+async function getRoutes(dir: string, basePath: string = ""): Promise<Route[]> {
+  let routes: Route[] = [];
+  try {
+    const files = await fs.promises.readdir(dir);
+
+    for (const file of files) {
+      const fullPath = path.join(dir, file);
+      const stat = await fs.promises.stat(fullPath);
+
+      if (stat.isDirectory()) {
+        if (DIRS_TO_SKIP.includes(file)) {
+          continue;
+        }
+        routes = routes.concat(await getRoutes(fullPath, `${basePath}/${file}`));
+      } else if (
+        file.endsWith(".js") ||
+        (file.endsWith(".tsx") && !file.includes("_layout") && !file.includes("[")) // omit [] dynamic routes
+      ) {
+        const route = file.replace(/(\.js|\.tsx)$/, "");
+        if (route === "index") {
+          routes.push(handleIndexRoute(basePath));
+        } else if (route.startsWith("[") && route.endsWith("]")) {
+          routes.push(handleParameterizedRoute(basePath, route));
+        } else {
+          routes.push(handleRegularRoute(basePath, route));
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading directory ${dir}:`, error);
+  }
+  return routes;
+}
+
+export async function getAppRoutes() {
+  const appRoot = await findAppRootFolder();
+  if (!appRoot) {
+    return [];
+  }
+  return getRoutes(path.join(appRoot, "app"));
+}

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import { useProject } from "../providers/ProjectProvider";
 import UrlSelect, { UrlItem } from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";
@@ -39,11 +39,23 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const [urlList, setUrlList] = useState<UrlItem[]>([]);
   const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
   const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id);
+  const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id ?? "/{}");
 
   useEffect(() => {
     function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {
       return [newUrl, ...urls.filter((record) => record.id !== newUrl.id)];
+    }
+
+    function handleNavigationInit(navigationData: { displayName: string; id: string }[]) {
+      const entries: Record<string, UrlItem> = {};
+      urlList.forEach((item) => {
+        entries[item.id] = item;
+      });
+      navigationData.forEach((item) => {
+        entries[item.id] = { ...item, name: item.displayName };
+      });
+      const merged = Object.values(entries);
+      setUrlList(merged);
     }
 
     function handleNavigationChanged(navigationData: { displayName: string; id: string }) {
@@ -72,8 +84,10 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
       setBackNavigationPath("");
     }
 
+    project.addListener("navigationInit", handleNavigationInit);
     project.addListener("navigationChanged", handleNavigationChanged);
     return () => {
+      project.removeListener("navigationInit", handleNavigationInit);
       project.removeListener("navigationChanged", handleNavigationChanged);
     };
   }, [recentUrlList, urlHistory, backNavigationPath]);

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -58,7 +58,7 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
             </Select.Group>
             <Select.Separator className="url-select-separator" />
             <Select.Group>
-              <Select.Label className="url-select-label">All visited paths:</Select.Label>
+              <Select.Label className="url-select-label">All paths:</Select.Label>
               {items.map(
                 (item) =>
                   item.name && (


### PR DESCRIPTION
This PR improves how expo router integration works.
These changes add initial routes based on the file based routing that allows to use this integration immediately without the need to visit them at first.

### How Has This Been Tested: 

The basic routes (excluding dynamic because currently this integration does not allow to input dynamic values, so it does not make sense including them) should be visible and clickable (first start, after reload, after restart, ...all the time)




https://github.com/user-attachments/assets/b8e2a63b-6808-4d9b-a9b1-4b5b1685b4a9



