### PR TITLE
Add an option to test deeplinks with app terminated

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -175,7 +175,7 @@ export interface ProjectInterface {
   resetAppPermissions(permissionType: AppPermissionType): Promise<void>;
 
   getDeepLinksHistory(): Promise<string[]>;
-  openDeepLink(link: string): Promise<void>;
+  openDeepLink(link: string, terminateApp: boolean): Promise<void>;
 
   startRecording(): void;
   captureAndStopRecording(): void;

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -540,9 +540,13 @@ export class AndroidEmulatorDevice extends DeviceBase {
     return true; // Android will terminate the process if any of the permissions were granted prior to reset-permissions call
   }
 
-  async sendDeepLink(link: string, build: BuildResult) {
+  async sendDeepLink(link: string, build: BuildResult, terminateApp: boolean) {
     if (build.platform !== DevicePlatform.Android) {
       throw new Error("Invalid platform");
+    }
+
+    if (terminateApp) {
+      await exec(ADB_PATH, ["-s", this.serial!, "shell", "am", "force-stop", build.packageName]);
     }
 
     await exec(ADB_PATH, [

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -444,7 +444,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     }
     // terminate the app before launching, otherwise launch commands won't actually start the process which
     // may be in a bad state
-    await exec(ADB_PATH, ["-s", this.serial!, "shell", "am", "force-stop", build.packageName]);
+    this.terminateApp(build.packageName);
 
     this.mirrorNativeLogs(build);
 
@@ -540,13 +540,13 @@ export class AndroidEmulatorDevice extends DeviceBase {
     return true; // Android will terminate the process if any of the permissions were granted prior to reset-permissions call
   }
 
-  async sendDeepLink(link: string, build: BuildResult, terminateApp: boolean) {
+  async terminateApp(packageName: string) {
+    await exec(ADB_PATH, ["-s", this.serial!, "shell", "am", "force-stop", packageName]);
+  }
+
+  async sendDeepLink(link: string, build: BuildResult) {
     if (build.platform !== DevicePlatform.Android) {
       throw new Error("Invalid platform");
-    }
-
-    if (terminateApp) {
-      await exec(ADB_PATH, ["-s", this.serial!, "shell", "am", "force-stop", build.packageName]);
     }
 
     await exec(ADB_PATH, [

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -33,7 +33,11 @@ export abstract class DeviceBase implements Disposable {
     appPermission: AppPermissionType,
     buildResult: BuildResult
   ): Promise<boolean>;
-  abstract sendDeepLink(link: string, buildResult: BuildResult): Promise<void>;
+  abstract sendDeepLink(
+    link: string,
+    buildResult: BuildResult,
+    terminateApp: boolean
+  ): Promise<void>;
 
   async acquire() {
     const acquired = await tryAcquiringLock(this.lockFilePath);

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -26,6 +26,7 @@ export abstract class DeviceBase implements Disposable {
   abstract getClipboard(): Promise<string | void>;
   abstract installApp(build: BuildResult, forceReinstall: boolean): Promise<void>;
   abstract launchApp(build: BuildResult, metroPort: number, devtoolsPort: number): Promise<void>;
+  abstract terminateApp(packageNameOrBundleID: string): Promise<void>;
   abstract makePreview(): Preview;
   abstract get platform(): DevicePlatform;
   abstract get deviceInfo(): DeviceInfo;

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -290,7 +290,7 @@ export class IosSimulatorDevice extends DeviceBase {
     }
   }
 
-  terminateApp = async (bundleID: string) => {
+  async terminateApp(bundleID: string) {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
 
     // Terminate the app if it's running:
@@ -303,7 +303,7 @@ export class IosSimulatorDevice extends DeviceBase {
     } catch (e) {
       // terminate will exit with non-zero code when the app wasn't running. we ignore this error
     }
-  };
+  }
 
   /**
    * This function terminates any running applications. Might be useful when you launch a new application
@@ -327,7 +327,11 @@ export class IosSimulatorDevice extends DeviceBase {
       matches.push(match[1]);
     }
 
-    await Promise.all(matches.map(this.terminateApp));
+    await Promise.all(
+      matches.map((e) => {
+        this.terminateApp(e);
+      })
+    );
   }
 
   async launchWithBuild(build: IOSBuildResult) {
@@ -458,13 +462,9 @@ export class IosSimulatorDevice extends DeviceBase {
     return false;
   }
 
-  async sendDeepLink(link: string, build: BuildResult, terminateApp: boolean) {
+  async sendDeepLink(link: string, build: BuildResult) {
     if (build.platform !== DevicePlatform.IOS) {
       throw new Error("Invalid platform");
-    }
-
-    if (terminateApp) {
-      await this.terminateApp(build.bundleID);
     }
 
     await exec("xcrun", [

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -316,9 +316,13 @@ export class DeviceSession implements Disposable {
     return false;
   }
 
-  public async sendDeepLink(link: string) {
+  public async sendDeepLink(link: string, terminateApp: boolean) {
     if (this.maybeBuildResult) {
-      return this.device.sendDeepLink(link, this.maybeBuildResult);
+      await this.device.sendDeepLink(link, this.maybeBuildResult, terminateApp);
+
+      if (terminateApp) {
+        this.debugSession?.reconnectJSDebuggerIfNeeded(this.metro);
+      }
     }
   }
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -18,6 +18,7 @@ import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildCache } from "../builders/BuildCache";
 import { CancelToken } from "../builders/cancelToken";
+import { DevicePlatform } from "../common/DeviceManager";
 
 type PreviewReadyCallback = (previewURL: string) => void;
 type StartOptions = { cleanBuild: boolean; previewReadyCallback: PreviewReadyCallback };
@@ -318,6 +319,15 @@ export class DeviceSession implements Disposable {
 
   public async sendDeepLink(link: string, terminateApp: boolean) {
     if (this.maybeBuildResult) {
+      if (terminateApp) {
+        const packageNameOrBundleID =
+          this.maybeBuildResult.platform === DevicePlatform.Android
+            ? this.maybeBuildResult.packageName
+            : this.maybeBuildResult.bundleID;
+
+        await this.device.terminateApp(packageNameOrBundleID);
+      }
+
       await this.device.sendDeepLink(link, this.maybeBuildResult, terminateApp);
 
       if (terminateApp) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -668,7 +668,7 @@ export class Project
     return extensionContext.workspaceState.get<string[] | undefined>(DEEP_LINKS_HISTORY_KEY) ?? [];
   }
 
-  async openDeepLink(link: string) {
+  async openDeepLink(link: string, terminateApp: boolean) {
     const history = await this.getDeepLinksHistory();
     if (history.length === 0 || link !== history[0]) {
       extensionContext.workspaceState.update(
@@ -677,7 +677,7 @@ export class Project
       );
     }
 
-    this.deviceSession?.sendDeepLink(link);
+    this.deviceSession?.sendDeepLink(link, terminateApp);
   }
 
   public dispatchTouches(touches: Array<TouchPoint>, type: "Up" | "Move" | "Down") {

--- a/packages/vscode-extension/src/webview/views/OpenDeepLinkView.css
+++ b/packages/vscode-extension/src/webview/views/OpenDeepLinkView.css
@@ -8,3 +8,12 @@
   display: flex;
   justify-content: center;
 }
+
+.checkbox-container {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #333; /* Adjust color to match your theme */
+}

--- a/packages/vscode-extension/src/webview/views/OpenDeepLinkView.tsx
+++ b/packages/vscode-extension/src/webview/views/OpenDeepLinkView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import * as Switch from "@radix-ui/react-switch";
 import { useProject } from "../providers/ProjectProvider";
 import { useModal } from "../providers/ModalProvider";
 import { SearchSelect } from "../components/shared/SearchSelect";
@@ -11,6 +12,7 @@ export const OpenDeepLinkView = () => {
 
   const [url, setUrl] = useState<string>("");
   const [history, setHistory] = useState<string[] | undefined>(undefined);
+  const [terminateApp, setTerminateApp] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
@@ -24,7 +26,7 @@ export const OpenDeepLinkView = () => {
       return;
     }
     closeModal();
-    await project.openDeepLink(link);
+    await project.openDeepLink(link, terminateApp);
   };
 
   return (
@@ -41,6 +43,15 @@ export const OpenDeepLinkView = () => {
         isLoading={history === undefined}
         onValueChange={setUrl}
       />
+      <div className="checkbox-container">
+        <Switch.Root
+          className="switch-root small-switch"
+          onCheckedChange={setTerminateApp}
+          defaultChecked={terminateApp}>
+          <Switch.Thumb className="switch-thumb" />
+        </Switch.Root>
+        <label>Terminate app before sending deep link</label>
+      </div>
       <div className="submit-button-container">
         <Button className="submit-button" type="secondary" onClick={() => openDeepLink(url)}>
           Open


### PR DESCRIPTION
This PR adds an option to terminate an app before sending deep link to the device.

### How Has This Been Tested: 

- run `expo-52-prebuild-with-plugins` test app 
- test the termination flow with `myapp://` deeplink 
- test flow without termination (ass app is opened nothing should happen) 



https://github.com/user-attachments/assets/b6925895-4d71-4c3f-b9c7-43a74608aee4

