### PR TITLE
remove exception handling related code

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -32,7 +32,6 @@ export type ProjectState = {
     | "running"
     | "buildError"
     | "bootError"
-    | "runtimeError"
     | "bundleBuildFailedError"
     | "bundlingError"
     | "debuggerPaused"

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -104,15 +104,13 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
   public sendStoppedEvent = (
     pausedStackFrames: StackFrame[],
     pausedScopeChains: CDPDebuggerScope[][],
-    reason: string,
-    exceptionText?: string,
-    isFatal?: string
+    reason: string
   ) => {
     this.pausedStackFrames = pausedStackFrames;
     this.pausedScopeChains = pausedScopeChains;
 
-    this.sendEvent(new StoppedEvent(reason, this.threads[0].id, exceptionText));
-    this.sendEvent(new Event("RNIDE_paused", { reason, isFatal }));
+    this.sendEvent(new StoppedEvent(reason, this.threads[0].id));
+    this.sendEvent(new Event("RNIDE_paused", { reason }));
   };
 
   //#endregion

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -208,7 +208,7 @@ export class Project
         this.updateProjectState({ status: "refreshing" });
         break;
       case "fastRefreshComplete":
-        const ignoredEvents = ["starting", "bundlingError", "runtimeError"];
+        const ignoredEvents = ["starting", "bundlingError"];
         if (ignoredEvents.includes(this.projectState.status)) {
           return;
         }
@@ -224,15 +224,7 @@ export class Project
   }
 
   onDebuggerPaused(event: DebugSessionCustomEvent) {
-    if (event.body?.reason === "exception") {
-      // if we know that incremental bundle error happened, we don't want to change the status
-      if (this.projectState.status === "bundlingError") {
-        return;
-      }
-      this.updateProjectState({ status: "runtimeError" });
-    } else {
-      this.updateProjectState({ status: "debuggerPaused" });
-    }
+    this.updateProjectState({ status: "debuggerPaused" });
 
     // we don't want to focus on debug side panel if it means hiding Radon IDE
     const panelLocation = workspace

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -136,7 +136,7 @@
   color: #001a72;
 }
 
-.phone-exception-overlay {
+.phone-error-overlay {
   background-color: rgba(255, 106, 89, 0.85);
   color: #001a72;
 }

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -95,12 +95,11 @@ function Preview({
   const hasBundleBuildFailedError = projectStatus === "bundleBuildFailedError";
 
   const debugPaused = projectStatus === "debuggerPaused";
-  const debugException = projectStatus === "runtimeError";
 
   const previewURL = projectState.previewURL;
 
   const isStarting =
-    hasBundleBuildFailedError || hasBundlingError || debugException
+    hasBundleBuildFailedError || hasBundlingError
       ? false
       : !projectState || projectState.status === "starting";
   const showDevicePreview =
@@ -126,7 +125,6 @@ function Preview({
     let { x: anchorX, y: anchorY } = anchorPoint;
     const { x: prevPointX, y: prevPointY } = touchPoint;
     const { x: newPointX, y: newPointY } = getTouchPosition(event);
-
     anchorX += newPointX - prevPointX;
     anchorY += newPointY - prevPointY;
     anchorX = clamp(anchorX, 0, 1);
@@ -210,7 +208,6 @@ function Preview({
 
   const shouldPreventInputEvents =
     debugPaused ||
-    debugException ||
     hasBundleBuildFailedError ||
     hasBundlingError ||
     projectStatus === "refreshing" ||
@@ -558,17 +555,9 @@ function Preview({
                   <Debugger />
                 </div>
               )}
-              {debugException && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
-                  <button className="uncaught-button" onClick={() => project.resumeDebugger()}>
-                    Uncaught exception&nbsp;
-                    <span className="codicon codicon-debug-continue" />
-                  </button>
-                </div>
-              )}
               {/* TODO: Add different label in case of bundle/incremental bundle error */}
               {hasBundleBuildFailedError && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
+                <div className="phone-screen phone-debug-overlay phone-error-overlay">
                   <button
                     className="uncaught-button"
                     onClick={() => {
@@ -580,7 +569,7 @@ function Preview({
                 </div>
               )}
               {hasBundlingError && (
-                <div className="phone-screen phone-debug-overlay phone-exception-overlay">
+                <div className="phone-screen phone-debug-overlay phone-error-overlay">
                   <button className="uncaught-button" onClick={() => project.restart(false)}>
                     Bundle error&nbsp;
                     <span className="codicon codicon-refresh" />


### PR DESCRIPTION
Removes some leftover code after we stopped handling exceptions ourselves in #1040 

### How Has This Been Tested: 
- Open an app with RN version <0.76 (in order to use the old debugger)
- trigger an uncaught exception
- don't crash and burn


