### PR TITLE
[Radon AI] Chat fixes and improvements

### DIFF
--- a/packages/vscode-extension/src/chat/api.ts
+++ b/packages/vscode-extension/src/chat/api.ts
@@ -47,8 +47,6 @@ export async function executeToolCall(
   toolCall: vscode.LanguageModelToolCallPart,
   jwt: string
 ): Promise<vscode.LanguageModelToolResultPart[] | undefined> {
-  Logger.debug("Calling tool:", toolCall);
-
   try {
     const url = new URL("/api/tool_calls/", BASE_RADON_AI_URL);
     const response = await fetch(url, {
@@ -61,6 +59,7 @@ export async function executeToolCall(
         tool_calls: [{ name: toolCall.name, id: toolCall.callId, args: toolCall.input }],
       }),
     });
+
     if (response.status !== 200) {
       Logger.error(`Failed to fetch response from Radon AI with status: ${response.status}`);
       getTelemetryReporter().sendTelemetryEvent("chat:error", {
@@ -70,7 +69,6 @@ export async function executeToolCall(
     }
 
     const results: ToolResult = await response.json();
-    Logger.debug("Tool call results:", results);
     const toolResults = results.tool_results.map((result) => ({
       callId: result.tool_call_id,
       content: [result.content],

--- a/packages/vscode-extension/src/chat/history.ts
+++ b/packages/vscode-extension/src/chat/history.ts
@@ -1,30 +1,22 @@
 import * as vscode from "vscode";
 import { CHAT_PARTICIPANT_ID } from ".";
 
-const START_OF_PREVIOUS_RESPONSES = "\n# PREVIOUS RESPONSES:\n\n";
-const END_OF_PREVIOUS_RESPONSES = "\n# END OF PREVIOUS RESPONSES.\n\n";
-
-interface ChatMessage {
-  role: "user" | "assistant";
-  content: string;
-}
-
-export function getChatHistory(context: vscode.ChatContext): ChatMessage[] {
+export function getChatHistory(context: vscode.ChatContext): vscode.LanguageModelChatMessage[] {
   const chatMessageHistory = context.history.filter(
     (chatTurn) => chatTurn.participant === CHAT_PARTICIPANT_ID
   );
 
-  const history: ChatMessage[] = [];
+  const history: vscode.LanguageModelChatMessage[] = [];
 
   if (chatMessageHistory.length > 0) {
     chatMessageHistory.forEach((chatMessage) => {
       if ("prompt" in chatMessage) {
-        history.push({ role: "user", content: chatMessage.prompt });
+        history.push(vscode.LanguageModelChatMessage.User(chatMessage.prompt));
       }
       if ("response" in chatMessage) {
         chatMessage.response.forEach((r) => {
           if (r instanceof vscode.ChatResponseMarkdownPart) {
-            history.push({ role: "assistant", content: r.value.value });
+            history.push(vscode.LanguageModelChatMessage.Assistant(r.value.value));
           }
         });
       }
@@ -32,16 +24,4 @@ export function getChatHistory(context: vscode.ChatContext): ChatMessage[] {
   }
 
   return history;
-}
-
-export function formatChatHistory(chatHistory: ChatMessage[]): string {
-  let chatHistoryText = START_OF_PREVIOUS_RESPONSES;
-
-  chatHistory.forEach((chatMessage) => {
-    chatHistoryText += `${chatMessage.role.toUpperCase()}: ${chatMessage.content}\n\n`;
-  });
-
-  chatHistoryText += END_OF_PREVIOUS_RESPONSES;
-
-  return chatHistoryText;
 }

--- a/packages/vscode-extension/src/chat/index.ts
+++ b/packages/vscode-extension/src/chat/index.ts
@@ -88,13 +88,13 @@ export function registerChat(context: vscode.ExtensionContext) {
             const toolMessages = results.map((result) =>
               // result.content will always be a 1-long array of strings
               vscode.LanguageModelChatMessage.Assistant(
-                `${chunk.name} tool has been called - results:\n\n\`\`\`\n${result.content[0]}\n\`\`\``
+                `"${chunk.name}" has been called - results:\n\n\`\`\`\n${result.content[0]}\n\`\`\``
               )
             );
 
-            carryOverMessages.push(...toolMessages);
-            // request.model.sendRequest API requires `User` to be the last message
             carryOverMessages.push(
+              ...toolMessages,
+              // request.model.sendRequest API requires `User` to be the last message
               vscode.LanguageModelChatMessage.User("All requested tool calls have been executed.")
             );
 

--- a/packages/vscode-extension/src/chat/index.ts
+++ b/packages/vscode-extension/src/chat/index.ts
@@ -6,6 +6,7 @@ import { executeToolCall as invokeToolCall, getSystemPrompt } from "./api";
 import { getChatHistory, formatChatHistory } from "./history";
 
 export const CHAT_PARTICIPANT_ID = "chat.radon-ai";
+const TOOLS_INTERACTION_LIMIT = 3;
 
 interface IChatResult extends vscode.ChatResult {
   metadata: {
@@ -65,6 +66,7 @@ export function registerChat(context: vscode.ExtensionContext) {
       ];
 
       const carryOverMessages: vscode.LanguageModelChatMessage[] = [];
+      let toolInteractionCount = 0;
 
       do {
         messages.push(...carryOverMessages);
@@ -95,9 +97,11 @@ export function registerChat(context: vscode.ExtensionContext) {
             carryOverMessages.push(
               vscode.LanguageModelChatMessage.User("All requested tool calls have been executed.")
             );
+
+            toolInteractionCount++;
           }
         }
-      } while (carryOverMessages.length > 0);
+      } while (carryOverMessages.length > 0 && toolInteractionCount < TOOLS_INTERACTION_LIMIT);
     } catch (err) {
       Logger.error("Error: ", err);
       handleError(err, stream);

--- a/packages/vscode-extension/src/chat/index.ts
+++ b/packages/vscode-extension/src/chat/index.ts
@@ -74,10 +74,12 @@ export function registerChat(context: vscode.ExtensionContext) {
             stream.markdown("Radon AI couldn't execute tool call.");
             return { metadata: { command: "" } };
           }
-          const toolMessages = [
-            vscode.LanguageModelChatMessage.Assistant(chunk.name),
-            vscode.LanguageModelChatMessage.User(results),
-          ];
+          const toolMessages = results.map((result) =>
+            vscode.LanguageModelChatMessage.Assistant(
+              result.content[0] as string,
+              `tool_result:${result.callId}`
+            )
+          );
           await request.model.sendRequest(toolMessages, {}, token);
         }
       }

--- a/packages/vscode-extension/src/chat/index.ts
+++ b/packages/vscode-extension/src/chat/index.ts
@@ -3,7 +3,7 @@ import { Logger } from "../Logger";
 import { getLicenseToken } from "../utilities/license";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { executeToolCall as invokeToolCall, getSystemPrompt } from "./api";
-import { getChatHistory, formatChatHistory } from "./history";
+import { getChatHistory } from "./history";
 
 export const CHAT_PARTICIPANT_ID = "chat.radon-ai";
 const TOOLS_INTERACTION_LIMIT = 3;
@@ -56,11 +56,10 @@ export function registerChat(context: vscode.ExtensionContext) {
       }
 
       const chatHistory = getChatHistory(chatContext);
-      const chatHistoryText = formatChatHistory(chatHistory);
 
       const messages = [
+        ...chatHistory,
         vscode.LanguageModelChatMessage.Assistant(documentation),
-        vscode.LanguageModelChatMessage.Assistant(chatHistoryText),
         vscode.LanguageModelChatMessage.Assistant(system),
         vscode.LanguageModelChatMessage.User(request.prompt),
       ];


### PR DESCRIPTION
Changes:
- allow Assistant to call tools multiple times during a single Assistant turn
- fix errors after Assistant uses a tool
- simplify history retrieval

---

This PR is still work-in-progress - debugger logs may still be present.

### How Has This Been Tested: 

- use the following prompt to test if the chatbot is capable of using tools: 
  - `Leave feedback using "leave_feedback" function, and reply to me with the result that you will get`
- use the following prompt to test how the chatbot handles tool-usage edge-cases: 
  - `Now call "leave_feedback" function multiple times, by creating mutliple tool calls in a single request, and reply to me with the results that you will get` 