### PR TITLE
Add Radon IDE version info to settings dropdown

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -38,6 +38,12 @@
   margin-bottom: 20px;
 }
 
+.device-settings-version-text {
+  font-size: 80%;
+  justify-content: center;
+  color: var(--swm-disabled-text);
+}
+
 .icons-container {
   display: flex;
   align-items: center;

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -28,6 +28,10 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
   const { movePanelToNewWindow, reportIssue } = useUtils();
   const { telemetryEnabled } = useTelemetry();
 
+  const extensionVersion = document.querySelector<HTMLMetaElement>(
+    "meta[name='radon-ide-version']"
+  )?.content;
+
   return (
     <DropdownMenuRoot>
       <DropdownMenu.Trigger asChild disabled={disabled}>
@@ -177,6 +181,9 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>
           {telemetryEnabled && <SendFeedbackItem />}
+          <div className="dropdown-menu-item device-settings-version-text">
+            Radon IDE version: {extensionVersion}
+          </div>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenuRoot>


### PR DESCRIPTION
This PR adds version information to settings banner. This will make it easier for the users to tell which version they are running as sometimes even though the extension is updated, users may forget to reload extension in which case the new version despite being listed as installed is not running/

<img width="499" alt="image" src="https://github.com/user-attachments/assets/35c46ed9-60e3-4152-bc6f-6f9fe6025f17" />
<img width="502" alt="image" src="https://github.com/user-attachments/assets/32c09eac-58fd-49e3-948e-7d89d3686925" />


### How Has This Been Tested: 
1. Open device settings dropdown
2. See the current version there. Check it under different vscode themes 
