### PR TITLE
Rework CI to build fresh versions for publication

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -101,7 +101,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.package_extension.outputs.vsix_path }}
           pat: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
           target: ${{ steps.set_targets.outputs.targets }}
 
@@ -111,6 +110,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          extensionFile: ${{ steps.package_extension.outputs.vsix_path }}
           pat: ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }}
           target: ${{ steps.set_targets.outputs.targets }}


### PR DESCRIPTION
This PR changes the behavior of the publishing CI to allow for automatic packaging process to take place when publishing instead of using an artefakt created for github publication. 
This change is needed because `vsce` and `osvx` publishing commands are not capable of changing the metadata of already packaged `vsix` directories and the universal target specified in original artefakt would conflict with targets specified by CI user. 

### How Has This Been Tested: 

it can only be tested by running it :( 



