### PR TITLE
Fix CapsLock handling

### DIFF
--- a/packages/vscode-extension/src/webview/Preview/hooks.ts
+++ b/packages/vscode-extension/src/webview/Preview/hooks.ts
@@ -2,15 +2,35 @@ import { useRef, useCallback } from "react";
 import { keyboardEventToHID } from "../utilities/keyMapping";
 import { useProject } from "../providers/ProjectProvider";
 
+const CAPS_LOCK_HID_CODE = 57;
+
 export function useKeyPresses() {
   const pressedKeys = useRef(new Set<number>());
+  const lastKnownCapsLockState = useRef(false);
   const { project } = useProject();
 
   const dispatchKeyPress = useCallback((e: KeyboardEvent) => {
-    const isKeydown = e.type === "keydown";
+    // CapsLock is a special case, since it fires only a keydown event when it's turned on, and only a keyup event when it's turned off.
+    // However, the devices expect a full keydown-keyup sequence to properly toggle CapsLock state, and go out of sync otherwise. Moreover,
+    // CapsLock can go out of sync if it's toggled outside of the context of the webview. To prevent this, we have to send full keydown-keyup
+    // sequence whenever CapsLock is pressed or when we detect that it has gone out of sync when handling other keys.
+    const isCapsLockActive = e.getModifierState("CapsLock");
+
+    if (isCapsLockActive !== lastKnownCapsLockState.current) {
+      lastKnownCapsLockState.current = isCapsLockActive;
+      project.dispatchKeyPress(CAPS_LOCK_HID_CODE, "Down");
+      project.dispatchKeyPress(CAPS_LOCK_HID_CODE, "Up");
+    }
+
     const hidCode = keyboardEventToHID(e);
 
     if (hidCode) {
+      if (hidCode === CAPS_LOCK_HID_CODE) {
+        return;
+      }
+
+      const isKeydown = e.type === "keydown";
+
       if (isKeydown) {
         pressedKeys.current.add(hidCode);
       } else {


### PR DESCRIPTION
This PR fixes handling CapsLock by taking into account that simulators expect full keydown-keyup sequence to properly trigger CapsLock – currently, we only send a keydown when enabling CapsLock and defer sending keyup up until its deactivation, leading to desynchronization of CapsLock state. It also introduces reading CapsLock state from incoming inputs and synchronizing its state on the device, preventing desynchronization when pressing CapsLock with unfocused preview.

### How Has This Been Tested: 

Verified that CapsLock is synchronized properly when using the IDE, as well as when changing its state outside and coming back to IDE.



