### PR TITLE
Fix new debugger detection

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -377,7 +377,7 @@ export class Metro implements Disposable {
         page.reactNative &&
         (page.title.startsWith("React Native Bridge") ||
           page.description.endsWith("[C++ connection]") ||
-          page?.reactNative?.capabilities?.prefersFuseboxFrontend)
+          page.reactNative.capabilities?.prefersFuseboxFrontend)
     );
   }
 

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -376,7 +376,8 @@ export class Metro implements Disposable {
       (page) =>
         page.reactNative &&
         (page.title.startsWith("React Native Bridge") ||
-          page.description.endsWith("[C++ connection]"))
+          page.description.endsWith("[C++ connection]") ||
+          page?.reactNative?.capabilities?.prefersFuseboxFrontend)
     );
   }
 


### PR DESCRIPTION
This PR changes how we check if the new JS debugger (aka. Fusebox) is enabled by inspecting the debugged Page's `capabilities` for the `prefersFuseboxFrontend` flag, which is set by the RN application when the new debugger is enabled.