### PR TITLE
fix terminating just started app

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -327,11 +327,7 @@ export class IosSimulatorDevice extends DeviceBase {
       matches.push(match[1]);
     }
 
-    await Promise.all(
-      matches.map((e) => {
-        this.terminateApp(e);
-      })
-    );
+    await Promise.all(matches.map(async (e) => await this.terminateApp(e)));
   }
 
   async launchWithBuild(build: IOSBuildResult) {


### PR DESCRIPTION
Fixes an issue where the iOS app is sometimes immediately terminated, causing Radon to hang on "Waiting for app" or "Attaching debugger".

The issue was caused by not awaiting the promises for app termination, which caused a race condition between terminating the app and starting it again.


