### PR TITLE
Fix redux plugin after reloads or device switch

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -117,7 +117,7 @@ export class DebugAdapter extends DebugSession {
           }
         }
 
-        if (!sourceMapData) {
+        if (!sourceMapData || !sourceMapData.sources) {
           break;
         }
 

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
@@ -128,6 +128,9 @@ export class ReduxDevToolsPluginWebviewProvider implements WebviewViewProvider {
     }
 
     reduxDevtoolsPlugin.connectDevtoolsWebview(webview);
+    webviewView.onDidDispose(() => {
+      reduxDevtoolsPlugin.disconnectDevtoolsWebview(webview);
+    });
 
     webviewView.onDidChangeVisibility(() => {
       reportToolVisibilityChanged(REDUX_PLUGIN_ID, webviewView.visible);

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
@@ -11,8 +11,9 @@ import {
 import { extensionContext } from "../../utilities/extensionContext";
 import { getUri } from "../../utilities/getUri";
 import { getNonce } from "../../utilities/getNonce";
-import { REDUX_PLUGIN_ID } from "./redux-devtools-plugin";
-import { reportToolOpened } from "../../project/tools";
+import { REDUX_PLUGIN_ID, ReduxDevtoolsPlugin } from "./redux-devtools-plugin";
+import { reportToolOpened, reportToolVisibilityChanged } from "../../project/tools";
+import { IDE } from "../../project/ide";
 
 const PATH = "dist/redux-devtools/";
 
@@ -85,7 +86,7 @@ function generateWebviewContent(
             media-src vscode-resource: http: https:;
             style-src ${webview.cspSource} 'unsafe-inline';
             script-src 'nonce-${nonce}';
-            font-src vscode-resource: https:;" 
+            font-src vscode-resource: https:;"
           />
           ${cssImports}
         </head>
@@ -106,29 +107,36 @@ function generateWebviewContent(
 export class ReduxDevToolsPluginWebviewProvider implements WebviewViewProvider {
   constructor(private readonly context: ExtensionContext) {}
 
-  cb?: (webview: WebviewView) => void;
-
   public resolveWebviewView(
     webviewView: WebviewView,
     context: WebviewViewResolveContext,
     token: CancellationToken
   ): void {
     reportToolOpened(REDUX_PLUGIN_ID);
-    webviewView.webview.options = {
+    const webview = webviewView.webview;
+    webview.options = {
       enableScripts: true,
       localResourceRoots: [Uri.joinPath(this.context.extensionUri, PATH)],
     };
 
-    webviewView.webview.html = generateWebviewContent(
+    const project = IDE.getInstanceIfExists()?.project;
+    const reduxDevtoolsPlugin = project?.toolsManager.getPlugin(
+      REDUX_PLUGIN_ID
+    ) as ReduxDevtoolsPlugin;
+    if (!reduxDevtoolsPlugin) {
+      throw new Error("Couldn't find redux devtools plugin");
+    }
+
+    reduxDevtoolsPlugin.connectDevtoolsWebview(webview);
+
+    webviewView.onDidChangeVisibility(() => {
+      reportToolVisibilityChanged(REDUX_PLUGIN_ID, webviewView.visible);
+    });
+
+    webview.html = generateWebviewContent(
       extensionContext,
       webviewView.webview,
       extensionContext.extensionUri
     );
-
-    this.cb?.(webviewView);
-  }
-
-  setListener(cb: (webview: WebviewView) => void) {
-    this.cb = cb;
   }
 }

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -38,11 +38,21 @@ export class ReduxDevtoolsPlugin implements ToolPlugin {
 
   devtoolsListener = (event: string, payload: any) => {
     if (event === REDUX_PLUGIN_ID) {
-      console.log("[WTF] PROXY DEVTOOLS LISTENER", event, payload);
       this.connectedWebview?.postMessage({
         scope: event,
         data: payload,
       });
+    } else if (event === "RNIDE_appReady" && this.connectedWebview) {
+      // Sometimes, the messaging channel (devtools) is established only after
+      // the Redux store is created and after it sends the first message. In that
+      // case, the "start" event never makes it to the webview.
+      // To workaround this, we use "appReady" event which is sent after the messaging
+      // channel is established. We then force reload the webview with redux devtools
+      // which causes the devtools to initialize a new session and, as a consequence force the store
+      // to reconnect.
+      const html = this.connectedWebview.html;
+      this.connectedWebview.html = "";
+      this.connectedWebview.html = html;
     }
   };
 

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -1,5 +1,5 @@
-import { commands, window, Disposable, WebviewView, Webview } from "vscode";
-import { ToolKey, ToolPlugin, ToolsManager } from "../../project/tools";
+import { commands, window, Webview } from "vscode";
+import { ToolKey, ToolPlugin } from "../../project/tools";
 import { extensionContext } from "../../utilities/extensionContext";
 import { Devtools } from "../../project/devtools";
 import { ReduxDevToolsPluginWebviewProvider } from "./ReduxDevToolsPluginWebviewProvider";

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -59,7 +59,7 @@ export class Project
 {
   public metro: Metro;
   public toolsManager: ToolsManager;
-  private devtools = new Devtools();
+  private devtools;
   private eventEmitter = new EventEmitter();
 
   private isCachedBuildStale: boolean;

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -11,7 +11,7 @@ import {
 import { NetworkPlugin, NETWORK_PLUGIN_ID } from "../plugins/network/network-plugin";
 import {
   REDUX_PLUGIN_ID,
-  createReduxDevtools,
+  ReduxDevtoolsPlugin,
 } from "../plugins/redux-devtools-plugin/redux-devtools-plugin";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { RenderOutlinesPlugin } from "../plugins/render-outlines/render-outlines-plugin";
@@ -59,7 +59,7 @@ export class ToolsManager implements Disposable {
       this.plugins.set(plugin.id, plugin);
     }
 
-    this.plugins.set(REDUX_PLUGIN_ID, createReduxDevtools(this));
+    this.plugins.set(REDUX_PLUGIN_ID, new ReduxDevtoolsPlugin(devtools));
     this.plugins.set(NETWORK_PLUGIN_ID, new NetworkPlugin(devtools));
     this.plugins.set(RENDER_OUTLINES_PLUGIN_ID, new RenderOutlinesPlugin(devtools));
 

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -63,9 +63,6 @@ export class ToolsManager implements Disposable {
     for (const plugin of createExpoDevPluginTools()) {
       this.plugins.set(plugin.id, plugin);
     }
-    const reduxPlugin = createReduxDevtools(this);
-    this.plugins.set(reduxPlugin.id, reduxPlugin);
-
     const reactQueryPlugin = createReactQueryDevtools();
     this.plugins.set(reactQueryPlugin.id, reactQueryPlugin);
 


### PR DESCRIPTION
This PR fixes the issue with redux devtools webview not connecting properly after restarts/reloads or device changes reported in #992.

There were two separate reasons for the described issues:
1) The first issue stems from the timings between redux sents its init messages and when communication channel is established. Uless devtools agent is sent, we silently swallow all messages generated by the devtools. This is mostly ok, as we also need to support connecting the devtools at some later point, so we can't rely on the devtools being ready as soon as the store is created. However, if the devtools frontend was already opened at that time, which happens when we switch between devices, we can't ignore such messages as this would cause the frontend to never properly communicate. The fix for this issue is to make sure the frontent reloads when the communication channel is established. We use "appReady" event for this purpose.
2) The second issue was due to the fact that the plugin was architected in a way that stores stale instances of webview and devtools. As a consequence, after Rebooting IDE instead of routing the messages to the correct instances, we'd attempt to hook to old webview messages or to the stale devtools. The solution is to adapt the workflow the network plugin uses. In that workflow we use webview provider resolve method to get the currenct devtools instance. We then establish the communication between devtools and webview instances from within the resolve method. 

Fixes #992

### How Has This Been Tested: 
1. Open app with redux plugin
2. Make sure plugin works
3. Try different reload options: reload JS, restart metro, reboot IDE
4. Switch to Android and try the same options
5. Before this change, the redux devtools would stop reporting events after reboot IDE and after switching to Android


