### PR TITLE
Use vscode-js-debug as the debugger implementation

### DIFF
--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -12,6 +12,8 @@ function __RNIDE_breakOnError(error, isFatal) {
   debugger;
 }
 
+// NOTE: this is only used on RN versions <= 0.75, where we use our own CDP implementation.
+// With the new debugger, uncaught exceptions are handled by the debugger itself.
 global.__RNIDE_onDebuggerReady = function () {
   // install error handler that breaks into the debugger but only do it when
   // debugger is connected. Otherwise we may miss some important initialization

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -17131,6 +17131,13 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "dev": true,
@@ -20297,6 +20304,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -21512,6 +21545,16 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/leven": {
@@ -25852,6 +25895,32 @@
       "version": "5.26.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -21527,16 +21527,6 @@
         "prebuild-install": "^7.0.1"
       }
     },
-    "node_modules/kleur": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.11"
-      }
-    },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -66,6 +66,7 @@
         "minimatch": "^9.0.4",
         "mocha": "^10.4.0",
         "node-fetch": "^2.7.0",
+        "patch-package": "^8.0.0",
         "plist": "^3.1.0",
         "prettier": "^2.2.1",
         "re-resizable": "^6.9.16",
@@ -84,6 +85,7 @@
         "url-loader": "^4.1.1",
         "uuid": "^9.0.1",
         "vite": "^5.0.8",
+        "vscode-cdp-proxy": "^0.2.1",
         "vscode-js-debug": "file:../vscode-js-debug",
         "vscode-test": "^1.5.0",
         "ws": "^8.14.2",
@@ -17122,10 +17124,12 @@
       "license": "Apache-2.0",
       "peer": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "BSD-2-Clause"
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -17471,6 +17475,16 @@
       "version": "0.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -17942,6 +17956,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -18259,6 +18290,22 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "dev": true,
@@ -18323,6 +18370,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cockatiel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-2.0.2.tgz",
+      "integrity": "sha512-ehw7t3twohGiMTxARX0AcFiUxndXLhnIBWbnRnHtfde2jRywlPpPB/o3s9YSptXPj6tkOG0fzET4CUUx4GIpEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10 <11 || >=12"
       }
     },
     "node_modules/color-convert": {
@@ -18665,6 +18722,21 @@
       ],
       "license": "BSD-2-Clause"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "dev": true,
@@ -18810,12 +18882,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -20210,26 +20281,20 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/fs.realpath": {
@@ -20347,15 +20412,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20370,6 +20442,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-symbol-description": {
@@ -20592,7 +20678,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20953,6 +21041,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -21146,6 +21250,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
@@ -21279,8 +21396,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -21299,6 +21443,29 @@
       "version": "3.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -21333,8 +21500,18 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/leven": {
@@ -21603,6 +21780,16 @@
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdurl": {
@@ -22494,6 +22681,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -22776,6 +22980,74 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/path-exists": {
@@ -25581,30 +25853,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unique-filename": {
+    "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unplugin": {
@@ -26316,6 +26572,17 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vscode-cdp-proxy": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-cdp-proxy/-/vscode-cdp-proxy-0.2.1.tgz",
+      "integrity": "sha512-xL7DcTa4Ih9nOmqPh9hd5BBjV30owB7+fvKP/PZBQPpON/6Czfrc8a0Sk4fRzpskmlX2FEHjYkJ/u4uotqCZNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cockatiel": "^2.0.2",
+        "ws": "^8.2.3"
+      }
+    },
     "node_modules/vscode-js-debug": {
       "resolved": "../vscode-js-debug",
       "link": true
@@ -26641,6 +26908,19 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -296,6 +296,15 @@
         ]
       },
       {
+        "type": "radon-pwa-node",
+        "label": "Radon IDE internal debugger for React Native",
+        "hiddenWhen": "true",
+        "languages": [
+          "javascript",
+          "typescript"
+        ]
+      },
+      {
         "type": "radon-ide",
         "label": "Radon IDE",
         "languages": [
@@ -724,5 +733,8 @@
     "vscode-test": "^1.5.0",
     "ws": "^8.14.2",
     "xml2js": "^0.6.2"
-  }
+  },
+  "enabledApiProposals": [
+    "portsAttributes"
+  ]
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -639,11 +639,12 @@
     "copy:redux-devtools-plugin": "rm -rf lib/plugins/third-party/redux-devtools-expo-dev-plugin.js && cp ../redux-devtools-expo-dev-plugin/artifacts/RadonIDE/redux-devtools-expo-dev-plugin.js lib/plugins/third-party/redux-devtools-expo-dev-plugin.js",
     "build:redux-devtools-ui": "rm -rf dist/redux-devtools && cp -R ../redux-devtools-expo-dev-plugin/artifacts/RadonIDE/redux-devtools dist/redux-devtools",
     "build:chrome-devtools-ui": "rm -rf dist/network-devtools-frontend && cp -R ../chrome-devtools-ui/build_artifacts/RadonIDE/gen/front_end/ dist/network-devtools-frontend",
-    "build:third-party": "npm run build:chrome-devtools-ui && npm run build:redux-devtools-ui",
+    "build:third-party": "npm run build:chrome-devtools-ui && npm run build:redux-devtools-ui && npm run build:vscode-js-debug",
     "build:extension-debug": "npm run fetch:third-party && node ./scripts/buildExtensionCode.mjs debug && npm run build:third-party",
     "build:extension": "node ./scripts/buildExtensionCode.mjs production && npm run build:third-party",
     "build:webview": "vite build --mode production && cp ./node_modules/@vscode/codicons/dist/codicon.* dist/.",
     "build:sim-server-debug": "bash ./scripts/build-sim-server-debug.sh dist",
