### PR TITLE
Additional expo detection method

### DIFF
--- a/packages/vscode-extension/src/utilities/expoCli.ts
+++ b/packages/vscode-extension/src/utilities/expoCli.ts
@@ -20,12 +20,18 @@ export function shouldUseExpoCLI() {
 
   const appRootFolder = getAppRootFolder();
   let hasExpoCLIInstalled = false,
-    hasExpoCommandsInScripts = false;
+    hasExpoCommandsInScripts = false,
+    hasExpoConfigInAppJson = false;
   try {
     hasExpoCLIInstalled =
       require.resolve("@expo/cli/build/src/start/index", {
         paths: [appRootFolder],
       }) !== undefined;
+  } catch (e) {}
+
+  try {
+    const appJson = require(path.join(appRootFolder, "app.json"));
+    hasExpoConfigInAppJson = Object.keys(appJson).includes("expo");
   } catch (e) {}
 
   try {
@@ -35,5 +41,5 @@ export function shouldUseExpoCLI() {
     });
   } catch (e) {}
 
-  return hasExpoCLIInstalled && hasExpoCommandsInScripts;
+  return hasExpoCLIInstalled && (hasExpoCommandsInScripts || hasExpoConfigInAppJson);
 }

--- a/packages/vscode-extension/src/utilities/expoCli.ts
+++ b/packages/vscode-extension/src/utilities/expoCli.ts
@@ -21,7 +21,8 @@ export function shouldUseExpoCLI() {
   const appRootFolder = getAppRootFolder();
   let hasExpoCLIInstalled = false,
     hasExpoCommandsInScripts = false,
-    hasExpoConfigInAppJson = false;
+    hasExpoConfigInAppJson = false,
+    hasExpoConfigInAppConfigJs = false;
   try {
     hasExpoCLIInstalled =
       require.resolve("@expo/cli/build/src/start/index", {
@@ -35,11 +36,19 @@ export function shouldUseExpoCLI() {
   } catch (e) {}
 
   try {
+    const appConfigJs = require(path.join(appRootFolder, "app.config.js"));
+    hasExpoConfigInAppConfigJs = Object.keys(appConfigJs).includes("expo");
+  } catch (e) {}
+
+  try {
     const packageJson = require(path.join(appRootFolder, "package.json"));
     hasExpoCommandsInScripts = Object.values<string>(packageJson.scripts).some((script: string) => {
       return script.includes("expo ");
     });
   } catch (e) {}
 
-  return hasExpoCLIInstalled && (hasExpoCommandsInScripts || hasExpoConfigInAppJson);
+  return (
+    hasExpoCLIInstalled &&
+    (hasExpoCommandsInScripts || hasExpoConfigInAppJson || hasExpoConfigInAppConfigJs)
+  );
 }

--- a/packages/vscode-extension/src/utilities/expoCli.ts
+++ b/packages/vscode-extension/src/utilities/expoCli.ts
@@ -42,7 +42,7 @@ export function shouldUseExpoCLI() {
   } catch (e) {}
 
   try {
-    const packageJson = require(path.join(appRootFolder, "package.json"));
+    const packageJson = requireNoCache(path.join(appRootFolder, "package.json"));
     hasExpoCommandsInScripts = Object.values<string>(packageJson.scripts).some((script: string) => {
       return script.includes("expo ");
     });

--- a/packages/vscode-extension/src/utilities/expoCli.ts
+++ b/packages/vscode-extension/src/utilities/expoCli.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { getAppRootFolder } from "./extensionContext";
 import { getLaunchConfiguration } from "./launchConfiguration";
+import { requireNoCache } from "./requireNoCache";
 
 export function shouldUseExpoCLI() {
   // The mechanism for detecting whether the project should use Expo CLI or React Native Community CLI works as follows:
@@ -19,10 +20,10 @@ export function shouldUseExpoCLI() {
   }
 
   const appRootFolder = getAppRootFolder();
-  let hasExpoCLIInstalled = false,
-    hasExpoCommandsInScripts = false,
-    hasExpoConfigInAppJson = false,
-    hasExpoConfigInAppConfigJs = false;
+  let hasExpoCLIInstalled = false;
+  let hasExpoCommandsInScripts = false;
+  let hasExpoConfigInAppJson = false;
+  let hasExpoConfigInAppConfigJs = false;
   try {
     hasExpoCLIInstalled =
       require.resolve("@expo/cli/build/src/start/index", {
@@ -31,12 +32,12 @@ export function shouldUseExpoCLI() {
   } catch (e) {}
 
   try {
-    const appJson = require(path.join(appRootFolder, "app.json"));
+    const appJson = requireNoCache(path.join(appRootFolder, "app.json"));
     hasExpoConfigInAppJson = Object.keys(appJson).includes("expo");
   } catch (e) {}
 
   try {
-    const appConfigJs = require(path.join(appRootFolder, "app.config.js"));
+    const appConfigJs = requireNoCache(path.join(appRootFolder, "app.config.js"));
     hasExpoConfigInAppConfigJs = Object.keys(appConfigJs).includes("expo");
   } catch (e) {}
 


### PR DESCRIPTION
This PR adds additional method for detecting if expo is used in the user application. The current method was assuming that if expo is used, users have defined scripts that use, expo CLI in their package json. This assumption unfortunately does not hold true for every user especially those using exclusively eas builds. To solve that issue we also check if a user has `"expo"`, configuration in their `app.json`. 

### How Has This Been Tested: 

Run `expo-52-prebuild-with-plugins` test app and remove all scripts form `package.json` before the change  rudon would crash, after it works. 


