### PR TITLE
Add option to record and preview CPU profile of the app

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -125,6 +125,7 @@ export interface ProjectEventMap {
   needsNativeRebuild: void;
   replayDataCreated: MultimediaData;
   isRecording: boolean;
+  isProfilingCPU: boolean;
 }
 
 export interface ProjectEventListener<T> {
@@ -174,6 +175,9 @@ export interface ProjectInterface {
   captureAndStopRecording(): void;
   captureReplay(): void;
   captureScreenshot(): void;
+
+  startProfilingCPU(): void;
+  stopProfilingCPU(): void;
 
   dispatchTouches(touches: Array<TouchPoint>, type: "Up" | "Move" | "Down"): void;
   dispatchKeyPress(keyCode: number, direction: "Up" | "Down"): void;

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -10,6 +10,8 @@ export type DebugSessionDelegate = {
   onConsoleLog(event: DebugSessionCustomEvent): void;
   onDebuggerPaused(event: DebugSessionCustomEvent): void;
   onDebuggerResumed(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStarted(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStopped(event: DebugSessionCustomEvent): void;
 };
 
 export class DebugSession implements Disposable {
@@ -27,6 +29,12 @@ export class DebugSession implements Disposable {
           break;
         case "RNIDE_continued":
           this.delegate.onDebuggerResumed(event);
+          break;
+        case "RNIDE_profilingCPUStarted":
+          this.delegate.onProfilingCPUStarted(event);
+          break;
+        case "RNIDE_profilingCPUStopped":
+          this.delegate.onProfilingCPUStopped(event);
           break;
         default:
           // ignore other events
@@ -96,6 +104,14 @@ export class DebugSession implements Disposable {
 
   public stepOverDebugger() {
     this.session.customRequest("next");
+  }
+
+  public async startProfilingCPU() {
+    await this.session.customRequest("startProfiling");
+  }
+
+  public async stopProfilingCPU() {
+    await this.session.customRequest("stopProfiling");
   }
 
   private get session() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -313,6 +313,22 @@ export class DeviceSession implements Disposable {
     return this.device.captureScreenshot();
   }
 
+  public async startProfilingCPU() {
+    if (this.debugSession) {
+      await this.debugSession.startProfilingCPU();
+    } else {
+      throw new Error("Debug session not started");
+    }
+  }
+
+  public async stopProfilingCPU() {
+    if (this.debugSession) {
+      await this.debugSession.stopProfilingCPU();
+    } else {
+      throw new Error("Debug session not started");
+    }
+  }
+
   public sendTouches(touches: Array<TouchPoint>, type: "Up" | "Move" | "Down") {
     this.device.sendTouches(touches, type);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -215,6 +215,30 @@ export class Project
     return this.deviceSession.captureAndStopRecording();
   }
 
+  async startProfilingCPU() {
+    if (this.deviceSession) {
+      await this.deviceSession.startProfilingCPU();
+    } else {
+      throw new Error("No device session available");
+    }
+  }
+
+  async stopProfilingCPU() {
+    if (this.deviceSession) {
+      await this.deviceSession.stopProfilingCPU();
+    } else {
+      throw new Error("No device session available");
+    }
+  }
+
+  onProfilingCPUStarted(event: DebugSessionCustomEvent): void {
+    this.eventEmitter.emit("isProfilingCPU", true);
+  }
+
+  onProfilingCPUStopped(event: DebugSessionCustomEvent): void {
+    this.eventEmitter.emit("isProfilingCPU", false);
+  }
+
   async captureAndStopRecording() {
     const recording = await this.stopRecording();
     await this.utils.saveMultimedia(recording);

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -9,6 +9,7 @@ import "./ToolsDropdown.css";
 import { useProject } from "../providers/ProjectProvider";
 import IconButton from "./shared/IconButton";
 import { DropdownMenuRoot } from "./DropdownMenuRoot";
+import Label from "./shared/Label";
 
 interface DevToolCheckboxProps {
   label: string;
@@ -75,6 +76,16 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
           className="dropdown-menu-content device-settings-content"
           onCloseAutoFocus={(e) => e.preventDefault()}>
           <h4 className="device-settings-heading">Tools</h4>
+          <Label>Utilities</Label>
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
+            onSelect={() =>
+              isProfilingCPU ? project.stopProfilingCPU() : project.startProfilingCPU()
+            }>
+            <span className="codicon codicon-chip" />
+            {isProfilingCPU ? "Stop JS CPU Profiler" : "Start JS CPU Profiler"}
+          </DropdownMenu.Item>
+          <Label>Tool Panels</Label>
           {toolEntries}
           {toolEntries.length === 0 && (
             <div className="tools-empty-message">
@@ -82,13 +93,6 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
               <a href="https://ide.swmansion.com/docs/features/dev-tools">Learn more</a>
             </div>
           )}
-          <DropdownMenu.Item
-            className="dropdown-menu-item"
-            onSelect={() =>
-              isProfilingCPU ? project.stopProfilingCPU() : project.startProfilingCPU()
-            }>
-            {isProfilingCPU ? "Stop JS Profiler" : "Start JS Profiler"}
-          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -45,7 +45,7 @@ function DevToolCheckbox({
 }
 
 function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) {
-  const { project, toolsState } = useProject();
+  const { project, toolsState, isProfilingCPU } = useProject();
 
   const toolEntries = Object.entries(toolsState).map(([key, tool]) => {
     return (
@@ -82,6 +82,13 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
               <a href="https://ide.swmansion.com/docs/features/dev-tools">Learn more</a>
             </div>
           )}
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
+            onSelect={() =>
+              isProfilingCPU ? project.stopProfilingCPU() : project.startProfilingCPU()
+            }>
+            {isProfilingCPU ? "Stop JS Profiler" : "Start JS Profiler"}
+          </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>
     </DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -1,6 +1,5 @@
 :root {
-  --url-select-min-width: 130px;
-  --url-select-max-width: 300px;
+  --url-select-max-width: 200px;
 }
 
 .url-select-trigger {
@@ -19,7 +18,8 @@
   color: var(--swm-url-select);
   background-color: var(--swm-url-select-background);
   user-select: none;
-  min-width: var(--url-select-min-width);
+  max-width: var(--url-select-max-width);
+  flex: 1;
 }
 .url-select-trigger:hover {
   background-color: var(--swm-url-select-hover-background);

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -28,6 +28,7 @@ interface ProjectContextProps {
   replayData: MultimediaData | undefined;
   setReplayData: Dispatch<SetStateAction<MultimediaData | undefined>>;
   isRecording: boolean;
+  isProfilingCPU: boolean;
 }
 
 const defaultProjectState: ProjectState = {
@@ -61,6 +62,7 @@ const ProjectContext = createContext<ProjectContextProps>({
   replayData: undefined,
   setReplayData: () => {},
   isRecording: false,
+  isProfilingCPU: false,
 });
 
 export default function ProjectProvider({ children }: PropsWithChildren) {
@@ -69,6 +71,7 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
   const [toolsState, setToolsState] = useState<ToolsState>({});
   const [hasActiveLicense, setHasActiveLicense] = useState(true);
   const [isRecording, setIsRecording] = useState(false);
+  const [isProfilingCPU, setIsProfilingCPU] = useState(false);
   const [replayData, setReplayData] = useState<MultimediaData | undefined>(undefined);
 
   useEffect(() => {
@@ -86,6 +89,8 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
 
     project.addListener("isRecording", setIsRecording);
     project.addListener("replayDataCreated", setReplayData);
+
+    project.addListener("isProfilingCPU", setIsProfilingCPU);
 
     return () => {
       project.removeListener("projectStateChanged", setProjectState);
@@ -105,6 +110,7 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
       replayData,
       setReplayData,
       isRecording,
+      isProfilingCPU,
     };
   }, [
     projectState,
@@ -115,6 +121,7 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     replayData,
     setReplayData,
     isRecording,
+    isProfilingCPU,
   ]);
 
   return <ProjectContext.Provider value={contextValue}>{children}</ProjectContext.Provider>;

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -570,7 +570,8 @@ body[data-use-code-theme="true"] {
   --swm-button-counter-background: var(--vscode-activityBarBadge-background);
   --swm-button-counter-border: var(--vscode-contrastBorder);
 
-  --swm-button-recording-on-background: var(--navy-light-60);
+  --swm-button-recording-on: var(--vscode-activityBarBadge-foreground);
+  --swm-button-recording-on-background: var(--vscode-activityBarBadge-background);
   --swm-button-replay-hover: var(--navy-light-transparent);
 
   /* Tooltip */

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -1,10 +1,20 @@
 .button-group-top,
 .button-group-bottom {
   display: flex;
-  align-items: center;
+  justify-content: space-between;
   width: 100%;
   margin: 8px;
   gap: 4px;
+}
+
+.button-group-top-left,
+.button-group-top-right {
+  display: flex;
+  flex-direction: row;
+}
+
+.button-group-top-left {
+  flex: 1;
 }
 
 .icons-rewind:before {
@@ -71,10 +81,31 @@
 .recording-rec-indicator {
   display: flex;
   align-items: center;
-  color: white;
+  color: var(--swm-button-recording-on);
   font-size: 120%;
   filter: blur(0.4px);
   font-family: "Courier new", fixed;
+}
+
+.icon-red {
+  color: red;
+  font-size: 24px;
+  scale: 2.8;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(0.85);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .recording-rec-dot {
@@ -84,6 +115,7 @@
   align-self: center;
   border-radius: 50%;
   margin-right: 6px;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 @media (max-width: 385px) {

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -73,17 +73,17 @@
 .button-recording-on,
 .button-recording-on:hover {
   background-color: var(--swm-button-recording-on-background);
+  color: var(--swm-button-recording-on);
+  border: 1px solid var(--swm-button-counter-border);
   border-radius: 10px;
   width: auto;
-  padding: 0 5px 0 8px;
+  padding: 0 8px;
 }
 
 .recording-rec-indicator {
   display: flex;
   align-items: center;
-  color: var(--swm-button-recording-on);
   font-size: 120%;
-  filter: blur(0.4px);
   font-family: "Courier new", fixed;
 }
 

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -175,17 +175,20 @@ function PreviewView() {
           <UrlBar key={resetKey} disabled={hasNoDevices} />
         </div>
         <div className="button-group-top-right">
-          {isProfilingCPU && (
-            <IconButton
-              className="button-recording-on"
-              tooltip={{
-                label: "Stop profiling CPU",
-              }}
-              onClick={stopProfilingCPU}>
-              <div className="recording-rec-dot" />
-              <span>Profiling CPU&nbsp;</span>
-            </IconButton>
-          )}
+          <IconButton
+            className={isProfilingCPU ? "button-recording-on" : ""}
+            tooltip={{
+              label: "Stop profiling CPU",
+            }}
+            disabled={!isProfilingCPU}
+            onClick={stopProfilingCPU}>
+            {isProfilingCPU && (
+              <>
+                <div className="recording-rec-dot" />
+                <span>Profiling CPU</span>
+              </>
+            )}
+          </IconButton>
           <ToolsDropdown disabled={hasNoDevices || !isRunning}>
             <IconButton tooltip={{ label: "Tools", type: "primary" }}>
               <span className="codicon codicon-tools" />

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -42,6 +42,7 @@ function PreviewView() {
     hasActiveLicense,
     replayData,
     isRecording,
+    isProfilingCPU,
     setReplayData,
   } = useProject();
   const { showDismissableError } = useUtils();
@@ -136,6 +137,10 @@ function PreviewView() {
     }
   }
 
+  function stopProfilingCPU() {
+    project.stopProfilingCPU();
+  }
+
   async function handleReplay() {
     try {
       await project.captureReplay();
@@ -166,64 +171,78 @@ function PreviewView() {
   return (
     <div className="panel-view">
       <div className="button-group-top">
-        <UrlBar key={resetKey} disabled={hasNoDevices} />
-        <div className="spacer" />
-        <ToolsDropdown disabled={hasNoDevices || !isRunning}>
-          <IconButton tooltip={{ label: "Tools", type: "primary" }}>
-            <span className="codicon codicon-tools" />
-          </IconButton>
-        </ToolsDropdown>
-        <IconButton
-          className={isRecording ? "button-recording-on" : ""}
-          tooltip={{
-            label: isRecording ? "Stop screen recording" : "Start screen recording",
-          }}
-          onClick={toggleRecording}
-          disabled={isStarting}>
-          {isRecording ? (
-            <div className="recording-rec-indicator">
+        <div className="button-group-top-left">
+          <UrlBar key={resetKey} disabled={hasNoDevices} />
+        </div>
+        <div className="button-group-top-right">
+          {isProfilingCPU && (
+            <IconButton
+              className="button-recording-on"
+              tooltip={{
+                label: "Stop profiling CPU",
+              }}
+              onClick={stopProfilingCPU}>
               <div className="recording-rec-dot" />
-              <span>{recordingTimeFormat}</span>
-            </div>
-          ) : (
-            <RecordingIcon />
+              <span>Profiling CPU&nbsp;</span>
+            </IconButton>
           )}
-        </IconButton>
-        {showReplayButton && (
+          <ToolsDropdown disabled={hasNoDevices || !isRunning}>
+            <IconButton tooltip={{ label: "Tools", type: "primary" }}>
+              <span className="codicon codicon-tools" />
+            </IconButton>
+          </ToolsDropdown>
+          <IconButton
+            className={isRecording ? "button-recording-on" : ""}
+            tooltip={{
+              label: isRecording ? "Stop screen recording" : "Start screen recording",
+            }}
+            onClick={toggleRecording}
+            disabled={isStarting}>
+            {isRecording ? (
+              <div className="recording-rec-indicator">
+                <div className="recording-rec-dot" />
+                <span>{recordingTimeFormat}</span>
+              </div>
+            ) : (
+              <RecordingIcon />
+            )}
+          </IconButton>
+          {showReplayButton && (
+            <IconButton
+              tooltip={{
+                label: "Replay the last few seconds of the app",
+              }}
+              onClick={handleReplay}
+              disabled={isStarting}>
+              <ReplayIcon />
+            </IconButton>
+          )}
           <IconButton
             tooltip={{
-              label: "Replay the last few seconds of the app",
+              label: "Capture a screenshot of the app",
             }}
-            onClick={handleReplay}
+            onClick={captureScreenshot}
             disabled={isStarting}>
-            <ReplayIcon />
+            <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
-        )}
-        <IconButton
-          tooltip={{
-            label: "Capture a screenshot of the app",
-          }}
-          onClick={captureScreenshot}
-          disabled={isStarting}>
-          <span slot="start" className="codicon codicon-device-camera" />
-        </IconButton>
-        <IconButton
-          counter={logCounter}
-          onClick={() => {
-            setLogCounter(0);
-            project.focusDebugConsole();
-          }}
-          tooltip={{
-            label: "Open logs panel",
-          }}
-          disabled={hasNoDevices}>
-          <span slot="start" className="codicon codicon-debug-console" />
-        </IconButton>
-        <SettingsDropdown project={project} isDeviceRunning={isRunning} disabled={hasNoDevices}>
-          <IconButton tooltip={{ label: "Settings", type: "primary" }}>
-            <span className="codicon codicon-settings-gear" />
+          <IconButton
+            counter={logCounter}
+            onClick={() => {
+              setLogCounter(0);
+              project.focusDebugConsole();
+            }}
+            tooltip={{
+              label: "Open logs panel",
+            }}
+            disabled={hasNoDevices}>
+            <span slot="start" className="codicon codicon-debug-console" />
           </IconButton>
-        </SettingsDropdown>
+          <SettingsDropdown project={project} isDeviceRunning={isRunning} disabled={hasNoDevices}>
+            <IconButton tooltip={{ label: "Settings", type: "primary" }}>
+              <span className="codicon codicon-settings-gear" />
+            </IconButton>
+          </SettingsDropdown>
+        </div>
       </div>
 
       {selectedDevice && initialized ? (


### PR DESCRIPTION
This PR enables the CPU profiles to be captured via the Radon IDE Panel.

1. We're adding new "Start CPU Profile" button to the tools menu that starts recording CPU profile
2. We use CDP's Profile category that is supported by hermes to record the profile
3. When profiling is ongoing we show a button in the top section of the panel that indicates the profiling process and that also allows for the profiling to be stopped
4. When profiling session is ended, we open a save dialog for .cpuprofile file and open it in the editor

Some additional changes that this PR introduces:
1. We're restructuring the tools menu and introduce a section division into "utilities" and "tool panels". We move all the panel checkboxes into the latter section.
2. This PR changes the styling of the top bar allowing the URL bar to shrink when there's not enough space. Previously the URL bar had a min-width set which turns out to not be necessary. Instead, we're making the top bar to align using space-between and allow for the bar to shrink when there are more items than the bar could fit.
3. When flame chart extension isn't installed, we show a dialog recommending that extension and also a button that jumps to a search with that extension. When user opens .cpuprofile file it has a flame chart icon that can be only used when that extension is installed. So the extension isn't essential but without it you cannot use the flame chart preview of the profile.
4. We're changing the recording button to pulsate which better indicates the fact of an ongoing recording process (either video or profile recording). With video recording we show timer so it doesn't help as much there, but with profiling we only show "Profiling CPU" message on the button.
5. We're unifying the styles of the recording button such that it uses the extension theme instead. This change applies to both video and profiling record buttons.

New structure of the tools menu:
<img width="289" alt="image" src="https://github.com/user-attachments/assets/f41ed333-1a51-48c4-8c7e-2b78a9ae5fc4" />

Active profiling button in different themes:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/0684712d-bd68-49c9-ac3a-fe574635b6e2" />
<img width="496" alt="image" src="https://github.com/user-attachments/assets/b3817675-1c1c-4df7-8869-65847bda8121" />

Save dialog:
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/cc5d93c2-c8e3-4aa7-b864-eefaa491f32d" />

Profile preview:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/08d88cc3-7c4a-4fbf-82fa-f107b735a81e" />


### How Has This Been Tested: 
1. Open any test app
2. Start profiling
3. Click on things in the app
4. Use "stop profile" button from the tools menu, but also use the new blue button that appears in the top bar to end profiling session
6. Test both scenarios when you dismiss the profile save dialog and when you save the profile
7. After saving, the .cpuprofile should open
8. Install / uninstall flame chart visualizer extension and when it isn't installed you should see a message recommending to install it


