### PR TITLE
Refactor publishing CI so it publishes the same artefacts it packges

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           IFS=' ' read -r -a output_paths <<< "${{ steps.package_and_upload.outputs.output_paths }}"
           for output_path in "${output_paths[@]}"; do
-            npm run vscode:publish -- --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --vsix $output_path
+            npm run vscode:publish -- --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath $output_path
           done
       
       - name: Publish to Open VSX Registry for each target
@@ -118,5 +118,5 @@ jobs:
         run: |
           IFS=' ' read -r -a output_paths <<< "${{ steps.package_and_upload.outputs.output_paths }}"
           for output_path in "${output_paths[@]}"; do
-            npm run openVSX:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --vsix $output_path
+            npm run openVSX:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --packagePath $output_path
           done

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -78,30 +78,45 @@ jobs:
           package_name=radon-ide-${ref_name}-${{ steps.date.outputs.date }}
           echo "package_name=$package_name" >> $GITHUB_OUTPUT
 
-      - name: Package extension
+      - name: Package extension for each target
         working-directory: packages/vscode-extension
-        id: package_extension
+        id: package_and_upload
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          out_path=/tmp/${{ steps.prepare_name.outputs.package_name }}.vsix
-          npm run vscode:package -- --out $out_path
-          echo "vsix_path=$out_path" >> $GITHUB_OUTPUT
+          IFS=' ' read -r -a targets <<< "${{ steps.set_targets.outputs.targets }}"
+          output_paths=""
+          for target in "${targets[@]}"; do
+            out_path=/tmp/${{ steps.prepare_name.outputs.package_name }}-$target.vsix
+            npm run vscode:package -- --out $out_path --target $target
+            output_paths="$output_paths $out_path"
+          done
+          echo "output_paths=$output_paths" >> $GITHUB_OUTPUT
 
-      - name: Upload extension artifact
+      - name: Upload extension artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.prepare_name.outputs.package_name }}
-          path: ${{ steps.package_extension.outputs.vsix_path }}
+          name: radon-ide-extensions
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*.vsix
 
-      - name: Publish to Visual Studio Marketplace
+      - name: Publish to Visual Studio Marketplace for each target
         working-directory: packages/vscode-extension
+        if: ${{ github.event.inputs.publish == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: npm run vscode:publish -- --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --target ${{ steps.set_targets.outputs.targets }}
-        
-      - name: Publish to Open VSX Registry
+        run: |
+          IFS=' ' read -r -a output_paths <<< "${{ steps.package_and_upload.outputs.output_paths }}"
+          for output_path in "${output_paths[@]}"; do
+            npm run vscode:publish -- --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --vsix $output_path
+          done
+      
+      - name: Publish to Open VSX Registry for each target
         working-directory: packages/vscode-extension
+        if: ${{ github.event.inputs.publish == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: npm run openVSX:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --target ${{ steps.set_targets.outputs.targets }}
+        run: |
+          IFS=' ' read -r -a output_paths <<< "${{ steps.package_and_upload.outputs.output_paths }}"
+          for output_path in "${output_paths[@]}"; do
+            npm run openVSX:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --vsix $output_path
+          done

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -118,5 +118,5 @@ jobs:
         run: |
           IFS=' ' read -r -a output_paths <<< "${{ steps.package_and_upload.outputs.output_paths }}"
           for output_path in "${output_paths[@]}"; do
-            npm run openVSX:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --packagePath $output_path
+            npm run open-vsx:publish -- --pat ${{ secrets.OPENVSX_MARKETPLACE_TOKEN }} --packagePath $output_path
           done

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -628,7 +628,7 @@
     "vscode:package": "vsce package",
     "vscode:prepublish": "npm run package",
     "vscode:publish": "vsce publish",
-    "openVSX:publish": "ovsx publish",
+    "open-vsx:publish": "ovsx publish",
     "copy:redux-devtools-plugin": "rm -rf lib/plugins/third-party/redux-devtools-expo-dev-plugin.js && cp ../redux-devtools-expo-dev-plugin/artifacts/RadonIDE/redux-devtools-expo-dev-plugin.js lib/plugins/third-party/redux-devtools-expo-dev-plugin.js",
     "build:redux-devtools-ui": "rm -rf dist/redux-devtools && cp -R ../redux-devtools-expo-dev-plugin/artifacts/RadonIDE/redux-devtools dist/redux-devtools",
     "build:react-query-devtools-ui": "rm -rf dist/react-query-devtools && cp -R ../radon-ide-react-query-webui/artifacts dist/react-query-devtools",


### PR DESCRIPTION
This change allows us for packaging each target only once and not 3 times. 

### How Has This Been Tested: 

Dry job was run here https://github.com/software-mansion/radon-ide/actions/runs/13837593885
with `Publish to Visual Studio Marketplace for each target` printing the targets instead of publishing them 
unfortunately publishing it self can only be tested live 