+    "build:vscode-js-debug": "cd ../vscode-js-debug && npm run compile && cp dist/src/chromehash_bg.wasm ../vscode-extension/dist/",
     "build:debug": "npm run build:extension-debug && npm run build:sim-server-debug",
     "build:dist": "npm run fetch:third-party && npm run fetch:sim-server-assets && npm run build:extension && npm run build:webview && npm run build:third-party-notice",
     "build:third-party-notice": "node ./scripts/mergeThirdPartyNotices.mjs ./submodules-NOTICES.json ./dist/simulator-server-NOTICES.json ./dist/webview-NOTICES.json ./dist/extension-NOTICES.json ./ThirdPartyNotices.json",
@@ -742,8 +743,5 @@
     "vscode-test": "^1.5.0",
     "ws": "^8.14.2",
     "xml2js": "^0.6.2"
-  },
-  "enabledApiProposals": [
-    "portsAttributes"
-  ]
+  }
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -640,7 +640,8 @@
     "test": "npm run build:extension && npm run build:webview && npm run build:tests && vscode-test",
     "preinstall": "bash ./scripts/init-submodules-if-not-present.sh ../vscode-js-debug && cd ../vscode-js-debug && npm i && npm exec tsc",
     "fetch:sim-server-assets": "bash ./scripts/download-sim-server-release-assets.sh dist",
-    "fetch:third-party": "bash ./scripts/init-submodules-if-not-present.sh ../chrome-devtools-ui ../redux-devtools-expo-dev-plugin"
+    "fetch:third-party": "bash ./scripts/init-submodules-if-not-present.sh ../chrome-devtools-ui ../redux-devtools-expo-dev-plugin",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",
@@ -699,6 +700,7 @@
     "minimatch": "^9.0.4",
     "mocha": "^10.4.0",
     "node-fetch": "^2.7.0",
+    "patch-package": "^8.0.0",
     "plist": "^3.1.0",
     "prettier": "^2.2.1",
     "re-resizable": "^6.9.16",
@@ -717,6 +719,7 @@
     "url-loader": "^4.1.1",
     "uuid": "^9.0.1",
     "vite": "^5.0.8",
