### PR TITLE
Start separate debug adapters for Metro and JS debugging

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -288,7 +288,16 @@
     "debuggers": [
       {
         "type": "com.swmansion.react-native-debugger",
-        "label": "Radon IDE internal debugger for React Native",
+        "label": "Radon IDE internal debugger for React Native projects",
+        "hiddenWhen": "true",
+        "languages": [
+          "javascript",
+          "typescript"
+        ]
+      },
+      {
+        "type": "com.swmansion.js-debugger",
+        "label": "Radon IDE internal JavaScript debugger",
         "hiddenWhen": "true",
         "languages": [
           "javascript",

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -33,16 +33,6 @@ export type CDPConfiguration = {
 
 const ERROR_RESPONSE_FAIL_TO_RETRIEVE_VARIABLE_ID = 4000;
 
-export function typeToCategory(type: string) {
-  switch (type) {
-    case "warning":
-    case "error":
-      return "stderr";
-    default:
-      return "stdout";
-  }
-}
-
 export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate {
   private cdpSession: CDPSession | undefined;
 
@@ -57,10 +47,10 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
       "websocketAddress" in configuration,
       "CDPDebugSession requires websocketAddress"
     );
-    this.connectJSDebugger(configuration as unknown as CDPConfiguration);
+    this.startCDPSession(configuration as unknown as CDPConfiguration);
   }
 
-  private connectJSDebugger(cdpConfiguration: CDPConfiguration) {
+  private startCDPSession(cdpConfiguration: CDPConfiguration) {
     this.cdpSession = new CDPSession(
       this,
       cdpConfiguration.websocketAddress,

--- a/packages/vscode-extension/src/debugging/CDPDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugSession.ts
@@ -1,0 +1,391 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { DebugConfiguration } from "vscode";
+import {
+  DebugSession,
+  InitializedEvent,
+  StoppedEvent,
+  Event,
+  ContinuedEvent,
+  OutputEvent,
+  Thread,
+  TerminatedEvent,
+  ThreadEvent,
+  StackFrame,
+} from "@vscode/debugadapter";
+import { DebugProtocol } from "@vscode/debugprotocol";
+import { Logger } from "../Logger";
+import {
+  inferDAPScopePresentationHintFromCDPType,
+  inferDAPVariableValueForCDPRemoteObject,
+  CDPDebuggerScope,
+} from "./cdp";
+import { CDPSession, CDPSessionDelegate } from "./CDPSession";
+import getArraySlots from "./templates/getArraySlots";
+
+export type CDPConfiguration = {
+  websocketAddress: string;
+  expoPreludeLineCount: number;
+  sourceMapAliases: [string, string][];
+  breakpointsAreRemovedOnContextCleared: boolean;
+};
+
+const ERROR_RESPONSE_FAIL_TO_RETRIEVE_VARIABLE_ID = 4000;
+
+export function typeToCategory(type: string) {
+  switch (type) {
+    case "warning":
+    case "error":
+      return "stderr";
+    default:
+      return "stdout";
+  }
+}
+
+export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate {
+  private cdpSession: CDPSession | undefined;
+
+  private threads: Array<Thread> = [];
+
+  private pausedStackFrames: StackFrame[] = [];
+  private pausedScopeChains: CDPDebuggerScope[][] = [];
+
+  constructor(configuration: DebugConfiguration) {
+    super();
+    console.assert(
+      "websocketAddress" in configuration,
+      "CDPDebugSession requires websocketAddress"
+    );
+    this.connectJSDebugger(configuration as unknown as CDPConfiguration);
+  }
+
+  private connectJSDebugger(cdpConfiguration: CDPConfiguration) {
+    this.cdpSession = new CDPSession(
+      this,
+      cdpConfiguration.websocketAddress,
+      {
+        expoPreludeLineCount: cdpConfiguration.expoPreludeLineCount,
+        sourceMapAliases: cdpConfiguration.sourceMapAliases,
+      },
+      {
+        breakpointsAreRemovedOnContextCleared:
+          cdpConfiguration.breakpointsAreRemovedOnContextCleared,
+      }
+    );
+  }
+  //#region CDPDelegate
+
+  public onExecutionContextCreated = (threadId: number, threadName: string) => {
+    this.sendEvent(new ThreadEvent("started", threadId));
+    this.threads.push(new Thread(threadId, threadName));
+  };
+
+  public onConnectionClosed = () => {
+    this.sendEvent(new TerminatedEvent());
+  };
+
+  public onDebugSessionReady = () => {
+    this.sendEvent(new InitializedEvent());
+  };
+
+  public onDebuggerPaused = (message: any) => {};
+
+  public onDebuggerResumed = () => {
+    this.sendEvent(new ContinuedEvent(this.threads[0].id));
+  };
+
+  public onExecutionContextsCleared = () => {
+    const allThreads = this.threads;
+    this.threads = [];
+    // send events for all threads that exited
+    allThreads.forEach((thread) => {
+      this.sendEvent(new ThreadEvent("exited", thread.id));
+    });
+
+    // send event to clear console
+    this.sendEvent(new OutputEvent("\x1b[2J", "console"));
+  };
+
+  public sendOutputEvent = (output: OutputEvent) => {
+    this.sendEvent(output);
+    this.sendEvent(new Event("RNIDE_consoleLog", { category: output.body.category }));
+  };
+
+  public sendStoppedEvent = (
+    pausedStackFrames: StackFrame[],
+    pausedScopeChains: CDPDebuggerScope[][],
+    reason: string,
+    exceptionText?: string,
+    isFatal?: string
+  ) => {
+    this.pausedStackFrames = pausedStackFrames;
+    this.pausedScopeChains = pausedScopeChains;
+
+    this.sendEvent(new StoppedEvent(reason, this.threads[0].id, exceptionText));
+    this.sendEvent(new Event("RNIDE_paused", { reason, isFatal }));
+  };
+
+  //#endregion
+
+  //#region DAP Implementation
+
+  protected initializeRequest(
+    response: DebugProtocol.InitializeResponse,
+    args: DebugProtocol.InitializeRequestArguments
+  ): void {
+    response.body = response.body || {};
+
+    this.sendResponse(response);
+  }
+
+  protected launchRequest(
+    response: DebugProtocol.LaunchResponse,
+    args: DebugProtocol.LaunchRequestArguments
+  ): void {
+    // Implement launching the debugger
+    this.sendResponse(response);
+  }
+
+  protected async setBreakPointsRequest(
+    response: DebugProtocol.SetBreakpointsResponse,
+    args: DebugProtocol.SetBreakpointsArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [setBreakPointsRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    const sourcePath = args.source.path;
+    if (!sourcePath) {
+      this.sendResponse(response);
+      return;
+    }
+
+    const resolvedBreakpoints = await this.cdpSession.handleSetBreakpointRequest(
+      sourcePath,
+      args.breakpoints
+    );
+
+    // send back the actual breakpoint positions
+    response.body = {
+      breakpoints: resolvedBreakpoints,
+    };
+    this.sendResponse(response);
+  }
+
+  protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+    response.body = {
+      threads: this.threads,
+    };
+    this.sendResponse(response);
+  }
+
+  protected stackTraceRequest(
+    response: DebugProtocol.StackTraceResponse,
+    args: DebugProtocol.StackTraceArguments
+  ): void {
+    response.body = response.body || {};
+    response.body.stackFrames = this.pausedStackFrames;
+    this.sendResponse(response);
+  }
+
+  protected async scopesRequest(
+    response: DebugProtocol.ScopesResponse,
+    args: DebugProtocol.ScopesArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [scopesRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    response.body = response.body || {};
+
+    response.body.scopes =
+      this.pausedScopeChains[args.frameId]?.map((scope) => ({
+        name: scope.type === "closure" ? "CLOSURE" : scope.name || scope.type.toUpperCase(), // for closure type, names are just numbers, so they don't look good, instead we just use name "CLOSURE"
+        variablesReference: this.cdpSession!.adaptCDPObjectId(scope.object.objectId),
+        presentationHint: inferDAPScopePresentationHintFromCDPType(scope.type),
+        expensive: scope.type !== "local", // we only mark local scope as non-expensive as it is the one typically people want to look at and shouldn't have too many objects
+      })) || [];
+    this.sendResponse(response);
+  }
+
+  protected async sourceRequest(
+    response: DebugProtocol.Response & {
+      body: {
+        sourceURL: string;
+        lineNumber1Based: number;
+        columnNumber0Based: number;
+        scriptURL: string;
+      };
+    },
+    args: DebugProtocol.SourceArguments & {
+      fileName: string;
+      line0Based: number;
+      column0Based: number;
+    },
+    request?: DebugProtocol.Request
+  ) {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [sourceRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    response.body = {
+      ...this.cdpSession.findOriginalPosition(args.fileName, args.line0Based, args.column0Based),
+    };
+    this.sendResponse(response);
+  }
+
+  protected async variablesRequest(
+    response: DebugProtocol.Response,
+    args: DebugProtocol.VariablesArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [variablesRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    response.body = response.body || {};
+    response.body.variables = [];
+
+    try {
+      if (args.filter !== "indexed" && args.filter !== "named") {
+        response.body.variables = await this.cdpSession.getVariable(args.variablesReference);
+      } else if (args.filter === "indexed") {
+        const stringified = "" + getArraySlots;
+
+        const partialValue = await this.cdpSession!.sendCDPMessage("Runtime.callFunctionOn", {
+          functionDeclaration: stringified,
+          objectId: this.cdpSession.convertDAPObjectIdToCDP(args.variablesReference),
+          arguments: [args.start, args.count].map((value) => ({ value })),
+        });
+
+        const properties = await this.cdpSession.getVariable(
+          this.cdpSession.adaptCDPObjectId(partialValue.result.objectId)
+        );
+
+        response.body.variables = properties;
+      } else if (args.filter === "named") {
+        // We do nothing for named variables. We set 'named' and 'indexed' only for arrays in variableStore
+        // so the 'named' here means "display chunks" (which is handled by Debugger). If we'd get the properties
+        // here we would get all indexed properties even when passing `nonIndexedPropertiesOnly: true` param
+        // to Runtime.getProperties. I assume that this property just does not work yet as it's marked as experimental.
+      }
+    } catch (e) {
+      Logger.error("[CDP] Failed to retrieve variable", e);
+      response.success = false;
+      response.body.error = {
+        id: ERROR_RESPONSE_FAIL_TO_RETRIEVE_VARIABLE_ID,
+        format: "Failed to retrieve variable",
+      };
+    }
+
+    this.sendResponse(response);
+  }
+
+  protected async continueRequest(
+    response: DebugProtocol.ContinueResponse,
+    args: DebugProtocol.ContinueArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [continueRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    await this.cdpSession.sendCDPMessage("Debugger.resume", { terminateOnResume: false });
+    this.sendResponse(response);
+    this.sendEvent(new Event("RNIDE_continued"));
+  }
+
+  protected async nextRequest(
+    response: DebugProtocol.NextResponse,
+    args: DebugProtocol.NextArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [nextRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    await this.cdpSession.sendCDPMessage("Debugger.stepOver", {});
+    this.sendResponse(response);
+  }
+
+  protected disconnectRequest(
+    response: DebugProtocol.DisconnectResponse,
+    args: DebugProtocol.DisconnectArguments
+  ): void {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [disconnectRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    this.cdpSession.closeConnection();
+    this.sendResponse(response);
+  }
+
+  protected async evaluateRequest(
+    response: DebugProtocol.EvaluateResponse,
+    args: DebugProtocol.EvaluateArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [evaluateRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    const cdpResponse = await this.cdpSession!.sendCDPMessage("Runtime.evaluate", {
+      expression: args.expression,
+    });
+    const remoteObject = cdpResponse.result;
+    const stringValue = inferDAPVariableValueForCDPRemoteObject(remoteObject);
+
+    response.body = response.body || {};
+    response.body.result = stringValue;
+    response.body.variablesReference = 0;
+    if (remoteObject.type === "object") {
+      const dapID = this.cdpSession.adaptCDPObjectId(remoteObject.objectId);
+      response.body.type = "object";
+      response.body.variablesReference = dapID;
+    }
+    this.sendResponse(response);
+  }
+
+  protected async customRequest(
+    command: string,
+    response: DebugProtocol.Response,
+    args: any,
+    request?: DebugProtocol.Request | undefined
+  ) {
+    switch (command) {
+      case "RNIDE_startProfiling":
+        if (this.cdpSession) {
+          await this.cdpSession.startProfiling();
+          this.sendEvent(new Event("RNIDE_profilingCPUStarted"));
+        }
+        break;
+      case "RNIDE_stopProfiling":
+        if (this.cdpSession) {
+          const profile = await this.cdpSession.stopProfiling();
+          const fileName = `profile-${Date.now()}.cpuprofile`;
+          const filePath = path.join(os.tmpdir(), fileName);
+          await fs.promises.writeFile(filePath, JSON.stringify(profile));
+          this.sendEvent(new Event("RNIDE_profilingCPUStopped", { filePath }));
+        }
+        break;
+      default:
+        Logger.debug(`Custom req ${command} ${args}`);
+    }
+    this.sendResponse(response);
+  }
+
+  //#endregion
+}

--- a/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
@@ -1,6 +1,6 @@
 import vscode from "vscode";
 import { DebugAdapter } from "./DebugAdapter";
-import { CDPDebugAdapter } from "./CDPDebugSession";
+import { CDPDebugAdapter } from "./CDPDebugAdapter";
 
 export class DebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
   createDebugAdapterDescriptor(

--- a/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
@@ -1,11 +1,20 @@
 import vscode from "vscode";
 import { DebugAdapter } from "./DebugAdapter";
+import { CDPDebugAdapter } from "./CDPDebugSession";
 
 export class DebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
   createDebugAdapterDescriptor(
     session: vscode.DebugSession
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    return new vscode.DebugAdapterInlineImplementation(new DebugAdapter(session));
+  }
+}
+
+export class CDPDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+  createDebugAdapterDescriptor(
+    session: vscode.DebugSession
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
     const configuration = session.configuration;
-    return new vscode.DebugAdapterInlineImplementation(new DebugAdapter(configuration));
+    return new vscode.DebugAdapterInlineImplementation(new CDPDebugAdapter(configuration));
   }
 }

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -1,4 +1,6 @@
+import { assert } from "console";
 import {
+  commands,
   debug,
   DebugSessionCustomEvent,
   Disposable,
@@ -19,6 +21,8 @@ export type DebugSessionDelegate = {
 };
 
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
+
+const REACT_NATIVE_SESSION_TYPE = "com.swmansion.react-native-debugger";
 
 export class DebugSession implements Disposable {
   private vscSession: VscDebugSession | undefined;
@@ -71,11 +75,18 @@ export class DebugSession implements Disposable {
   }
 
   private async startInternal() {
+    const unsub = debug.onDidStartDebugSession((session) => {
+      if (session.type === REACT_NATIVE_SESSION_TYPE) {
+        this.vscSession = session;
+        unsub.dispose();
+      }
+    });
+
     const debugStarted = await debug.startDebugging(
       undefined,
       {
-        type: "com.swmansion.react-native-debugger",
-        name: "Radon IDE Debugger",
+        type: REACT_NATIVE_SESSION_TYPE,
+        name: "React Native Preview Debugger",
         request: "attach",
       },
       {
@@ -87,7 +98,9 @@ export class DebugSession implements Disposable {
     );
 
     if (debugStarted) {
-      this.vscSession = debug.activeDebugSession!;
+      // NOTE: this is safe, because `debugStarted` means the session started successfully,
+      // and we set the session in the `onDidStartDebugSession` handler
+      assert(this.vscSession, "Expected debug session to be set");
       return true;
     }
     return false;
@@ -162,11 +175,15 @@ export class DebugSession implements Disposable {
   }
 
   public resumeDebugger() {
-    this.session.customRequest("continue");
+    commands.executeCommand("workbench.action.debug.continue", undefined, {
+      sessionId: this.vscSession?.id,
+    });
   }
 
   public stepOverDebugger() {
-    this.session.customRequest("next");
+    commands.executeCommand("workbench.action.debug.stepOver", undefined, {
+      sessionId: this.vscSession?.id,
+    });
   }
 
   public async isWsTargetAlive(metro: Metro): Promise<boolean> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -15,7 +15,10 @@ import vscode from "vscode";
 import { TabPanel } from "./panels/Tabpanel";
 import { PreviewCodeLensProvider } from "./providers/PreviewCodeLensProvider";
 import { DebugConfigProvider } from "./providers/DebugConfigProvider";
-import { DebugAdapterDescriptorFactory } from "./debugging/DebugAdapterDescriptorFactory";
+import {
+  CDPDebugAdapterDescriptorFactory,
+  DebugAdapterDescriptorFactory,
+} from "./debugging/DebugAdapterDescriptorFactory";
 import { Logger, enableDevModeLogging } from "./Logger";
 import {
   extensionContext,
@@ -223,9 +226,23 @@ export async function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
+    debug.registerDebugConfigurationProvider(
+      "com.swmansion.js-debugger",
+      new DebugConfigProvider(),
+      DebugConfigurationProviderTriggerKind.Dynamic
+    )
+  );
+
+  context.subscriptions.push(
     debug.registerDebugAdapterDescriptorFactory(
       "com.swmansion.react-native-debugger",
       new DebugAdapterDescriptorFactory()
+    )
+  );
+  context.subscriptions.push(
+    debug.registerDebugAdapterDescriptorFactory(
+      "com.swmansion.js-debugger",
+      new CDPDebugAdapterDescriptorFactory()
     )
   );
 

--- a/packages/vscode-extension/src/providers/DebugConfigProvider.ts
+++ b/packages/vscode-extension/src/providers/DebugConfigProvider.ts
@@ -14,9 +14,6 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
   ): ProviderResult<DebugConfiguration> {
     return {
       ...debugConfiguration,
-      request: "attach",
-      name: "React Native Preview Debugger",
-      websocketAddress: debugConfiguration.websocketAddress,
       internalConsoleOptions: "neverOpen",
     };
   }


### PR DESCRIPTION
Refactors the changes introduced in #964 to separate logging metro messages and JS debugging into separate DAP Sessions. This will also make integrating #1001 easier with other changes made to `DebugAdapter`.

### How Has This Been Tested: 
Open an app and check the debugger still works correctly:
- breakpoints and uncaught errors should still stop the application
- debugger controls in the preview should resume/step over breakpoints
- check profiling still works
- check if Metro errors are logged to the debug console.


