### PR TITLE
Fix circular dependency in CDPBreakpoints

### DIFF
--- a/packages/vscode-extension/src/debugging/BreakpointsController.ts
+++ b/packages/vscode-extension/src/debugging/BreakpointsController.ts
@@ -67,7 +67,9 @@ export class BreakpointsController {
         return previousBp;
       } else {
         return new CDPBreakpoint(
-          this.cdpSession,
+          (method: string, params: object, timeoutMs?: number) => {
+            return this.cdpSession.sendCDPMessage(method, params, timeoutMs);
+          },
           this.sourceMapController,
           sourcePath,
           bp.line,


### PR DESCRIPTION
This PR fixes an issue with CDPBreakpoints owning CDPSession causing circular dependency after #964.  

We solve the problem by: CDPBreakpoints no longer owns CDPSession and only takes a callback that alows it to send CDP messages

### How Has This Been Tested: 

Run `expo-go` test app and set some breakpoints


