### PR TITLE
Fix WebView disconnecting in debug mode when laptop goes to sleep 

### DIFF
--- a/packages/vscode-extension/vite.config.js
+++ b/packages/vscode-extension/vite.config.js
@@ -64,7 +64,7 @@ export default defineConfig({
   server: {
     port: 2137,
     hmr: {
-      host: "localhost",
+      host: "127.0.0.1",
     },
   },
 });


### PR DESCRIPTION
This PR fixes an issue when webview is disconnecting, when laptop goes sleep. It happens only on development setup. The solution is based on this thread: https://stackoverflow.com/a/73560133

### How Has This Been Tested: 

- Run Radon IDE 
- Close MacBook lid 
- Open it back
- The Radon IDE webview should be working as usuall 

