### PR TITLE
Fix appearance of send deep link on diffrend themes

### DIFF
--- a/packages/vscode-extension/src/webview/views/OpenDeepLinkView.css
+++ b/packages/vscode-extension/src/webview/views/OpenDeepLinkView.css
@@ -15,5 +15,5 @@
   align-items: center;
   gap: 8px;
   font-size: 14px;
-  color: #333; /* Adjust color to match your theme */
+  color: var(--swm-default-text);
 }


### PR DESCRIPTION
This PR fixes an issue that snicked into #1035, by making the text color responsive.

### How Has This Been Tested: 

open `Open Deep Link` view and change themes



