### PR TITLE
Add configuration option to specify arguments passed to expo start

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -324,6 +324,10 @@
                 "type": "string",
                 "description": "Location of Metro config relative to the workspace. This is used for using custom configs for e.g. development."
               },
+              "expoStartArgs": {
+                "type": "array",
+                "description": "Extra arguments to pass to Expo start command."
+              },
               "customBuild": {
                 "type": "object",
                 "description": "Configuration for using custom scripts for building and fingerprinting the app.",
@@ -486,6 +490,10 @@
               "metroConfigPath": {
                 "type": "string",
                 "description": "Location of Metro config relative to the workspace. This is used for using custom configs for e.g. development."
+              },
+              "expoStartArgs": {
+                "type": "array",
+                "description": "Extra arguments to pass to Expo start command."
               },
               "ios": {
                 "description": "Provides a way to customize Xcode builds for iOS",

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -9,6 +9,7 @@ export type CustomBuild = {
 export type LaunchConfigurationOptions = {
   appRoot?: string;
   metroConfigPath?: string;
+  expoStartArgs?: string[];
   customBuild?: {
     ios?: CustomBuild;
     android?: CustomBuild;

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -139,9 +139,18 @@ export class Metro implements Disposable {
     appRootFolder: string,
     libPath: string,
     resetCache: boolean,
+    expoStartExtraArgs: string[] | undefined,
     metroEnv: typeof process.env
   ) {
-    return exec("node", [path.join(libPath, "expo_start.js"), ...(resetCache ? ["--clear"] : [])], {
+    const args = [path.join(libPath, "expo_start.js")];
+    if (resetCache) {
+      args.push("--clear");
+    }
+    if (expoStartExtraArgs) {
+      args.push(...expoStartExtraArgs);
+    }
+
+    return exec("node", args, {
       cwd: appRootFolder,
       env: metroEnv,
       buffer: false,
@@ -207,7 +216,13 @@ export class Metro implements Disposable {
     let bundlerProcess: ChildProcess;
 
     if (shouldUseExpoCLI()) {
-      bundlerProcess = this.launchExpoMetro(appRootFolder, libPath, resetCache, metroEnv);
+      bundlerProcess = this.launchExpoMetro(
+        appRootFolder,
+        libPath,
+        resetCache,
+        launchConfiguration.expoStartArgs,
+        metroEnv
+      );
     } else {
       bundlerProcess = this.launchPackager(appRootFolder, libPath, resetCache, metroEnv);
     }


### PR DESCRIPTION
In one of the projects we heard the feedback from, they use `--scheme` option provided to expo start command. This is necessary for legacy reasons that they keep using expo this way.

The `--scheme` option makes it so that expo bundler uses the provided scheme when generating app URLs that we use for launching the app when expo dev client is detected. We eventually want to avoid relying on launching dev clients via URL, but the necessary changes only landed in SDK 52 (https://github.com/expo/expo/pull/33182), so for compatibility reasons we need to have a way for the schema to be customized on older versions (and until we add a way to launch dev client with extra arguments like proposed here https://github.com/expo/expo/pull/33182)

For the time being, the easiest workaround is to extend the launch configuration and give option to pass additional arguments to expo start. It doesn't appear like any other args really make sense to be added, yet giving more genering "args" option seem to require less explanation.

### How Has This Been Tested: 
1. Launch expo dev client project – make sure nothing breaks
2. Add `--scheme something' as extra args in launch configuration. See that it wouldn't launch and in debug logs you'll see that the app tries to launch using `something://` scheme


