### PR TITLE
Add a fallback path to the end of the path variable

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -31,7 +31,14 @@ async function getPathEnv(appRoot: string) {
       env: {},
     }
   );
-  const path = stdout.split(RNIDE_PATH_DELIMITER)[1].trim();
+
+  // The approach above is not always loading the whole path as it ignores some setup scripts,
+  // like .zprofile for example, to mitigate the effects of that problem we append the PATH
+  // of the current running process to the end of the ne PATH variable.
+  const vsCodeProcessPath = process.env.PATH;
+
+  const path = `${stdout.split(RNIDE_PATH_DELIMITER)[1].trim()}:${vsCodeProcessPath}`;
+
   Logger.debug("Obtained PATH environment variable:", path);
   return path;
 }


### PR DESCRIPTION
This PR fixes the issue introduced by  #975, that was causing for the path variable to be incomplete.
The problem could be surfaced  when trying to use `sim-server fingerprint` functionality as it relies on the PATH variable. 

The solution is to in addition to the new path finding method, append the old path at the end of the new one to fill in any missing paths. 

### How Has This Been Tested: 

- Run `react-native-78` test app
- add license



