### PR TITLE
update react-scan hash in package lock

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -23249,7 +23249,7 @@
     "node_modules/react-scan": {
       "version": "0.1.3-radon-2",
       "resolved": "https://github.com/software-mansion-labs/react-scan/releases/download/0.1.3-radon-2/react-scan-0.1.3-radon-2.tgz",
-      "integrity": "sha512-aq16RPe1wEp4zKeckjqboPtEuJOpedCFI/6wMIZ3V9aA0wHG2gDOr+/VqfBQoe8eAei1Dq1bMCJfTCAO90GPGQ==",
+      "integrity": "sha512-Si0ye7taSeKz8DKCVRrvMnQ1TLcZWngHh9kEuH2TG68xFj6piRvSILnWvMzYJizpO6LciZ8b0yi0e46ABhor0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updates package-lock after updating the react-scan package to include https://github.com/software-mansion-labs/react-scan/commit/b3afb2f427d2fefb8d61bcab98a26bafe9141c69