### PR TITLE
Allow tools to not persist their status

### DIFF
--- a/packages/vscode-extension/src/plugins/expo-dev-plugins/expo-dev-plugins.ts
+++ b/packages/vscode-extension/src/plugins/expo-dev-plugins/expo-dev-plugins.ts
@@ -57,6 +57,7 @@ export function createExpoDevPluginTools(): ToolPlugin[] {
       id: id as ExpoDevPluginToolName,
       label: pluginInfo.label,
       available: false,
+      persist: true,
       activate() {
         commands.executeCommand("setContext", `${pluginInfo.viewIdPrefix}.available`, true);
       },

--- a/packages/vscode-extension/src/plugins/network/network-plugin.ts
+++ b/packages/vscode-extension/src/plugins/network/network-plugin.ts
@@ -92,6 +92,7 @@ export class NetworkPlugin implements ToolPlugin {
   public readonly label = "Network";
 
   public available = false;
+  public readonly persist = true;
 
   private readonly websocketBackend;
 

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -74,6 +74,7 @@ export const createReduxDevtools = (toolsManager: ToolsManager): ToolPlugin => {
     id: REDUX_PLUGIN_ID,
     label: "Redux DevTools",
     available: false,
+    persist: true,
     activate() {
       commands.executeCommand("setContext", `${REDUX_PLUGIN_PREFIX}.available`, true);
     },


### PR DESCRIPTION
Allows tools to configure (via the `persist` boolean property) whether their enabled/disabled status should persist IDE restarts.
This is motivated by the "Outline Renders" tool (PR #967), which shouldn't be enabled when the IDE starts.

### How Has This Been Tested: 
- change the `persist` value for one of the tool plugins to `false`
- verify that when the extension is restarted:
  - tools which have `persist` set to `true` remember their status
  - tools which have `persist` set to `false` are disabled
