### PR TITLE
fix "Outline Renders" initialization when tool is already enabled

### DIFF
--- a/packages/vscode-extension/src/common/RenderOutlines.ts
+++ b/packages/vscode-extension/src/common/RenderOutlines.ts
@@ -22,10 +22,9 @@ export interface RenderOutlinesEventMap {
   rendersReported: {
     blueprintOutlines: BlueprintEntry[];
   };
-  isEnabledChanged: {
-    isEnabled: boolean;
-  };
 }
+
+export const RENDER_OUTLINES_PLUGIN_ID = "RNIDE-render-outlines";
 
 export interface RenderOutlinesInterface {
   addEventListener<K extends keyof RenderOutlinesEventMap>(

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -3,7 +3,7 @@ import { Logger } from "../Logger";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { IDE } from "../project/ide";
 import { disposeAll } from "../utilities/disposables";
-import { RENDER_OUTLINES_PLUGIN_ID } from "../plugins/render-outlines/render-outlines-plugin";
+import { RENDER_OUTLINES_PLUGIN_ID } from "../common/RenderOutlines";
 
 type CallArgs = {
   callId: string;

--- a/packages/vscode-extension/src/plugins/render-outlines/render-outlines-plugin.ts
+++ b/packages/vscode-extension/src/plugins/render-outlines/render-outlines-plugin.ts
@@ -1,14 +1,13 @@
 import { EventEmitter } from "stream";
 import { Disposable } from "vscode";
 import {
+  RENDER_OUTLINES_PLUGIN_ID,
   RenderOutlinesEventListener,
   RenderOutlinesEventMap,
   RenderOutlinesInterface,
 } from "../../common/RenderOutlines";
 import { Devtools } from "../../project/devtools";
 import { ToolPlugin } from "../../project/tools";
-
-export const RENDER_OUTLINES_PLUGIN_ID = "RNIDE-render-outlines";
 
 export class RenderOutlinesPlugin implements ToolPlugin, RenderOutlinesInterface, Disposable {
   private eventEmitter = new EventEmitter();
@@ -47,7 +46,6 @@ export class RenderOutlinesPlugin implements ToolPlugin, RenderOutlinesInterface
   setEnabled(isEnabled: boolean) {
     this.isEnabled = isEnabled;
     this.devtools.send("RNIDE_updateInstrumentationOptions", { isEnabled });
-    this.eventEmitter.emit("isEnabledChanged", { isEnabled });
   }
 
   addEventListener<K extends keyof RenderOutlinesEventMap>(

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -14,10 +14,8 @@ import {
   createReduxDevtools,
 } from "../plugins/redux-devtools-plugin/redux-devtools-plugin";
 import { getTelemetryReporter } from "../utilities/telemetry";
-import {
-  RENDER_OUTLINES_PLUGIN_ID,
-  RenderOutlinesPlugin,
-} from "../plugins/render-outlines/render-outlines-plugin";
+import { RenderOutlinesPlugin } from "../plugins/render-outlines/render-outlines-plugin";
+import { RENDER_OUTLINES_PLUGIN_ID } from "../common/RenderOutlines";
 
 const TOOLS_SETTINGS_KEY = "tools_settings";
 

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { CanvasOutlineRenderer, OutlineRenderer, WorkerOutlineRenderer } from "react-scan";
 import {
   RenderOutlinesEventListener,
   RenderOutlinesEventMap,
   RenderOutlinesInterface,
+  RENDER_OUTLINES_PLUGIN_ID,
 } from "../../common/RenderOutlines";
 import { makeProxy } from "../utilities/rpc";
 import "./RenderOutlinesOverlay.css";
+import { useProject } from "../providers/ProjectProvider";
 
 const RenderOutlines = makeProxy<RenderOutlinesInterface>("RenderOutlines");
 
@@ -28,21 +30,8 @@ function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: numbe
 }
 
 function useIsEnabled() {
-  const [enabled, setEnabled] = useState(false);
-
-  useEffect(() => {
-    const listener: RenderOutlinesEventListener<RenderOutlinesEventMap["isEnabledChanged"]> = ({
-      isEnabled,
-    }) => {
-      setEnabled(isEnabled);
-    };
-    RenderOutlines.addEventListener("isEnabledChanged", listener);
-    return () => {
-      RenderOutlines.removeEventListener("isEnabledChanged", listener);
-    };
-  }, []);
-
-  return enabled;
+  const { toolsState } = useProject();
+  return toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
 }
 
 function RenderOutlinesOverlay() {


### PR DESCRIPTION
Fixes # (issue)
"Outline Renders" tool not working when the application is reloaded while the tool is enabled.

### How Has This Been Tested: 
- open the Radon IDE panel
- enable the "Outline Renders" tool
- select "Restart app process" from the reload dropdown
- verify the tool still works
