### PR TITLE
Ignore derived data for fingerprint calculation

### DIFF
--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -19,6 +19,7 @@ const IGNORE_PATHS = [
   path.join("android", "build/**/*"),
   path.join("android", "app", "build/**/*"),
   path.join("ios", "build/**/*"),
+  path.join("ios", "DerivedData/**/*"),
   "**/node_modules/**/android/.cxx/**/*",
   "**/node_modules/**/.gradle/**/*",
   "**/node_modules/**/android/build/intermediates/cxx/**/*",


### PR DESCRIPTION
This PR adds `DerivedData` to ignore paths of fingerprint command. 
This is a solve for very long calculation times for users that keep this data relative to their ios project. 
To enable this behavior:
1) open `xcode`
2) from top menu choose xcode>settings
3) go to locations tab
4) switch derived data to relative

### How Has This Been Tested: 

- switch the option as described above 
- clean rebuild `expo-52-prebuild-with-plugins` test app
- reload after the clean build and check if calculation takes normal amount of time



