### PR TITLE
Fix bundle error source

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -288,7 +288,7 @@ export class Metro implements Disposable {
               const message = stripAnsi(event.message);
               let filename = event.error.originModulePath;
               if (!filename && event.error.filename) {
-                filename = appRoot + event.error.filename;
+                filename = path.join(appRoot, event.error.filename);
               }
               this.delegate.onBundlingError(
                 message,


### PR DESCRIPTION
this PR fixes how bundle error source was created in case when `originModulePath` is missing

### How Has This Been Tested: 

run `react-native-77` test app and force syntax error



