### PR TITLE
fix misalignment of render outlines

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -72,7 +72,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.53.2",
-        "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
+        "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-2/react-scan-0.1.3-radon-2.tgz",
         "rollup": "^4.18.1",
         "rollup-plugin-license": "^3.5.3",
         "semver": "^7.6.2",
@@ -23247,9 +23247,9 @@
       "license": "0BSD"
     },
     "node_modules/react-scan": {
-      "version": "0.1.3-radon-1",
-      "resolved": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
-      "integrity": "sha512-rWBhg2OFnw5A4OnihKMoIRUKgzH/ZKMXbOx+++/ns6+bpXKAaRWX7wczbgFjwZclsOP6cITIYrQfeatqApNljw==",
+      "version": "0.1.3-radon-2",
+      "resolved": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-2/react-scan-0.1.3-radon-2.tgz",
+      "integrity": "sha512-aq16RPe1wEp4zKeckjqboPtEuJOpedCFI/6wMIZ3V9aA0wHG2gDOr+/VqfBQoe8eAei1Dq1bMCJfTCAO90GPGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -706,7 +706,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.53.2",
-    "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-1/react-scan-0.1.3-radon-1.tgz",
+    "react-scan": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-2/react-scan-0.1.3-radon-2.tgz",
     "rollup": "^4.18.1",
     "rollup-plugin-license": "^3.5.3",
     "semver": "^7.6.2",

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { CanvasOutlineRenderer, OutlineRenderer, WorkerOutlineRenderer } from "react-scan";
+import { CanvasOutlineRenderer, OutlineRenderer } from "react-scan";
 import {
   RenderOutlinesEventListener,
   RenderOutlinesEventMap,
@@ -22,11 +22,7 @@ interface Size {
 }
 
 function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: number) {
-  try {
-    return new WorkerOutlineRenderer(canvas, size, dpr);
-  } catch {
-    return new CanvasOutlineRenderer(canvas, size, dpr);
-  }
+  return new CanvasOutlineRenderer(canvas, size, dpr);
 }
 
 function useIsEnabled() {


### PR DESCRIPTION
Fixes #1012  
Fixes misalignment of render outlines when the display is scaled.
The actual fix was made in https://github.com/software-mansion-labs/react-scan/pull/1/commits/5e45c560a964b7c5d490505cac89618d739b777b
