### PR TITLE
Fix android app name detection

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -151,7 +151,7 @@ export async function buildAndroid(
   const androidAppName = loadConfig({
     projectRoot: appRoot,
     selectedPlatform: "android",
-  }).platforms.android.projectConfig(appRoot)?.appName;
+  }).platforms.android?.projectConfig(appRoot)?.appName;
   const productFlavor = android?.productFlavor || "";
   const buildType = android?.buildType || "debug";
   const gradleArgs = [


### PR DESCRIPTION
This PR fixes a regression introduces in #1004. It seems that in some configuration loadConfig is returning an object but gives no details for `platform.android` that caused Radon to crash. As we already expect that config might not exist the fix is to read `projectConfig` conditionally.

### How Has This Been Tested: 

The problem surfaced itself for me in `expo-52-prebuild-with.-plugins` test app. It build correctly after this fix