+    "vscode-cdp-proxy": "^0.2.1",
     "vscode-js-debug": "file:../vscode-js-debug",
     "vscode-test": "^1.5.0",
     "ws": "^8.14.2",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -296,6 +296,15 @@
         ]
       },
       {
+        "type": "com.swmansion.proxy-debugger",
+        "label": "Radon IDE internal debugger for React Native",
+        "hiddenWhen": "true",
+        "languages": [
+          "javascript",
+          "typescript"
+        ]
+      },
+      {
         "type": "radon-pwa-node",
         "label": "Radon IDE internal debugger for React Native",
         "hiddenWhen": "true",

--- a/packages/vscode-extension/patches/vscode-cdp-proxy+0.2.1.patch
+++ b/packages/vscode-extension/patches/vscode-cdp-proxy+0.2.1.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/vscode-cdp-proxy/dist/index.js b/node_modules/vscode-cdp-proxy/dist/index.js
+index ca7886c..be99d9e 100644
+--- a/node_modules/vscode-cdp-proxy/dist/index.js
++++ b/node_modules/vscode-cdp-proxy/dist/index.js
+@@ -16,7 +16,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ __exportStar(require("./server"), exports);
+ __exportStar(require("./disposable"), exports);
+ __exportStar(require("./connection"), exports);
+-__exportStar(require("./cdp"), exports);
++// __exportStar(require("./cdp"), exports);
+ __exportStar(require("./cdp-error"), exports);
+ __exportStar(require("./transports/transports"), exports);
+ __exportStar(require("./transports/websocket"), exports);

--- a/packages/vscode-extension/patches/vscode-cdp-proxy+0.2.1.patch
+++ b/packages/vscode-extension/patches/vscode-cdp-proxy+0.2.1.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/vscode-cdp-proxy/dist/connection.js b/node_modules/vscode-cdp-proxy/dist/connection.js
+index f46fe58..e934b5e 100644
+--- a/node_modules/vscode-cdp-proxy/dist/connection.js
++++ b/node_modules/vscode-cdp-proxy/dist/connection.js
+@@ -126,7 +126,7 @@ class Connection {
+         if (this.pauseQueue) {
+             this.pauseQueue.push(message);
+         }
+-        if (message.id === undefined) {
++        if (message.id === undefined || message.method !== undefined) {
+             // for some reason, TS doesn't narrow this even though IProtocolCommand
+             // is the only type of the tuple where id can be undefined.
+             const asCommand = message;
 diff --git a/node_modules/vscode-cdp-proxy/dist/index.js b/node_modules/vscode-cdp-proxy/dist/index.js
 index ca7886c..be99d9e 100644
 --- a/node_modules/vscode-cdp-proxy/dist/index.js

--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -1,0 +1,147 @@
+import { IncomingMessage } from "http";
+import { EventEmitter } from "vscode";
+import {
+  Connection,
+  IProtocolCommand,
+  IProtocolError,
+  IProtocolSuccess,
+  Server,
+  WebSocketTransport,
+} from "vscode-cdp-proxy";
+import { Logger } from "../Logger";
+
+export class CDPProxy {
+  private server: Server | null = null;
+  private hostAddress: string;
+  private port: number;
+  private debuggerTarget: Connection | null = null;
+  private applicationTarget: Connection | null = null;
+  private browserInspectUri: string;
+  private applicationTargetEventEmitter: EventEmitter<unknown> = new EventEmitter();
+
+  public readonly onApplicationTargetConnectionClosed = this.applicationTargetEventEmitter.event;
+
+  constructor(hostAddress: string, port: number) {
+    this.port = port;
+    this.hostAddress = hostAddress;
+    this.browserInspectUri = "";
+  }
+
+  public async initializeServer(): Promise<void> {
+    this.server = await Server.create({ port: this.port, host: this.hostAddress });
+    this.server.onConnection(this.onConnectionHandler.bind(this));
+  }
+
+  public async stopServer(): Promise<void> {
+    if (this.server) {
+      this.server.dispose();
+      this.server = null;
+    }
+
+    if (this.applicationTarget) {
+      await this.applicationTarget.close();
+      this.applicationTarget = null;
+    }
+
+    this.browserInspectUri = "";
+  }
+
+  public setBrowserInspectUri(browserInspectUri: string): void {
+    this.browserInspectUri = browserInspectUri;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private async onConnectionHandler([debuggerTarget, request]: [
+    Connection,
+    IncomingMessage
+  ]): Promise<void> {
+    this.debuggerTarget = debuggerTarget;
+
+    this.debuggerTarget.pause(); // don't listen for events until the target is ready
+
+    this.applicationTarget = new Connection(
+      await WebSocketTransport.create(this.browserInspectUri)
+    );
+
+    this.applicationTarget.onError(this.onApplicationTargetError.bind(this));
+    this.debuggerTarget.onError(this.onDebuggerTargetError.bind(this));
+
+    this.applicationTarget.onCommand(this.handleApplicationTargetCommand.bind(this));
+    this.debuggerTarget.onCommand(this.handleDebuggerTargetCommand.bind(this));
+
+    this.applicationTarget.onReply(this.handleApplicationTargetReply.bind(this));
+    this.debuggerTarget.onReply(this.handleDebuggerTargetReply.bind(this));
+
+    this.applicationTarget.onEnd(this.onApplicationTargetClosed.bind(this));
+    this.debuggerTarget.onEnd(this.onDebuggerTargetClosed.bind(this));
+
+    // dequeue any messages we got in the meantime
+    this.debuggerTarget.unpause();
+  }
+
+  private handleDebuggerTargetCommand(event: IProtocolCommand) {
+    // const processedMessage = this.CDPMessageHandler.processDebuggerCDPMessage(event);
+
+    // if (processedMessage.sendBack) {
+    //   this.debuggerTarget?.send(processedMessage.event);
+    // } else {
+    //   this.applicationTarget?.send(processedMessage.event);
+    // }
+    console.log("Debugger Target Command", event);
+    this.applicationTarget?.send(event);
+  }
+
+  private handleApplicationTargetCommand(event: IProtocolCommand) {
+    // const processedMessage = this.CDPMessageHandler.processApplicationCDPMessage(event);
+
+    // if (processedMessage.sendBack) {
+    //   this.applicationTarget?.send(processedMessage.event);
+    // } else {
+    //   this.debuggerTarget?.send(processedMessage.event);
+    // }
+    console.log("Application Target Command", event);
+    this.debuggerTarget?.send(event);
+  }
+
+  private handleDebuggerTargetReply(event: IProtocolError | IProtocolSuccess) {
+    // const processedMessage = this.CDPMessageHandler.processDebuggerCDPMessage(event);
+
+    // if (processedMessage.sendBack) {
+    //   this.debuggerTarget?.send(processedMessage.event);
+    // } else {
+    //   this.applicationTarget?.send(processedMessage.event);
+    // }
+    console.log("Debugger Target Reply", event);
+    this.applicationTarget?.send(event);
+  }
+
+  private handleApplicationTargetReply(event: IProtocolError | IProtocolSuccess) {
+    // const processedMessage = this.CDPMessageHandler.processApplicationCDPMessage(event);
+
+    // if (processedMessage.sendBack) {
+    //   this.applicationTarget?.send(processedMessage.event);
+    // } else {
+    //   this.debuggerTarget?.send(processedMessage.event);
+    // }
+    console.log("Application Target Reply", event);
+    this.debuggerTarget?.send(event);
+  }
+
+  private onDebuggerTargetError(err: Error) {
+    Logger.error("Error on debugger transport", err);
+  }
+
+  private onApplicationTargetError(err: Error) {
+    Logger.error("Error on application transport", err);
+  }
+
+  private async onApplicationTargetClosed() {
+    this.applicationTarget = null;
+    this.applicationTargetEventEmitter.fire({});
+  }
+
+  private async onDebuggerTargetClosed() {
+    this.browserInspectUri = "";
+    this.debuggerTarget = null;
+  }
+}

--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -89,13 +89,6 @@ export class CDPProxy {
   }
 
   private handleDebuggerTargetCommand(event: IProtocolCommand) {
-    // const processedMessage = this.CDPMessageHandler.processDebuggerCDPMessage(event);
-
-    // if (processedMessage.sendBack) {
-    //   this.debuggerTarget?.send(processedMessage.event);
-    // } else {
-    //   this.applicationTarget?.send(processedMessage.event);
-    // }
     console.log("Debugger Target Command", event);
     const processedMessage = this.cdpProxyDelegate.handleDebuggerCommand(event);
     if (processedMessage) {
@@ -104,13 +97,6 @@ export class CDPProxy {
   }
 
   private handleApplicationTargetCommand(event: IProtocolCommand) {
-    // const processedMessage = this.CDPMessageHandler.processApplicationCDPMessage(event);
-
-    // if (processedMessage.sendBack) {
-    //   this.applicationTarget?.send(processedMessage.event);
-    // } else {
-    //   this.debuggerTarget?.send(processedMessage.event);
-    // }
     console.log("Application Target Command", event);
     const processedMessage = this.cdpProxyDelegate.handleApplicationCommand(event);
     if (processedMessage) {
@@ -119,13 +105,6 @@ export class CDPProxy {
   }
 
   private handleDebuggerTargetReply(event: IProtocolError | IProtocolSuccess) {
-    // const processedMessage = this.CDPMessageHandler.processDebuggerCDPMessage(event);
-
-    // if (processedMessage.sendBack) {
-    //   this.debuggerTarget?.send(processedMessage.event);
-    // } else {
-    //   this.applicationTarget?.send(processedMessage.event);
-    // }
     console.log("Debugger Target Reply", event);
     const processedMessage = this.cdpProxyDelegate.handleDebuggerReply(event);
     if (processedMessage) {
@@ -134,13 +113,6 @@ export class CDPProxy {
   }
 
   private handleApplicationTargetReply(event: IProtocolError | IProtocolSuccess) {
-    // const processedMessage = this.CDPMessageHandler.processApplicationCDPMessage(event);
-
-    // if (processedMessage.sendBack) {
-    //   this.applicationTarget?.send(processedMessage.event);
-    // } else {
-    //   this.debuggerTarget?.send(processedMessage.event);
-    // }
     console.log("Application Target Reply", event);
     const processedMessage = this.cdpProxyDelegate.handleApplicationReply(event);
     if (processedMessage) {

--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -30,13 +30,16 @@ export class CDPProxy {
   public readonly onApplicationTargetConnectionClosed = this.applicationTargetEventEmitter.event;
 
   constructor(
-    private hostAddress: string,
-    private port: number,
+    public readonly hostAddress: string,
+    public readonly port: number,
     private browserInspectUri: string,
     private cdpProxyDelegate: CDPProxyDelegate
   ) {}
 
   public async initializeServer(): Promise<void> {
+    if (this.server) {
+      return;
+    }
     this.server = await Server.create({ port: this.port, host: this.hostAddress });
     this.server.onConnection(this.onConnectionHandler.bind(this));
   }
@@ -89,7 +92,6 @@ export class CDPProxy {
   }
 
   private handleDebuggerTargetCommand(event: IProtocolCommand) {
-    console.log("Debugger Target Command", event);
     const processedMessage = this.cdpProxyDelegate.handleDebuggerCommand(event);
     if (processedMessage) {
       this.applicationTarget?.send(event);
@@ -97,7 +99,6 @@ export class CDPProxy {
   }
 
   private handleApplicationTargetCommand(event: IProtocolCommand) {
-    console.log("Application Target Command", event);
     const processedMessage = this.cdpProxyDelegate.handleApplicationCommand(event);
     if (processedMessage) {
       this.debuggerTarget?.send(event);
@@ -105,7 +106,6 @@ export class CDPProxy {
   }
 
   private handleDebuggerTargetReply(event: IProtocolError | IProtocolSuccess) {
-    console.log("Debugger Target Reply", event);
     const processedMessage = this.cdpProxyDelegate.handleDebuggerReply(event);
     if (processedMessage) {
       this.applicationTarget?.send(processedMessage);
@@ -113,7 +113,6 @@ export class CDPProxy {
   }
 
   private handleApplicationTargetReply(event: IProtocolError | IProtocolSuccess) {
-    console.log("Application Target Reply", event);
     const processedMessage = this.cdpProxyDelegate.handleApplicationReply(event);
     if (processedMessage) {
       this.debuggerTarget?.send(event);

--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -10,14 +10,14 @@ import {
 import { Logger } from "../Logger";
 
 export interface CDPProxyDelegate {
-  handleApplicationCommand(command: IProtocolCommand): IProtocolCommand | undefined;
-  handleDebuggerCommand(command: IProtocolCommand): IProtocolCommand | undefined;
+  handleApplicationCommand(command: IProtocolCommand): Promise<IProtocolCommand | undefined>;
+  handleDebuggerCommand(command: IProtocolCommand): Promise<IProtocolCommand | undefined>;
   handleApplicationReply(
     reply: IProtocolSuccess | IProtocolError
-  ): IProtocolSuccess | IProtocolError | undefined;
+  ): Promise<IProtocolSuccess | IProtocolError | undefined>;
   handleDebuggerReply(
     reply: IProtocolSuccess | IProtocolError
-  ): IProtocolSuccess | IProtocolError | undefined;
+  ): Promise<IProtocolSuccess | IProtocolError | undefined>;
 }
 
 export class CDPProxy {
@@ -110,29 +110,29 @@ class ProxyTunnel {
     }
   }
 
-  private handleDebuggerTargetCommand(event: IProtocolCommand) {
-    const processedMessage = this.cdpProxyDelegate.handleDebuggerCommand(event);
+  private async handleDebuggerTargetCommand(event: IProtocolCommand) {
+    const processedMessage = await this.cdpProxyDelegate.handleDebuggerCommand(event);
     if (processedMessage) {
       this.applicationTarget?.send(event);
     }
   }
 
-  private handleApplicationTargetCommand(event: IProtocolCommand) {
-    const processedMessage = this.cdpProxyDelegate.handleApplicationCommand(event);
+  private async handleApplicationTargetCommand(event: IProtocolCommand) {
+    const processedMessage = await this.cdpProxyDelegate.handleApplicationCommand(event);
     if (processedMessage) {
       this.debuggerTarget?.send(event);
     }
   }
 
-  private handleDebuggerTargetReply(event: IProtocolError | IProtocolSuccess) {
-    const processedMessage = this.cdpProxyDelegate.handleDebuggerReply(event);
+  private async handleDebuggerTargetReply(event: IProtocolError | IProtocolSuccess) {
+    const processedMessage = await this.cdpProxyDelegate.handleDebuggerReply(event);
     if (processedMessage) {
       this.applicationTarget?.send(processedMessage);
     }
   }
 
-  private handleApplicationTargetReply(event: IProtocolError | IProtocolSuccess) {
-    const processedMessage = this.cdpProxyDelegate.handleApplicationReply(event);
+  private async handleApplicationTargetReply(event: IProtocolError | IProtocolSuccess) {
+    const processedMessage = await this.cdpProxyDelegate.handleApplicationReply(event);
     if (processedMessage) {
       this.debuggerTarget?.send(event);
     }

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -34,6 +34,7 @@ import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { BreakpointsController } from "./BreakpointsController";
 import { CDPSession } from "./CDPSession";
 import getArraySlots from "./templates/getArraySlots";
+import { DEBUG_CONSOLE_LOG, DEBUG_PAUSED, DEBUG_RESUMED } from "./DebugSession";
 
 function typeToCategory(type: string) {
   switch (type) {
@@ -246,9 +247,7 @@ export class DebugAdapter extends DebugSession {
       };
     }
     this.sendEvent(output);
-    this.sendEvent(
-      new Event("RNIDE_consoleLog", { category: typeToCategory(message.params.type) })
-    );
+    this.sendEvent(new Event(DEBUG_CONSOLE_LOG, { category: typeToCategory(message.params.type) }));
   }
 
   private async createVariableForOutputEvent(args: CDPRemoteObject[]) {
@@ -386,7 +385,7 @@ export class DebugAdapter extends DebugSession {
       );
       this.pausedStackFrames = stackFrames;
       this.sendEvent(new StoppedEvent("exception", this.threads[0].id, errorMessage));
-      this.sendEvent(new Event("RNIDE_paused", { reason: "exception", isFatal: isFatal }));
+      this.sendEvent(new Event(DEBUG_PAUSED, { reason: "exception", isFatal: isFatal }));
     } else {
       this.pausedStackFrames = message.params.callFrames.map((cdpFrame: any, index: number) => {
         const cdpLocation = cdpFrame.location;
@@ -408,7 +407,7 @@ export class DebugAdapter extends DebugSession {
         (cdpFrame: any) => cdpFrame.scopeChain
       );
       this.sendEvent(new StoppedEvent("breakpoint", this.threads[0].id, "Yollo"));
-      this.sendEvent(new Event("RNIDE_paused"));
+      this.sendEvent(new Event(DEBUG_PAUSED));
     }
   }
 
@@ -577,7 +576,7 @@ export class DebugAdapter extends DebugSession {
   ): Promise<void> {
     await this.cdpSession.sendCDPMessage("Debugger.resume", { terminateOnResume: false });
     this.sendResponse(response);
-    this.sendEvent(new Event("RNIDE_continued"));
+    this.sendEvent(new Event(DEBUG_RESUMED));
   }
 
   protected async nextRequest(

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -75,7 +75,7 @@ export class DebugSession implements Disposable {
       debugStarted = await debug.startDebugging(
         undefined,
         {
-          type: "pwa-node",
+          type: "radon-pwa-node",
           name: "Radon IDE Debugger",
           request: "attach",
           port: cdpProxyPort,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -9,6 +9,11 @@ import {
 } from "vscode";
 import { Metro } from "../project/metro";
 
+export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
+export const DEBUG_PAUSED = "RNIDE_paused";
+export const DEBUG_RESUMED = "RNIDE_continued";
+export const DEBUG_DISCONNECTED = "RNIDE_disconnected";
+
 export type DebugSessionDelegate = {
   onConsoleLog(event: DebugSessionCustomEvent): void;
   onDebuggerPaused(event: DebugSessionCustomEvent): void;
@@ -22,13 +27,13 @@ export class DebugSession implements Disposable {
   constructor(private metro: Metro, private delegate: DebugSessionDelegate) {
     this.debugEventsListener = debug.onDidReceiveDebugSessionCustomEvent((event) => {
       switch (event.event) {
-        case "RNIDE_consoleLog":
+        case DEBUG_CONSOLE_LOG:
           this.delegate.onConsoleLog(event);
           break;
-        case "RNIDE_paused":
+        case DEBUG_PAUSED:
           this.delegate.onDebuggerPaused(event);
           break;
-        case "RNIDE_continued":
+        case DEBUG_RESUMED:
           this.delegate.onDebuggerResumed(event);
           break;
         default:

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -1,4 +1,5 @@
 import {
+  commands,
   debug,
   DebugSessionCustomEvent,
   Disposable,
@@ -67,7 +68,7 @@ export class DebugSession implements Disposable {
         "127.0.0.1",
         cdpProxyPort,
         websocketAddress,
-        new RadonCDPProxyDelegate()
+        new RadonCDPProxyDelegate(this.delegate)
       );
       await cdpProxy.initializeServer();
 
@@ -126,11 +127,13 @@ export class DebugSession implements Disposable {
   }
 
   public resumeDebugger() {
-    this.session.customRequest("continue");
+    // this.session.customRequest("continue");
+    commands.executeCommand("workbench.action.debug.continue");
   }
 
   public stepOverDebugger() {
-    this.session.customRequest("next");
+    // this.session.customRequest("next");
+    commands.executeCommand("workbench.action.debug.stepOver");
   }
 
   private get session() {

--- a/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
@@ -5,6 +5,7 @@ import { debug, Disposable } from "vscode";
 import { CDPProxy } from "./CDPProxy";
 import { RadonCDPProxyDelegate } from "./RadonCDPProxyDelegate";
 import { disposeAll } from "../utilities/disposables";
+import { DEBUG_PAUSED, DEBUG_RESUMED } from "./DebugSession";
 
 export class ProxyDebugSessionAdapterDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory
@@ -38,17 +39,12 @@ export class ProxyDebugSession extends DebugSession {
 
     this.disposables.push(
       proxyDelegate.onDebuggerPaused(() => {
-        this.sendEvent(new Event("RNIDE_paused"));
+        this.sendEvent(new Event(DEBUG_PAUSED));
       })
     );
     this.disposables.push(
       proxyDelegate.onDebuggerResumed(() => {
-        this.sendEvent(new Event("RNIDE_continued"));
-      })
-    );
-    this.disposables.push(
-      proxyDelegate.onDebuggerReady(() => {
-        // this.sendEvent(new Event("RNIDE_continued"));
+        this.sendEvent(new Event(DEBUG_RESUMED));
       })
     );
   }
@@ -169,6 +165,7 @@ export class ProxyDebugSession extends DebugSession {
     request?: DebugProtocol.Request
   ) {
     this.terminate();
+    this.sendEvent(new Event("RNIDE_continued"));
     this.sendResponse(response);
   }
 

--- a/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
@@ -1,0 +1,120 @@
+import { DebugSession, ErrorDestination, Event } from "@vscode/debugadapter";
+import * as vscode from "vscode";
+import { DebugProtocol } from "@vscode/debugprotocol";
+import { debug, Disposable } from "vscode";
+import { CDPProxy } from "./CDPProxy";
+import { RadonCDPProxyDelegate } from "./RadonCDPProxyDelegate";
+
+export class ProxyDebugSessionAdapterDescriptorFactory
+  implements vscode.DebugAdapterDescriptorFactory
+{
+  createDebugAdapterDescriptor(
+    session: vscode.DebugSession
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    return new vscode.DebugAdapterInlineImplementation(new ProxyDebugSession(session));
+  }
+}
+
+export class ProxyDebugSession extends DebugSession {
+  private websocketAddress: string;
+  private sourceMapPathOverrides: Record<string, string>;
+
+  private cdpProxy: CDPProxy;
+  private disposables: Disposable[] = [];
+
+  constructor(private session: vscode.DebugSession) {
+    super();
+    this.websocketAddress = session.configuration.websocketAddress;
+    this.sourceMapPathOverrides = session.configuration.sourceMapPathOverrides;
+
+    const cdpProxyPort = Math.round(Math.random() * 40000 + 3000);
+    const proxyDelegate = new RadonCDPProxyDelegate();
+
+    this.cdpProxy = new CDPProxy("127.0.0.1", cdpProxyPort, this.websocketAddress, proxyDelegate);
+
+    this.disposables.push(
+      proxyDelegate.onDebuggerPaused(() => {
+        this.sendEvent(new Event("RNIDE_paused"));
+      })
+    );
+    this.disposables.push(
+      proxyDelegate.onDebuggerResumed(() => {
+        this.sendEvent(new Event("RNIDE_continued"));
+      })
+    );
+  }
+
+  protected initializeRequest(
+    response: DebugProtocol.InitializeResponse,
+    args: DebugProtocol.InitializeRequestArguments
+  ): void {
+    response.body = response.body || {};
+
+    response.body.supportsConfigurationDoneRequest = true;
+    response.body.supportsEvaluateForHovers = true;
+    response.body.supportTerminateDebuggee = false;
+    response.body.supportsCancelRequest = true;
+
+    response.body.exceptionBreakpointFilters = [
+      {
+        filter: "all",
+        label: "Caught Exceptions",
+        default: false,
+        supportsCondition: true,
+        description: "Breaks on all throw errors, even if they're caught later.",
+        conditionDescription: 'error.name == "MyError"',
+      },
+      {
+        filter: "uncaught",
+        label: "Uncaught Exceptions",
+        default: false,
+        supportsCondition: true,
+        description: "Breaks only on errors or promise rejections that are not handled.",
+        conditionDescription: 'error.name == "MyError"',
+      },
+    ];
+
+    this.sendResponse(response);
+  }
+
+  protected async attachRequest(
+    response: DebugProtocol.AttachResponse,
+    args: any,
+    request?: DebugProtocol.Request
+  ) {
+    await this.cdpProxy.initializeServer();
+
+    const childSessionStarted = await debug.startDebugging(
+      undefined,
+      {
+        type: "radon-pwa-node",
+        name: "Radon IDE Debugger",
+        request: "attach",
+        port: this.cdpProxy.port,
+        sourceMapPathOverrides: args.sourceMapPathOverrides,
+        resolveSourceMapLocations: ["**", "!**/node_modules/!(expo)/**"],
+      },
+      {
+        suppressDebugStatusbar: true,
+        suppressDebugView: true,
+        suppressDebugToolbar: true,
+        suppressSaveBeforeStart: true,
+        parentSession: this.session,
+        consoleMode: vscode.DebugConsoleMode.MergeWithParent,
+        lifecycleManagedByParent: true,
+      }
+    );
+
+    if (!childSessionStarted) {
+      this.sendErrorResponse(
+        response,
+        { format: "Failed to attach debugger session", id: 1 },
+        undefined,
+        undefined,
+        ErrorDestination.User
+      );
+    }
+
+    this.sendResponse(response);
+  }
+}

--- a/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugSession.ts
@@ -46,6 +46,11 @@ export class ProxyDebugSession extends DebugSession {
         this.sendEvent(new Event("RNIDE_continued"));
       })
     );
+    this.disposables.push(
+      proxyDelegate.onDebuggerReady(() => {
+        // this.sendEvent(new Event("RNIDE_continued"));
+      })
+    );
   }
 
   protected initializeRequest(

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,16 +1,45 @@
 import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
+import { debug } from "vscode";
 import { CDPProxyDelegate } from "./CDPProxy";
+import { DebugSessionDelegate } from "./DebugSession";
 
 export class RadonCDPProxyDelegate implements CDPProxyDelegate {
+  constructor(private debugSessionDelegate: DebugSessionDelegate) {}
   public handleApplicationCommand(command: IProtocolCommand): IProtocolCommand | undefined {
     switch (command.method) {
       case "Runtime.consoleAPICalled": {
         return this.handleConsoleAPICalled(command);
       }
+      case "Debugger.paused": {
+        this.debugSessionDelegate.onDebuggerPaused({
+          event: "RNIDE_paused",
+          session: debug.activeDebugSession!,
+          body: {},
+        });
+        return command;
+      }
+      case "Debugger.resumed": {
+        this.debugSessionDelegate.onDebuggerPaused({
+          event: "RNIDE_continued",
+          session: debug.activeDebugSession!,
+          body: {},
+        });
+        return command;
+      }
     }
     return command;
   }
   public handleDebuggerCommand(command: IProtocolCommand): IProtocolCommand | undefined {
+    // switch (command.method) {
+    //   case "Debugger.resume": {
+    //     this.debugSessionDelegate.onDebuggerResumed({
+    //       event: "RNIDE_continued",
+    //       session: debug.activeDebugSession!,
+    //       body: {},
+    //     });
+    //     return command;
+    //   }
+    // }
     return command;
   }
   public handleApplicationReply(

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -18,8 +18,21 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         });
         return command;
       }
-      case "Debugger.resumed": {
-        this.debugSessionDelegate.onDebuggerPaused({
+      // case "Debugger.resumed": {
+      //   this.debugSessionDelegate.onDebuggerPaused({
+      //     event: "RNIDE_continued",
+      //     session: debug.activeDebugSession!,
+      //     body: {},
+      //   });
+      //   return command;
+      // }
+    }
+    return command;
+  }
+  public handleDebuggerCommand(command: IProtocolCommand): IProtocolCommand | undefined {
+    switch (command.method) {
+      case "Debugger.resume": {
+        this.debugSessionDelegate.onDebuggerResumed({
           event: "RNIDE_continued",
           session: debug.activeDebugSession!,
           body: {},
@@ -27,19 +40,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         return command;
       }
     }
-    return command;
-  }
-  public handleDebuggerCommand(command: IProtocolCommand): IProtocolCommand | undefined {
-    // switch (command.method) {
-    //   case "Debugger.resume": {
-    //     this.debugSessionDelegate.onDebuggerResumed({
-    //       event: "RNIDE_continued",
-    //       session: debug.activeDebugSession!,
-    //       body: {},
-    //     });
-    //     return command;
-    //   }
-    // }
     return command;
   }
   public handleApplicationReply(

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,0 +1,64 @@
+import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
+import { CDPProxyDelegate } from "./CDPProxy";
+
+export class RadonCDPProxyDelegate implements CDPProxyDelegate {
+  public handleApplicationCommand(command: IProtocolCommand): IProtocolCommand | undefined {
+    switch (command.method) {
+      case "Runtime.consoleAPICalled": {
+        return this.handleConsoleAPICalled(command);
+      }
+    }
+    return command;
+  }
+  public handleDebuggerCommand(command: IProtocolCommand): IProtocolCommand | undefined {
+    return command;
+  }
+  public handleApplicationReply(
+    reply: IProtocolSuccess | IProtocolError
+  ): IProtocolSuccess | IProtocolError | undefined {
+    return reply;
+  }
+  public handleDebuggerReply(
+    reply: IProtocolSuccess | IProtocolError
+  ): IProtocolSuccess | IProtocolError | undefined {
+    return reply;
+  }
+
+  private handleConsoleAPICalled(command: IProtocolCommand): IProtocolCommand | undefined {
+    // We wrap console calls and add stack information as last three arguments, however
+    // some logs may baypass that, especially when printed in initialization phase, so we
+    // need to detect whether the wrapper has added the stack info or not
+    // We check if there are more than 3 arguments, and if the last one is a number
+    // We filter out logs that start with __RNIDE_INTERNAL as those are messages
+    // used by IDE for tracking the app state and should not appear in the VSCode
+    // console.
+    const { args, stackTrace } = command.params as Cdp.Runtime.ConsoleAPICalledEvent;
+    if (args.length > 0 && args[0].value === "__RNIDE_INTERNAL") {
+      // We return here to avoid passing internal logs to the user debug console,
+      // but they will still be visible in metro log feed.
+      return undefined;
+    }
+    if (args.length > 3 && args[args.length - 1].type === "number") {
+      // Since console.log stack is extracted from Error, unlike other messages sent over CDP
+      // the line and column numbers are 1-based
+      const [scriptURL, generatedLineNumber1Based, generatedColumn1Based] = args
+        .splice(-3)
+        .map((v) => v.value);
+
+      // we find the frame received from the wrapped in the stack and remove all frames above it
+      const originalCallFrameIndex = stackTrace?.callFrames.findIndex((frame) => {
+        return (
+          frame.url === scriptURL &&
+          frame.lineNumber === generatedLineNumber1Based - 1 &&
+          frame.columnNumber === generatedColumn1Based
+        );
+      });
+
+      stackTrace?.callFrames.splice(0, originalCallFrameIndex);
+
+      return command;
+    }
+
+    return command;
+  }
+}

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,24 +1,20 @@
 import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
 import { EventEmitter } from "vscode";
-import { CDPProxyDelegate } from "./CDPProxy";
-import { Logger } from "../Logger";
 import _ from "lodash";
+import { CDPProxyDelegate } from "./CDPProxy";
 
 export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   private debuggerPausedEmitter = new EventEmitter();
   private debuggerResumedEmitter = new EventEmitter();
-  private debuggerReadyEmitter = new EventEmitter();
 
   public onDebuggerPaused = this.debuggerPausedEmitter.event;
   public onDebuggerResumed = this.debuggerResumedEmitter.event;
-  public onDebuggerReady = this.debuggerReadyEmitter.event;
 
   constructor() {}
 
   public async handleApplicationCommand(
     command: IProtocolCommand
   ): Promise<IProtocolCommand | undefined> {
-    console.log("Application Command", command);
     switch (command.method) {
       case "Runtime.consoleAPICalled": {
         return this.handleConsoleAPICalled(command);
@@ -26,9 +22,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       case "Debugger.paused": {
         this.debuggerPausedEmitter.fire({});
         return command;
-      }
-      case "Debugger.scriptParsed": {
-        return this.handleScriptParsed(command);
       }
     }
     return command;
@@ -91,52 +84,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       stackTrace?.callFrames.splice(0, originalCallFrameIndex);
 
       return command;
-    }
-
-    return command;
-  }
-
-  private async handleScriptParsed(
-    _command: IProtocolCommand
-  ): Promise<IProtocolCommand | undefined> {
-    const command = _.cloneDeep(_command);
-    const params = command.params as Cdp.Debugger.ScriptParsedEvent;
-    const sourceMapURL = params.sourceMapURL;
-    if (!sourceMapURL) {
-      return command;
-    }
-
-    Logger.log("Source Map URL", sourceMapURL);
-
-    let sourceMapData;
-    if (sourceMapURL?.startsWith("data:")) {
-      const base64Data = sourceMapURL.split(",")[1];
-      const decodedData = Buffer.from(base64Data, "base64").toString("utf-8");
-      sourceMapData = JSON.parse(decodedData);
-    } else {
-      try {
-        const sourceMapResponse = await fetch(sourceMapURL);
-        sourceMapData = await sourceMapResponse.json();
-        const base64URL = Buffer.from(JSON.stringify(sourceMapData)).toString("base64");
-
-        // we need to overwrite the sourceMapURL with the base64 encoded source map
-        // because the js-debug node debugger does not support fetching source maps from http servers
-        params.sourceMapURL = `data:application/json;base64,${base64URL}`;
-      } catch {
-        Logger.debug(`Failed to fetch source map from: ${sourceMapURL}`);
-      }
-    }
-
-    if (!sourceMapData) {
-      return command;
-    }
-
-    const isMainBundle = sourceMapData.sources.some((source: string) =>
-      source.includes("__prelude__")
-    );
-
-    if (isMainBundle) {
-      this.debuggerReadyEmitter.fire({});
     }
 
     return command;

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -27,6 +27,7 @@ import { SidePanelViewProvider } from "./panels/SidepanelViewProvider";
 import { PanelLocation } from "./common/WorkspaceConfig";
 import { Platform } from "./utilities/platform";
 import { IDE } from "./project/ide";
+import { ProxyDebugSessionAdapterDescriptorFactory } from "./debugging/ProxyDebugSession";
 
 const OPEN_PANEL_ON_ACTIVATION = "open_panel_on_activation";
 
@@ -225,9 +226,24 @@ export async function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
+    debug.registerDebugConfigurationProvider(
+      "com.swmansion.proxy-debugger",
+      new DebugConfigProvider(),
+      DebugConfigurationProviderTriggerKind.Dynamic
+    )
+  );
+
+  context.subscriptions.push(
     debug.registerDebugAdapterDescriptorFactory(
       "com.swmansion.react-native-debugger",
       new DebugAdapterDescriptorFactory()
+    )
+  );
+
+  context.subscriptions.push(
+    debug.registerDebugAdapterDescriptorFactory(
+      "com.swmansion.proxy-debugger",
+      new ProxyDebugSessionAdapterDescriptorFactory()
     )
   );
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -12,6 +12,7 @@ import {
   Disposable,
 } from "vscode";
 import vscode from "vscode";
+import { activate as activateJsDebug } from "vscode-js-debug/dist/src/extension";
 import { TabPanel } from "./panels/Tabpanel";
 import { PreviewCodeLensProvider } from "./providers/PreviewCodeLensProvider";
 import { DebugConfigProvider } from "./providers/DebugConfigProvider";
@@ -58,6 +59,7 @@ export function deactivate(context: ExtensionContext): undefined {
 
 export async function activate(context: ExtensionContext) {
   handleUncaughtErrors();
+  await activateJsDebug(context);
 
   if (Platform.OS !== "macos" && Platform.OS !== "windows" && Platform.OS !== "linux") {
     window.showErrorMessage("Radon IDE works only on macOS, Windows and Linux.", "Dismiss");


### PR DESCRIPTION
Uses `js-debug`'s implementation of the JS debugger for targets which support it (Hermes with RN version >= 0.76).
This allows us to use the features already implemented there (exception breakpoints, conditional breakpoints) without having to reimplement them, and possibly allows us to remove our CDP debugger implementation in the future, once we drop support for the older RN versions.

### How Has This Been Tested: 
- launch various apps from `test-apps` repo
- verify that in each app, the debugger still works, and:
  - the debugger toolbar doesn't appear (we provide our own controls when a breakpoint is hit)
  - you can set "caught/uncaught exception" breakpoints and they work
  - setting regular breakpoints work correctly
  - setting conditional breakpoints work
  - logs are routed to the debug console
  - pausing inside RN code works correctly (i.e. when handling caught exceptions)
  - ???
