### PR TITLE
Support inline shell scripts for custom build script

### DIFF
--- a/packages/vscode-extension/src/builders/customBuild.ts
+++ b/packages/vscode-extension/src/builders/customBuild.ts
@@ -78,7 +78,7 @@ async function runExternalScript(
   cwd: string,
   cancelToken?: CancelToken
 ) {
-  let process = command(externalCommand, { cwd, env });
+  let process = command(externalCommand, { cwd, env, shell: true });
   process = cancelToken ? cancelToken.adapt(process) : process;
   Logger.info(`Running external script: ${externalCommand}`);
 


### PR DESCRIPTION
This PR adds a support for inline shell script in `customBuild.{Platform}.buildCommand` configuration. For many users the mos intuitive way of utilizing build command was to wirite something like `echo ${PWD}/apkPath` this would not work tho as `$ENV` syntax requires full shell, so we start running `buildCommand` in shell. 

### How Has This Been Tested: 

build `expo-52-prebuild-with-plugins` android project and find generated apk in `android/app/build/outputs/apk/debug` copy this apk to the root of the application and set the android build command as `echo ${PWD}/apkPath` remove the whole android folder from the project root and run application, it works correct. 

