### PR TITLE
fix render outline duration changing with display refresh rate

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -72,7 +72,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.53.2",
-        "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon/react-scan-0.1.3-radon.tgz",
+        "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
         "rollup": "^4.18.1",
         "rollup-plugin-license": "^3.5.3",
         "semver": "^7.6.2",
@@ -23247,9 +23247,9 @@
       "license": "0BSD"
     },
     "node_modules/react-scan": {
-      "version": "0.1.3-radon",
-      "resolved": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon/react-scan-0.1.3-radon.tgz",
-      "integrity": "sha512-TYnp+viBvt86T7IqJ8jtX5cOCfKqf7zdt5s3h2z1SJsa+/MkI42xgxSX+cadLnmlZnOfaMutEVrJqgPJHwegmQ==",
+      "version": "0.1.3-radon-1",
+      "resolved": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
+      "integrity": "sha512-rWBhg2OFnw5A4OnihKMoIRUKgzH/ZKMXbOx+++/ns6+bpXKAaRWX7wczbgFjwZclsOP6cITIYrQfeatqApNljw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -706,7 +706,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.53.2",
-    "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon/react-scan-0.1.3-radon.tgz",
+    "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
     "rollup": "^4.18.1",
     "rollup-plugin-license": "^3.5.3",
     "semver": "^7.6.2",


### PR DESCRIPTION
In `react-scan`'s outline renderer implementation, the duration of the outlines is fixed to 45 frames. This causes issues on high refresh rate displays, with frames disappearing too quickly.
This PR updates the version of `react-scan` to our fork which includes a fix for that.
The actual fix was made in https://github.com/software-mansion-labs/react-scan/commit/406f48e31cbd3ff0d16f6568597cbc980626350f