### PR TITLE
Refactor DebugSession and DebugAdapter to support only spawning JS debug session.

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -357,13 +357,13 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
       const res = await this.cdpSession.sendCDPMessage("Runtime.evaluate", {
         expression: "('ping')",
       });
-      const { result } = res;
-      if (result.value === "ping") {
-        this.sendEvent(new Event("RNIDE_pong"));
+      if (res.result.value === "ping") {
+        return true;
       }
     } catch (_) {
       /** debugSession is waiting for an event, if it won't get any it will fail after timeout, so we don't need to do anything here */
     }
+    return false;
   }
 
   protected async customRequest(
@@ -372,6 +372,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
     args: any,
     request?: DebugProtocol.Request | undefined
   ) {
+    response.body = response.body || {};
     switch (command) {
       case "RNIDE_startProfiling":
         if (this.cdpSession) {
@@ -388,7 +389,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
         }
         break;
       case "RNIDE_ping":
-        this.ping();
+        response.body.result = await this.ping();
         break;
       default:
         Logger.debug(`Custom req ${command} ${args}`);

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -12,9 +12,6 @@ export type CDPConfiguration = {
   metroWatchFolders: string[];
 };
 
-const OLD_JS_DEBUGGER_TYPE = "com.swmansion.js-debugger";
-const PROXY_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
-
 export function typeToCategory(type: string) {
   switch (type) {
     case "warning":
@@ -30,57 +27,6 @@ export class DebugAdapter extends DebugAdapterSession {
 
   constructor(private vscDebugSession: DebugSession) {
     super();
-  }
-
-  private async connectJSDebugger(cdpConfiguration: CDPConfiguration) {
-    const { websocketAddress, expoPreludeLineCount, isUsingNewDebugger, metroWatchFolders } =
-      cdpConfiguration;
-    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
-
-    let didStartHandler: Disposable | null = debug.onDidStartDebugSession((session) => {
-      if (session.type === debuggerType) {
-        this.cdpDebugSession = session;
-        didStartHandler?.dispose();
-        didStartHandler = null;
-      }
-    });
-
-    const sourceMapPathOverrides: Record<string, string> = {};
-    if (isUsingNewDebugger && metroWatchFolders.length > 0) {
-      // first entry in watchFolders is the project root
-      sourceMapPathOverrides["/[metro-project]/*"] = `${metroWatchFolders[0]}${path.sep}*`;
-      metroWatchFolders.forEach((watchFolder, index) => {
-        sourceMapPathOverrides[`/[metro-watchFolders]/${index}/*`] = `${watchFolder}${path.sep}*`;
-      });
-    }
-
-    try {
-      await debug.startDebugging(
-        undefined,
-        {
-          type: debuggerType,
-          name: "React Native JS Debugger",
-          request: "attach",
-          breakpointsAreRemovedOnContextCleared: isUsingNewDebugger ? false : true, // new debugger properly keeps all breakpoints in between JS reloads
-          sourceMapPathOverrides,
-          websocketAddress,
-          expoPreludeLineCount,
-        },
-        {
-          parentSession: this.vscDebugSession,
-          suppressDebugStatusbar: true,
-          suppressDebugView: true,
-          suppressDebugToolbar: true,
-          suppressSaveBeforeStart: true,
-          consoleMode: DebugConsoleMode.MergeWithParent,
-          compact: true,
-        }
-      );
-
-      console.assert(this.cdpDebugSession, "CDP Debug session should be set once it's started");
-    } finally {
-      didStartHandler?.dispose();
-    }
   }
 
   logCustomMessage(message: string, category: string, source?: DebugSource) {
@@ -104,19 +50,15 @@ export class DebugAdapter extends DebugAdapterSession {
     request?: DebugProtocol.Request | undefined
   ) {
     switch (command) {
-      case "RNIDE_connect_cdp_debugger":
-        if (this.cdpDebugSession) {
-          debug.stopDebugging(this.cdpDebugSession);
-          this.cdpDebugSession = null;
-        }
-        await this.connectJSDebugger(args);
-        break;
+      // case "RNIDE_connect_cdp_debugger":
+      //   if (this.cdpDebugSession) {
+      //     debug.stopDebugging(this.cdpDebugSession);
+      //     this.cdpDebugSession = null;
+      //   }
+      //   await this.connectJSDebugger(args);
+      //   break;
       case "RNIDE_log_message":
         this.logCustomMessage(args.message, args.type, args.source);
-        break;
-      default:
-        // NOTE: forward unhandled custom requests to the JS Debug session
-        await this.cdpDebugSession?.customRequest(command, args);
         break;
     }
     this.sendResponse(response);

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -1,4 +1,3 @@
-import { DebugSession } from "vscode";
 import { DebugSession as DebugAdapterSession, OutputEvent, Source } from "@vscode/debugadapter";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import { DebugSource } from "./DebugSession";
@@ -21,9 +20,7 @@ export function typeToCategory(type: string) {
 }
 
 export class DebugAdapter extends DebugAdapterSession {
-  private cdpDebugSession: DebugSession | null = null;
-
-  constructor(private vscDebugSession: DebugSession) {
+  constructor() {
     super();
   }
 

--- a/packages/vscode-extension/src/debugging/DebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapter.ts
@@ -1,8 +1,6 @@
-import path from "path";
-import { debug, DebugConsoleMode, DebugSession } from "vscode";
+import { DebugSession } from "vscode";
 import { DebugSession as DebugAdapterSession, OutputEvent, Source } from "@vscode/debugadapter";
 import { DebugProtocol } from "@vscode/debugprotocol";
-import { Disposable } from "vscode";
 import { DebugSource } from "./DebugSession";
 
 export type CDPConfiguration = {
@@ -50,13 +48,6 @@ export class DebugAdapter extends DebugAdapterSession {
     request?: DebugProtocol.Request | undefined
   ) {
     switch (command) {
-      // case "RNIDE_connect_cdp_debugger":
-      //   if (this.cdpDebugSession) {
-      //     debug.stopDebugging(this.cdpDebugSession);
-      //     this.cdpDebugSession = null;
-      //   }
-      //   await this.connectJSDebugger(args);
-      //   break;
       case "RNIDE_log_message":
         this.logCustomMessage(args.message, args.type, args.source);
         break;

--- a/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
+++ b/packages/vscode-extension/src/debugging/DebugAdapterDescriptorFactory.ts
@@ -6,7 +6,7 @@ export class DebugAdapterDescriptorFactory implements vscode.DebugAdapterDescrip
   createDebugAdapterDescriptor(
     session: vscode.DebugSession
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    return new vscode.DebugAdapterInlineImplementation(new DebugAdapter(session));
+    return new vscode.DebugAdapterInlineImplementation(new DebugAdapter());
   }
 }
 

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -1,173 +1,219 @@
 import assert from "assert";
-import {
-  commands,
-  debug,
-  DebugSessionCustomEvent,
-  Disposable,
-  DebugSession as VscDebugSession,
-} from "vscode";
+import { commands, debug, DebugConsoleMode, DebugSessionCustomEvent, Disposable } from "vscode";
+import * as vscode from "vscode";
 import { Metro } from "../project/metro";
 import { Logger } from "../Logger";
 import { CDPConfiguration } from "./DebugAdapter";
+import { disposeAll } from "../utilities/disposables";
+import path from "path";
 
 const PING_TIMEOUT = 1000;
+
+const MASTER_DEBUGGER_TYPE = "com.swmansion.react-native-debugger";
+const OLD_JS_DEBUGGER_TYPE = "com.swmansion.js-debugger";
+const PROXY_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
 
 export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
 export const DEBUG_PAUSED = "RNIDE_paused";
 export const DEBUG_RESUMED = "RNIDE_continued";
 
 export type DebugSessionDelegate = {
-  onConsoleLog(event: DebugSessionCustomEvent): void;
-  onDebuggerPaused(event: DebugSessionCustomEvent): void;
-  onDebuggerResumed(event: DebugSessionCustomEvent): void;
-  onProfilingCPUStarted(event: DebugSessionCustomEvent): void;
-  onProfilingCPUStopped(event: DebugSessionCustomEvent): void;
+  onConsoleLog?(event: DebugSessionCustomEvent): void;
+  onDebuggerPaused?(event: DebugSessionCustomEvent): void;
+  onDebuggerResumed?(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStarted?(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStopped?(event: DebugSessionCustomEvent): void;
+  onDebugSessionTerminated?(): void;
 };
 
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
 
-const REACT_NATIVE_SESSION_TYPE = "com.swmansion.react-native-debugger";
+/**
+ * Helpr function that starts a debug session and returns the session object upon sucesfull start
+ */
+async function startDebugging(
+  folder: vscode.WorkspaceFolder | undefined,
+  nameOrConfiguration: string | vscode.DebugConfiguration,
+  parentSessionOrOptions?: vscode.DebugSession | vscode.DebugSessionOptions
+) {
+  let debugSession: vscode.DebugSession | undefined;
+  let didStartHandler: Disposable | null = debug.onDidStartDebugSession((session) => {
+    if (session.type === nameOrConfiguration.type) {
+      didStartHandler?.dispose();
+      didStartHandler = null;
+      debugSession = session;
+    }
+  });
+  try {
+    const debugStarted = await debug.startDebugging(
+      folder,
+      nameOrConfiguration,
+      parentSessionOrOptions
+    );
+
+    if (debugStarted) {
+      // NOTE: this is safe, because `debugStarted` means the session started successfully,
+      // and we set the session in the `onDidStartDebugSession` handler
+      assert(debugSession, "Expected debug session to be set");
+      return debugSession;
+    } else {
+      throw new Error("Failed to start debug session");
+    }
+  } finally {
+    didStartHandler?.dispose();
+  }
+}
 
 export class DebugSession implements Disposable {
-  private vscSession: VscDebugSession | undefined;
-  private debugEventsListener: Disposable;
-  private pingTimeout: NodeJS.Timeout | undefined;
-  private pingResolve: ((result: boolean) => void) | undefined;
-  private wasConnectedToCDP: boolean = false;
+  private parentDebugSession: vscode.DebugSession | undefined;
+  private jsDebugSession: vscode.DebugSession | undefined;
+
+  private disposables: Disposable[] = [];
+
+  private pingResolve: (() => void) | undefined;
   private currentWsTarget: string | undefined;
 
   constructor(private delegate: DebugSessionDelegate) {
-    this.debugEventsListener = debug.onDidReceiveDebugSessionCustomEvent((event) => {
-      switch (event.event) {
-        case DEBUG_CONSOLE_LOG:
-          this.delegate.onConsoleLog(event);
-          break;
-        case DEBUG_PAUSED:
-          this.delegate.onDebuggerPaused(event);
-          break;
-        case DEBUG_RESUMED:
-          this.delegate.onDebuggerResumed(event);
-          break;
-        case "RNIDE_pong":
-          if (this.pingResolve) {
-            this.pingResolve(true);
-          } else {
-            Logger.warn("[DEBUG SESSION] Received unexpected pong event");
-          }
-          break;
-        case "RNIDE_profilingCPUStarted":
-          this.delegate.onProfilingCPUStarted(event);
-          break;
-        case "RNIDE_profilingCPUStopped":
-          this.delegate.onProfilingCPUStopped(event);
-          break;
-        default:
-          // ignore other events
-          break;
-      }
-    });
+    this.disposables.push(
+      debug.onDidTerminateDebugSession((session) => {
+        if (session.id === this.jsDebugSession?.id) {
+          this.delegate.onDebugSessionTerminated?.();
+        }
+      })
+    );
+    this.disposables.push(
+      debug.onDidReceiveDebugSessionCustomEvent((event) => {
+        switch (event.event) {
+          case DEBUG_CONSOLE_LOG:
+            this.delegate.onConsoleLog?.(event);
+            break;
+          case DEBUG_PAUSED:
+            this.delegate.onDebuggerPaused?.(event);
+            break;
+          case DEBUG_RESUMED:
+            this.delegate.onDebuggerResumed?.(event);
+            break;
+          case "RNIDE_pong":
+            if (this.pingResolve) {
+              this.pingResolve();
+            } else {
+              Logger.warn("[DEBUG SESSION] Received unexpected pong event");
+            }
+            break;
+          case "RNIDE_profilingCPUStarted":
+            this.delegate.onProfilingCPUStarted?.(event);
+            break;
+          case "RNIDE_profilingCPUStopped":
+            this.delegate.onProfilingCPUStopped?.(event);
+            break;
+          default:
+            // ignore other events
+            break;
+        }
+      })
+    );
   }
 
   public async reconnectJSDebuggerIfNeeded(metro: Metro) {
-    const isAlive = await this.isWsTargetAlive(metro);
-
-    if (!isAlive) {
-      return this.connectJSDebugger(metro);
-    }
-
-    return true;
+    // const isAlive = await this.isWsTargetAlive(metro);
+    // if (!isAlive) {
+    //   return this.connectJSDebugger(metro);
+    // }
+    // return true;
   }
 
-  private async startInternal() {
-    let didStartHandler: Disposable | null = debug.onDidStartDebugSession((session) => {
-      if (session.type === REACT_NATIVE_SESSION_TYPE) {
-        this.vscSession = session;
-        didStartHandler?.dispose();
-        didStartHandler = null;
+  public async startParentDebugSession() {
+    this.parentDebugSession = await startDebugging(
+      undefined,
+      {
+        type: MASTER_DEBUGGER_TYPE,
+        name: "Radon IDE Debugger",
+        request: "attach",
+      },
+      {
+        suppressDebugStatusbar: true,
+        suppressDebugView: true,
+        suppressDebugToolbar: true,
+        suppressSaveBeforeStart: true,
       }
-    });
-    try {
-      const debugStarted = await debug.startDebugging(
-        undefined,
-        {
-          type: REACT_NATIVE_SESSION_TYPE,
-          name: "React Native Preview Debugger",
-          request: "attach",
-        },
-        {
-          suppressDebugStatusbar: true,
-          suppressDebugView: true,
-          suppressDebugToolbar: true,
-          suppressSaveBeforeStart: true,
-        }
-      );
-
-      if (debugStarted) {
-        // NOTE: this is safe, because `debugStarted` means the session started successfully,
-        // and we set the session in the `onDidStartDebugSession` handler
-        assert(this.vscSession, "Expected debug session to be set");
-        return true;
-      }
-    } finally {
-      didStartHandler?.dispose();
-    }
+    );
   }
 
   public static start(debugEventDelegate: DebugSessionDelegate) {
     const debugSession = new DebugSession(debugEventDelegate);
-    debugSession.startInternal();
+    debugSession.startParentDebugSession();
     return debugSession;
   }
 
-  public async getOriginalSource(
-    fileName: string,
-    line0Based: number,
-    column0Based: number
-  ): Promise<{ sourceURL: string; lineNumber1Based: number; columnNumber0Based: number }> {
-    return await this.session.customRequest("source", { fileName, line0Based, column0Based });
-  }
-
   public async restart() {
+    const hasParentDebugSession = !!this.parentDebugSession;
     await this.stop();
-    await this.startInternal();
+    if (hasParentDebugSession) {
+      await this.startParentDebugSession();
+    }
   }
 
   private async stop() {
-    this.vscSession && (await debug.stopDebugging(this.vscSession));
-    this.vscSession = undefined;
-    this.wasConnectedToCDP = false;
+    if (this.parentDebugSession) {
+      await debug.stopDebugging(this.parentDebugSession);
+    } else {
+      await debug.stopDebugging(this.jsDebugSession);
+    }
+    this.parentDebugSession = undefined;
+    this.jsDebugSession = undefined;
     this.currentWsTarget = undefined;
   }
 
-  /**
-  This method is async to allow for awaiting it during restarts, please keep in mind tho that
-  build in vscode dispose system ignores async keyword and works synchronously.
-  */
-  public async dispose() {
-    this.vscSession && (await debug.stopDebugging(this.vscSession));
-    this.debugEventsListener.dispose();
+  public dispose() {
+    this.stop();
+    disposeAll(this.disposables);
   }
 
-  public async connectJSDebugger(metro: Metro) {
-    if (this.wasConnectedToCDP) {
-      await this.restart();
-    }
+  public async startJSDebugSession(metro: Metro) {
+    // if (this.wasConnectedToCDP) {
+    //   await this.restart();
+    // }
 
     const websocketAddress = await metro.getDebuggerURL();
     if (!websocketAddress) {
       return false;
     }
 
-    const isUsingNewDebugger = metro.isUsingNewDebugger.valueOf();
+    const isUsingNewDebugger = metro.isUsingNewDebugger;
+    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
-    await this.connectCDPDebugger({
-      websocketAddress,
-      metroWatchFolders: metro.watchFolders,
-      expoPreludeLineCount: metro.expoPreludeLineCount,
-      isUsingNewDebugger,
-    });
+    const sourceMapPathOverrides: Record<string, string> = {};
+    const metroWatchFolders = metro.watchFolders;
+    if (isUsingNewDebugger && metroWatchFolders.length > 0) {
+      sourceMapPathOverrides["/[metro-project]/*"] = `${metroWatchFolders[0]}${path.sep}*`;
+      metroWatchFolders.forEach((watchFolder, index) => {
+        sourceMapPathOverrides[`/[metro-watchFolders]/${index}/*`] = `${watchFolder}${path.sep}*`;
+      });
+    }
 
-    this.wasConnectedToCDP = true;
+    this.jsDebugSession = await startDebugging(
+      undefined,
+      {
+        type: debuggerType,
+        name: "React Native JS Debugger",
+        request: "attach",
+        breakpointsAreRemovedOnContextCleared: isUsingNewDebugger ? false : true, // new debugger properly keeps all breakpoints in between JS reloads
+        sourceMapPathOverrides,
+        websocketAddress,
+        expoPreludeLineCount: metro.expoPreludeLineCount,
+      },
+      {
+        parentSession: this.parentDebugSession,
+        suppressDebugStatusbar: true,
+        suppressDebugView: true,
+        suppressDebugToolbar: true,
+        suppressSaveBeforeStart: true,
+        consoleMode: DebugConsoleMode.MergeWithParent,
+        compact: true,
+      }
+    );
+
+    // this.wasConnectedToCDP = true;
     this.currentWsTarget = websocketAddress;
 
     return true;
@@ -175,13 +221,13 @@ export class DebugSession implements Disposable {
 
   public resumeDebugger() {
     commands.executeCommand("workbench.action.debug.continue", undefined, {
-      sessionId: this.vscSession?.id,
+      sessionId: this.jsDebugSession?.id,
     });
   }
 
   public stepOverDebugger() {
     commands.executeCommand("workbench.action.debug.stepOver", undefined, {
-      sessionId: this.vscSession?.id,
+      sessionId: this.jsDebugSession?.id,
     });
   }
 
@@ -197,56 +243,46 @@ export class DebugSession implements Disposable {
   }
 
   public async isCurrentWsTargetStillVisible(metro: Metro): Promise<boolean> {
-    return new Promise(async (resolve, reject) => {
-      const possibleWsTargets = await metro.fetchWsTargets();
-      const hasCurrentWsAddress = possibleWsTargets?.some(
-        (runtime) => runtime.webSocketDebuggerUrl === this.currentWsTarget
-      );
+    // return new Promise(async (resolve, reject) => {
+    const possibleWsTargets = await metro.fetchWsTargets();
+    const hasCurrentWsAddress = possibleWsTargets?.some(
+      (runtime) => runtime.webSocketDebuggerUrl === this.currentWsTarget
+    );
 
-      if (!this.currentWsTarget || !hasCurrentWsAddress) {
-        return resolve(false);
-      }
-      // We're rejecting as shouldDebuggerReconnect uses .any which waits for first promise to resolve.
-      // And th fact that current wsTarget is on the list is not enough, it might be stale, so in this case we wait for ping.
-      reject();
-    });
+    if (!this.currentWsTarget || !hasCurrentWsAddress) {
+      return false;
+    }
+    // We're rejecting as shouldDebuggerReconnect uses .any which waits for first promise to resolve.
+    // And th fact that current wsTarget is on the list is not enough, it might be stale, so in this case we wait for ping.
+    throw new Error("current");
   }
 
-  public async pingCurrentWsTarget(): Promise<boolean> {
-    this.session.customRequest("RNIDE_ping");
-    return new Promise((resolve, _) => {
-      this.pingResolve = (value) => {
-        clearTimeout(this.pingTimeout);
-        resolve(value);
+  public async pingCurrentWsTarget() {
+    this.jsDebugSession?.customRequest("RNIDE_ping");
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    const timeout = setTimeout(() => resolve(false), PING_TIMEOUT);
+    let prevResolve = this.pingResolve;
+    let currentResolve = () => {
+      clearTimeout(timeout);
+      resolve(true);
+      prevResolve?.();
+      if (this.pingResolve === currentResolve) {
         this.pingResolve = undefined;
-        this.pingTimeout = undefined;
-      };
-      this.pingTimeout = setTimeout(() => {
-        this.pingResolve?.(false);
-      }, PING_TIMEOUT);
-    });
+      }
+    };
+    this.pingResolve = currentResolve;
+    return promise;
   }
 
   public async startProfilingCPU() {
-    await this.session.customRequest("RNIDE_startProfiling");
+    await this.jsDebugSession?.customRequest("RNIDE_startProfiling");
   }
 
   public async stopProfilingCPU() {
-    await this.session.customRequest("RNIDE_stopProfiling");
-  }
-
-  private async connectCDPDebugger(cdpConfiguration: CDPConfiguration) {
-    await this.session.customRequest("RNIDE_connect_cdp_debugger", cdpConfiguration);
+    await this.jsDebugSession?.customRequest("RNIDE_stopProfiling");
   }
 
   public async appendDebugConsoleEntry(message: string, type: string, source?: DebugSource) {
-    await this.session.customRequest("RNIDE_log_message", { message, type, source });
-  }
-
-  private get session() {
-    if (!this.vscSession) {
-      throw new Error("Debugger not started");
-    }
-    return this.vscSession;
+    await this.parentDebugSession?.customRequest("RNIDE_log_message", { message, type, source });
   }
 }

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -143,13 +143,15 @@ export class DebugSession implements Disposable {
 
   private async stop() {
     if (this.parentDebugSession) {
-      await debug.stopDebugging(this.parentDebugSession);
+      const parentDebugSession = this.parentDebugSession;
+      this.parentDebugSession = undefined;
+      await debug.stopDebugging(parentDebugSession);
     }
     if (this.jsDebugSession) {
-      await debug.stopDebugging(this.jsDebugSession);
+      const jsDebugSession = this.jsDebugSession;
+      this.jsDebugSession = undefined;
+      await debug.stopDebugging(jsDebugSession);
     }
-    this.parentDebugSession = undefined;
-    this.jsDebugSession = undefined;
     this.currentWsTarget = undefined;
   }
 

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -117,6 +117,10 @@ export class DebugSession implements Disposable {
   }
 
   public async startParentDebugSession() {
+    assert(
+      !this.jsDebugSession,
+      "Cannot start parent debug session when js debug session is already running"
+    );
     this.useParentDebugSession = true;
     this.parentDebugSession = await startDebugging(
       undefined,
@@ -156,8 +160,9 @@ export class DebugSession implements Disposable {
   }
 
   public dispose() {
-    this.stop();
-    disposeAll(this.disposables);
+    this.stop()
+      .catch()
+      .then(() => disposeAll(this.disposables));
   }
 
   public async startJSDebugSession(metro: Metro) {

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -206,7 +206,6 @@ export class DebugSession implements Disposable {
       }
     );
 
-    // this.wasConnectedToCDP = true;
     this.currentWsTarget = websocketAddress;
 
     return true;

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -69,11 +69,12 @@ export class DebugSession implements Disposable {
   private parentDebugSession: vscode.DebugSession | undefined;
   private jsDebugSession: vscode.DebugSession | undefined;
 
+  private useParentDebugSession = false;
   private disposables: Disposable[] = [];
 
   private currentWsTarget: string | undefined;
 
-  constructor(private useParentDebugSession: boolean, private delegate: DebugSessionDelegate) {
+  constructor(private delegate: DebugSessionDelegate) {
     this.disposables.push(
       debug.onDidTerminateDebugSession((session) => {
         if (session.id === this.jsDebugSession?.id) {
@@ -116,6 +117,7 @@ export class DebugSession implements Disposable {
   }
 
   public async startParentDebugSession() {
+    this.useParentDebugSession = true;
     this.parentDebugSession = await startDebugging(
       undefined,
       {
@@ -130,12 +132,6 @@ export class DebugSession implements Disposable {
         suppressSaveBeforeStart: true,
       }
     );
-  }
-
-  public static start(debugEventDelegate: DebugSessionDelegate) {
-    const debugSession = new DebugSession(true, debugEventDelegate);
-    debugSession.startParentDebugSession();
-    return debugSession;
   }
 
   public async restart() {

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -18,12 +18,12 @@ export const DEBUG_PAUSED = "RNIDE_paused";
 export const DEBUG_RESUMED = "RNIDE_continued";
 
 export type DebugSessionDelegate = {
-  onConsoleLog?(event: DebugSessionCustomEvent): void;
-  onDebuggerPaused?(event: DebugSessionCustomEvent): void;
-  onDebuggerResumed?(event: DebugSessionCustomEvent): void;
-  onProfilingCPUStarted?(event: DebugSessionCustomEvent): void;
-  onProfilingCPUStopped?(event: DebugSessionCustomEvent): void;
-  onDebugSessionTerminated?(): void;
+  onConsoleLog(event: DebugSessionCustomEvent): void;
+  onDebuggerPaused(event: DebugSessionCustomEvent): void;
+  onDebuggerResumed(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStarted(event: DebugSessionCustomEvent): void;
+  onProfilingCPUStopped(event: DebugSessionCustomEvent): void;
+  onDebugSessionTerminated(): void;
 };
 
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
@@ -85,13 +85,13 @@ export class DebugSession implements Disposable {
       debug.onDidReceiveDebugSessionCustomEvent((event) => {
         switch (event.event) {
           case DEBUG_CONSOLE_LOG:
-            this.delegate.onConsoleLog?.(event);
+            this.delegate.onConsoleLog(event);
             break;
           case DEBUG_PAUSED:
-            this.delegate.onDebuggerPaused?.(event);
+            this.delegate.onDebuggerPaused(event);
             break;
           case DEBUG_RESUMED:
-            this.delegate.onDebuggerResumed?.(event);
+            this.delegate.onDebuggerResumed(event);
             break;
           case "RNIDE_pong":
             if (this.pingResolve) {
@@ -101,10 +101,10 @@ export class DebugSession implements Disposable {
             }
             break;
           case "RNIDE_profilingCPUStarted":
-            this.delegate.onProfilingCPUStarted?.(event);
+            this.delegate.onProfilingCPUStarted(event);
             break;
           case "RNIDE_profilingCPUStopped":
-            this.delegate.onProfilingCPUStopped?.(event);
+            this.delegate.onProfilingCPUStopped(event);
             break;
           default:
             // ignore other events

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -36,9 +36,11 @@ async function startDebugging(
   nameOrConfiguration: string | vscode.DebugConfiguration,
   parentSessionOrOptions?: vscode.DebugSession | vscode.DebugSessionOptions
 ) {
+  const debugSessionType =
+    typeof nameOrConfiguration === "string" ? nameOrConfiguration : nameOrConfiguration.type;
   let debugSession: vscode.DebugSession | undefined;
   let didStartHandler: Disposable | null = debug.onDidStartDebugSession((session) => {
-    if (session.type === nameOrConfiguration.type) {
+    if (session.type === debugSessionType) {
       didStartHandler?.dispose();
       didStartHandler = null;
       debugSession = session;
@@ -156,7 +158,8 @@ export class DebugSession implements Disposable {
   private async stop() {
     if (this.parentDebugSession) {
       await debug.stopDebugging(this.parentDebugSession);
-    } else {
+    }
+    if (this.jsDebugSession) {
       await debug.stopDebugging(this.jsDebugSession);
     }
     this.parentDebugSession = undefined;

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -259,11 +259,12 @@ export class ProxyDebugAdapter extends DebugSession {
         },
       });
       if ("value" in result && result.value === "ping") {
-        this.sendEvent(new Event("RNIDE_pong"));
+        return true;
       }
     } catch (_) {
       /** debugSession is waiting for an event, if it won't get any it will fail after timeout, so we don't need to do anything here */
     }
+    return false;
   }
 
   private async startProfiling() {
@@ -291,6 +292,7 @@ export class ProxyDebugAdapter extends DebugSession {
     args: any,
     request?: DebugProtocol.Request | undefined
   ) {
+    response.body = response.body || {};
     switch (command) {
       case "RNIDE_startProfiling":
         await this.startProfiling();
@@ -299,7 +301,7 @@ export class ProxyDebugAdapter extends DebugSession {
         await this.stopProfiling();
         break;
       case "RNIDE_ping":
-        this.ping();
+        response.body.result = await this.ping();
         break;
     }
     this.sendResponse(response);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -95,9 +95,9 @@ export class DeviceSession implements Disposable {
     this.debugSession = DebugSession.start(this.debugEventDelegate);
   }
 
-  /** 
+  /**
   This method is async to allow for awaiting it during restarts, please keep in mind tho that
-  build in vscode dispose system ignores async keyword and works synchronously. 
+  build in vscode dispose system ignores async keyword and works synchronously.
   */
   public async dispose() {
     await this.debugSession?.dispose();
@@ -288,7 +288,7 @@ export class DeviceSession implements Disposable {
   }
 
   private async connectJSDebugger() {
-    const connected = await this.debugSession.connectJSDebugger(this.metro);
+    const connected = await this.debugSession.startJSDebugSession(this.metro);
 
     if (connected) {
       // TODO(jgonet): Right now, we ignore start failure

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -1,5 +1,5 @@
 import { Disposable } from "vscode";
-import { Metro, MetroLauncher } from "./metro";
+import { Metro } from "./metro";
 import { Devtools } from "./devtools";
 import { DeviceBase } from "../devices/DeviceBase";
 import { Logger } from "../Logger";
@@ -18,6 +18,7 @@ import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildCache } from "../builders/BuildCache";
 import { CancelToken } from "../builders/cancelToken";
+import { DevicePlatform } from "../common/DeviceManager";
 
 type PreviewReadyCallback = (previewURL: string) => void;
 type StartOptions = { cleanBuild: boolean; previewReadyCallback: PreviewReadyCallback };
@@ -64,7 +65,7 @@ export class DeviceSession implements Disposable {
   constructor(
     private readonly device: DeviceBase,
     private readonly devtools: Devtools,
-    private readonly metro: MetroLauncher,
+    private readonly metro: Metro,
     readonly dependencyManager: DependencyManager,
     readonly buildCache: BuildCache,
     private readonly debugEventDelegate: DebugSessionDelegate,
@@ -87,11 +88,16 @@ export class DeviceSession implements Disposable {
           break;
       }
     });
+
+    // we start debug session here to be able to leverage the functionality of debug console
+    // the session is not connected to the js debugger here yet and that step can only happen,
+    // after app is running.
+    this.debugSession = DebugSession.start(this.debugEventDelegate);
   }
 
-  /**
+  /** 
   This method is async to allow for awaiting it during restarts, please keep in mind tho that
-  build in vscode dispose system ignores async keyword and works synchronously.
+  build in vscode dispose system ignores async keyword and works synchronously. 
   */
   public async dispose() {
     await this.debugSession?.dispose();
@@ -271,8 +277,6 @@ export class DeviceSession implements Disposable {
     { cleanBuild, previewReadyCallback }: StartOptions
   ) {
     this.deviceSettings = deviceSettings;
-    this.debugSession = new DebugSession(this.debugEventDelegate);
-    await this.debugSession.startParentDebugSession();
     await this.waitForMetroReady();
     // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
     await this.bootDevice(deviceSettings);
@@ -313,9 +317,22 @@ export class DeviceSession implements Disposable {
     return false;
   }
 
-  public async sendDeepLink(link: string) {
+  public async sendDeepLink(link: string, terminateApp: boolean) {
     if (this.maybeBuildResult) {
-      return this.device.sendDeepLink(link, this.maybeBuildResult);
+      if (terminateApp) {
+        const packageNameOrBundleID =
+          this.maybeBuildResult.platform === DevicePlatform.Android
+            ? this.maybeBuildResult.packageName
+            : this.maybeBuildResult.bundleID;
+
+        await this.device.terminateApp(packageNameOrBundleID);
+      }
+
+      await this.device.sendDeepLink(link, this.maybeBuildResult, terminateApp);
+
+      if (terminateApp) {
+        this.debugSession?.reconnectJSDebuggerIfNeeded(this.metro);
+      }
     }
   }
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -68,10 +68,11 @@ export class DeviceSession implements Disposable {
     private readonly metro: Metro,
     readonly dependencyManager: DependencyManager,
     readonly buildCache: BuildCache,
-    private readonly debugEventDelegate: DebugSessionDelegate,
+    debugEventDelegate: DebugSessionDelegate,
     private readonly eventDelegate: EventDelegate
   ) {
     this.buildManager = new BuildManager(dependencyManager, buildCache);
+    this.debugSession = new DebugSession(debugEventDelegate);
     this.devtools.addListener((event, payload) => {
       switch (event) {
         case "RNIDE_appReady":
@@ -276,7 +277,6 @@ export class DeviceSession implements Disposable {
     // We start the debug session early to be able to use it to surface bundle
     // errors in the console. We only start the parent debug session and the JS
     // debugger will be started at later time once the app is built and launched.
-    this.debugSession = new DebugSession(this.debugEventDelegate);
     await this.debugSession.startParentDebugSession();
 
     await this.waitForMetroReady();

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -88,11 +88,6 @@ export class DeviceSession implements Disposable {
           break;
       }
     });
-
-    // we start debug session here to be able to leverage the functionality of debug console
-    // the session is not connected to the js debugger here yet and that step can only happen,
-    // after app is running.
-    this.debugSession = DebugSession.start(this.debugEventDelegate);
   }
 
   /**
@@ -277,6 +272,13 @@ export class DeviceSession implements Disposable {
     { cleanBuild, previewReadyCallback }: StartOptions
   ) {
     this.deviceSettings = deviceSettings;
+
+    // We start the debug session early to be able to use it to surface bundle
+    // errors in the console. We only start the parent debug session and the JS
+    // debugger will be started at later time once the app is built and launched.
+    this.debugSession = new DebugSession(this.debugEventDelegate);
+    await this.debugSession.startParentDebugSession();
+
     await this.waitForMetroReady();
     // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
     await this.bootDevice(deviceSettings);

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -14,10 +14,6 @@ import { connectCDPAndEval } from "../utilities/connectCDPAndEval";
 import { progressiveRetryTimeout, sleep } from "../utilities/retry";
 import { getOpenPort } from "../utilities/common";
 import { DebugSource } from "../debugging/DebugSession";
-import { openFileAtPosition } from "../utilities/openFileAtPosition";
-
-const FAKE_EDITOR = "RADON_IDE_FAKE_EDITOR";
-const OPENING_IN_FAKE_EDITOR_REGEX = new RegExp(`Opening (.+) in ${FAKE_EDITOR}`);
 
 export interface MetroDelegate {
   onBundleBuildFailedError(): void;
@@ -78,15 +74,16 @@ type MetroEvent =
       ];
     };
 
-export class Metro implements Disposable {
-  private subprocess?: ChildProcess;
-  private _port = 0;
-  private _watchFolders: string[] | undefined = undefined;
-  private startPromise: Promise<void> | undefined;
-  private usesNewDebugger?: Boolean;
-  private _expoPreludeLineCount = 0;
+export class Metro {
+  protected _port: number;
+  protected _watchFolders: string[] | undefined = undefined;
+  protected usesNewDebugger?: boolean;
+  protected _expoPreludeLineCount = 0;
 
-  constructor(private readonly devtools: Devtools, private readonly delegate: MetroDelegate) {}
+  constructor(port: number, watchFolders: string[] | undefined = undefined) {
+    this._port = port;
+    this._watchFolders = watchFolders;
+  }
 
   public get isUsingNewDebugger() {
     if (this.usesNewDebugger === undefined) {
@@ -108,252 +105,6 @@ export class Metro implements Disposable {
 
   public get expoPreludeLineCount() {
     return this._expoPreludeLineCount;
-  }
-
-  public dispose() {
-    this.subprocess?.kill(9);
-  }
-
-  public async ready() {
-    if (!this.startPromise) {
-      throw new Error("metro not started");
-    }
-    await this.startPromise;
-  }
-
-  public async start(
-    resetCache: boolean,
-    progressListener: (newStageProgress: number) => void,
-    dependencies: Promise<any>[],
-    appRoot: string
-  ) {
-    if (this.startPromise) {
-      throw new Error("metro already started");
-    }
-    this.startPromise = this.startInternal(resetCache, progressListener, dependencies, appRoot);
-    this.startPromise.then(() => {
-      // start promise is used to indicate that metro has started, however, sometimes
-      // the metro process may exit, in which case we need to update the promise to
-      // indicate an error.
-      this.subprocess
-        ?.catch(() => {
-          // ignore the error, we are only interested in the process exit
-        })
-        ?.then(() => {
-          this.startPromise = Promise.reject(new Error("Metro process exited"));
-        });
-    });
-    return this.startPromise;
-  }
-
-  private launchExpoMetro(
-    appRootFolder: string,
-    libPath: string,
-    resetCache: boolean,
-    expoStartExtraArgs: string[] | undefined,
-    metroEnv: typeof process.env
-  ) {
-    const args = [path.join(libPath, "expo_start.js")];
-    if (resetCache) {
-      args.push("--clear");
-    }
-    if (expoStartExtraArgs) {
-      args.push(...expoStartExtraArgs);
-    }
-
-    return exec("node", args, {
-      cwd: appRootFolder,
-      env: metroEnv,
-      buffer: false,
-    });
-  }
-
-  private launchPackager(
-    appRootFolder: string,
-    port: number,
-    libPath: string,
-    resetCache: boolean,
-    metroEnv: typeof process.env
-  ) {
-    const reactNativeRoot = path.dirname(
-      require.resolve("react-native", { paths: [appRootFolder] })
-    );
-    return exec(
-      "node",
-      [
-        path.join(reactNativeRoot, "cli.js"),
-        "start",
-        ...(resetCache ? ["--reset-cache"] : []),
-        "--no-interactive",
-        "--port",
-        `${port}`,
-        "--config",
-        path.join(libPath, "metro_config.js"),
-        "--customLogReporterPath",
-        path.join(libPath, "metro_reporter.js"),
-      ],
-      {
-        cwd: appRootFolder,
-        env: metroEnv,
-        buffer: false,
-      }
-    );
-  }
-
-  public async startInternal(
-    resetCache: boolean,
-    progressListener: (newStageProgress: number) => void,
-    dependencies: Promise<any>[],
-    appRoot: string
-  ) {
-    const launchConfiguration = getLaunchConfiguration();
-    await Promise.all([this.devtools.ready()].concat(dependencies));
-
-    const libPath = path.join(extensionContext.extensionPath, "lib");
-    let metroConfigPath: string | undefined;
-    if (launchConfiguration.metroConfigPath) {
-      metroConfigPath = findCustomMetroConfig(launchConfiguration.metroConfigPath);
-    }
-    const isExtensionDev = extensionContext.extensionMode === ExtensionMode.Development;
-
-    const port = await getOpenPort();
-
-    // NOTE: this is needed to capture metro's open-stack-frame calls.
-    // See `packages/vscode-extension/atom` script for more details.
-    const fakeEditorPath = extensionContext.asAbsolutePath("dist/atom");
-
-    const metroEnv = {
-      ...launchConfiguration.env,
-      ...(metroConfigPath ? { RN_IDE_METRO_CONFIG_PATH: metroConfigPath } : {}),
-      NODE_PATH: path.join(appRoot, "node_modules"),
-      RCT_METRO_PORT: `${port}`,
-      RCT_DEVTOOLS_PORT: this.devtools.port.toString(),
-      RADON_IDE_LIB_PATH: libPath,
-      RADON_IDE_VERSION: extensionContext.extension.packageJSON.version,
-      REACT_EDITOR: fakeEditorPath,
-      // NOTE: At least as of version 52, Expo uses a different mechanism to open stack frames in the editor,
-      // which doesn't allow passing a path to the EDITOR executable.
-      // Instead, we pass it a fake editor name and inspect the debug logs to extract the file path to open.
-      DEBUG: "expo:utils:editor",
-      EXPO_EDITOR: FAKE_EDITOR,
-      ...(isExtensionDev ? { RADON_IDE_DEV: "1" } : {}),
-    };
-    let bundlerProcess: ChildProcess;
-
-    if (shouldUseExpoCLI(appRoot)) {
-      bundlerProcess = this.launchExpoMetro(
-        appRoot,
-        libPath,
-        resetCache,
-        launchConfiguration.expoStartArgs,
-        metroEnv
-      );
-    } else {
-      bundlerProcess = this.launchPackager(appRoot, port, libPath, resetCache, metroEnv);
-    }
-    this.subprocess = bundlerProcess;
-
-    const initPromise = new Promise<void>((resolve, reject) => {
-      // reject if process exits
-      bundlerProcess
-        .catch((reason) => {
-          Logger.error("Metro exited unexpectedly", reason);
-          reject(new Error(`Metro exited with code ${reason.exitCode}: ${reason.message}`));
-        })
-        .then(() => {
-          // we expect metro to produce a line with the port number indicating it started
-          // successfully. However, if it doesn't produce that line and exists, the promise
-          // would be waiting indefinitely, so we reject it in that case as well.
-          reject(new Error("Metro exited but did not start server successfully."));
-        });
-
-      lineReader(bundlerProcess).onLineRead((line) => {
-        const handleMetroEvent = (event: MetroEvent) => {
-          if (event.type === "bundle_transform_progressed") {
-            // Because totalFileCount grows as bundle_transform progresses at the beginning there are a few logs that indicate 100% progress thats why we ignore them
-            if (event.totalFileCount > 10) {
-              progressListener(event.transformedFileCount / event.totalFileCount);
-            }
-          } else if (event.type === "client_log" && event.level === "error") {
-            Logger.error(stripAnsi(event.data[0]));
-          } else {
-            Logger.debug("Metro", line);
-          }
-
-          switch (event.type) {
-            case "RNIDE_expo_env_prelude_lines":
-              this._expoPreludeLineCount = event.lineCount;
-              Logger.debug("Expo prelude line offset was set to: ", this._expoPreludeLineCount);
-              break;
-            case "initialize_done":
-              this._port = event.port;
-              Logger.info(`Metro started on port ${this._port}`);
-              resolve();
-              break;
-            case "RNIDE_watch_folders":
-              this._watchFolders = event.watchFolders;
-              Logger.info("Captured metro watch folders", this._watchFolders);
-              break;
-            case "bundle_build_failed":
-              this.delegate.onBundleBuildFailedError();
-              break;
-            case "bundling_error":
-              const message = stripAnsi(event.message);
-              let filename = event.error.originModulePath;
-              if (!filename && event.error.filename) {
-                filename = path.join(appRoot, event.error.filename);
-              }
-              this.delegate.onBundlingError(
-                message,
-                {
-                  filename,
-                  line1based: event.error.lineNumber,
-                  column0based: event.error.columnNumber,
-                },
-                event.error.originModulePath
-              );
-              break;
-          }
-        };
-
-        let event: MetroEvent | undefined;
-        try {
-          event = JSON.parse(line) as MetroEvent;
-        } catch {}
-
-        if (event) {
-          handleMetroEvent(event);
-          return;
-        }
-
-        Logger.debug("Metro", line);
-
-        if (line.startsWith("__RNIDE__open_editor__ ")) {
-          this.handleOpenEditor(line.slice("__RNIDE__open_editor__ ".length));
-        } else if (line.includes(FAKE_EDITOR)) {
-          const matches = line.match(OPENING_IN_FAKE_EDITOR_REGEX);
-          if (matches?.length) {
-            this.handleOpenEditor(matches[1]);
-          }
-        }
-      });
-    });
-
-    return initPromise;
-  }
-
-  private handleOpenEditor(payload: string) {
-    // NOTE: this regex matches `fileName[:lineNumber][:columnNumber]` format:
-    // - (.+?) - fileName (any character, non-greedy to allow for the trailing numbers)
-    // - (?::(\d+))? - optional ":number", not capturing the colon
-    const matches = /^(.+?)(?::(\d+))?(?::(\d+))?$/.exec(payload);
-    if (!matches) {
-      return;
-    }
-    const fileName = matches[1];
-    const lineNumber = matches[2] ? parseInt(matches[2], 10) - 1 : 0;
-    const columnNumber = matches[3] ? parseInt(matches[3], 10) - 1 : 0;
-    openFileAtPosition(fileName, lineNumber, columnNumber);
   }
 
   private async sendMessageToDevice(method: "devMenu" | "reload") {
@@ -540,6 +291,220 @@ export class Metro implements Disposable {
       : this.lookupWsAddressForOldDebugger(listJson);
 
     return websocketAddress;
+  }
+}
+
+export class MetroLauncher extends Metro implements Disposable {
+  private subprocess?: ChildProcess;
+  private startPromise: Promise<void> | undefined;
+
+  constructor(private readonly devtools: Devtools, private readonly delegate: MetroDelegate) {
+    super(0);
+  }
+
+  public dispose() {
+    this.subprocess?.kill(9);
+  }
+
+  public async ready() {
+    if (!this.startPromise) {
+      throw new Error("metro not started");
+    }
+    await this.startPromise;
+  }
+
+  public async start(
+    resetCache: boolean,
+    progressListener: (newStageProgress: number) => void,
+    dependencies: Promise<any>[],
+    appRoot: string
+  ) {
+    if (this.startPromise) {
+      throw new Error("metro already started");
+    }
+    this.startPromise = this.startInternal(resetCache, progressListener, dependencies, appRoot);
+    this.startPromise.then(() => {
+      // start promise is used to indicate that metro has started, however, sometimes
+      // the metro process may exit, in which case we need to update the promise to
+      // indicate an error.
+      this.subprocess
+        ?.catch(() => {
+          // ignore the error, we are only interested in the process exit
+        })
+        ?.then(() => {
+          this.startPromise = Promise.reject(new Error("Metro process exited"));
+        });
+    });
+    return this.startPromise;
+  }
+
+  private launchExpoMetro(
+    appRootFolder: string,
+    libPath: string,
+    resetCache: boolean,
+    expoStartExtraArgs: string[] | undefined,
+    metroEnv: typeof process.env
+  ) {
+    const args = [path.join(libPath, "expo_start.js")];
+    if (resetCache) {
+      args.push("--clear");
+    }
+    if (expoStartExtraArgs) {
+      args.push(...expoStartExtraArgs);
+    }
+
+    return exec("node", args, {
+      cwd: appRootFolder,
+      env: metroEnv,
+      buffer: false,
+    });
+  }
+
+  private launchPackager(
+    appRootFolder: string,
+    port: number,
+    libPath: string,
+    resetCache: boolean,
+    metroEnv: typeof process.env
+  ) {
+    const reactNativeRoot = path.dirname(
+      require.resolve("react-native", { paths: [appRootFolder] })
+    );
+    return exec(
+      "node",
+      [
+        path.join(reactNativeRoot, "cli.js"),
+        "start",
+        ...(resetCache ? ["--reset-cache"] : []),
+        "--no-interactive",
+        "--port",
+        `${port}`,
+        "--config",
+        path.join(libPath, "metro_config.js"),
+        "--customLogReporterPath",
+        path.join(libPath, "metro_reporter.js"),
+      ],
+      {
+        cwd: appRootFolder,
+        env: metroEnv,
+        buffer: false,
+      }
+    );
+  }
+
+  public async startInternal(
+    resetCache: boolean,
+    progressListener: (newStageProgress: number) => void,
+    dependencies: Promise<any>[],
+    appRoot: string
+  ) {
+    const launchConfiguration = getLaunchConfiguration();
+    await Promise.all([this.devtools.ready()].concat(dependencies));
+
+    const libPath = path.join(extensionContext.extensionPath, "lib");
+    let metroConfigPath: string | undefined;
+    if (launchConfiguration.metroConfigPath) {
+      metroConfigPath = findCustomMetroConfig(launchConfiguration.metroConfigPath);
+    }
+    const isExtensionDev = extensionContext.extensionMode === ExtensionMode.Development;
+
+    const port = await getOpenPort();
+
+    const metroEnv = {
+      ...launchConfiguration.env,
+      ...(metroConfigPath ? { RN_IDE_METRO_CONFIG_PATH: metroConfigPath } : {}),
+      NODE_PATH: path.join(appRoot, "node_modules"),
+      RCT_METRO_PORT: `${port}`,
+      RCT_DEVTOOLS_PORT: this.devtools.port.toString(),
+      RADON_IDE_LIB_PATH: libPath,
+      RADON_IDE_VERSION: extensionContext.extension.packageJSON.version,
+      ...(isExtensionDev ? { RADON_IDE_DEV: "1" } : {}),
+    };
+    let bundlerProcess: ChildProcess;
+
+    if (shouldUseExpoCLI(appRoot)) {
+      bundlerProcess = this.launchExpoMetro(
+        appRoot,
+        libPath,
+        resetCache,
+        launchConfiguration.expoStartArgs,
+        metroEnv
+      );
+    } else {
+      bundlerProcess = this.launchPackager(appRoot, port, libPath, resetCache, metroEnv);
+    }
+    this.subprocess = bundlerProcess;
+
+    const initPromise = new Promise<void>((resolve, reject) => {
+      // reject if process exits
+      bundlerProcess
+        .catch((reason) => {
+          Logger.error("Metro exited unexpectedly", reason);
+          reject(new Error(`Metro exited with code ${reason.exitCode}: ${reason.message}`));
+        })
+        .then(() => {
+          // we expect metro to produce a line with the port number indicating it started
+          // successfully. However, if it doesn't produce that line and exists, the promise
+          // would be waiting indefinitely, so we reject it in that case as well.
+          reject(new Error("Metro exited but did not start server successfully."));
+        });
+
+      lineReader(bundlerProcess).onLineRead((line) => {
+        try {
+          const event = JSON.parse(line) as MetroEvent;
+          if (event.type === "bundle_transform_progressed") {
+            // Because totalFileCount grows as bundle_transform progresses at the beginning there are a few logs that indicate 100% progress thats why we ignore them
+            if (event.totalFileCount > 10) {
+              progressListener(event.transformedFileCount / event.totalFileCount);
+            }
+          } else if (event.type === "client_log" && event.level === "error") {
+            Logger.error(stripAnsi(event.data[0]));
+          } else {
+            Logger.debug("Metro", line);
+          }
+
+          switch (event.type) {
+            case "RNIDE_expo_env_prelude_lines":
+              this._expoPreludeLineCount = event.lineCount;
+              Logger.debug("Expo prelude line offset was set to: ", this._expoPreludeLineCount);
+              break;
+            case "initialize_done":
+              this._port = event.port;
+              Logger.info(`Metro started on port ${this._port}`);
+              resolve();
+              break;
+            case "RNIDE_watch_folders":
+              this._watchFolders = event.watchFolders;
+              Logger.info("Captured metro watch folders", this._watchFolders);
+              break;
+            case "bundle_build_failed":
+              this.delegate.onBundleBuildFailedError();
+              break;
+            case "bundling_error":
+              const message = stripAnsi(event.message);
+              let filename = event.error.originModulePath;
+              if (!filename && event.error.filename) {
+                filename = path.join(appRoot, event.error.filename);
+              }
+              this.delegate.onBundlingError(
+                message,
+                {
+                  filename,
+                  line1based: event.error.lineNumber,
+                  column0based: event.error.columnNumber,
+                },
+                event.error.originModulePath
+              );
+              break;
+          }
+        } catch (error) {
+          // ignore parsing errors, just print out the line
+          Logger.debug("Metro", line);
+        }
+      });
+    });
+
+    return initPromise;
   }
 }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -350,6 +350,8 @@ export class Project
     }
   }
 
+  onDebugSessionTerminated() {}
+
   async captureAndStopRecording() {
     const recording = await this.stopRecording();
     await this.utils.saveMultimedia(recording);

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -37,7 +37,7 @@ import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { throttle, throttleAsync } from "../utilities/throttle";
 import { DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
-import { Metro, MetroDelegate } from "./metro";
+import { MetroDelegate, MetroLauncher } from "./metro";
 import { Devtools } from "./devtools";
 import { AppEvent, DeviceBootError, DeviceSession, EventDelegate } from "./deviceSession";
 import { PanelLocation } from "../common/WorkspaceConfig";
@@ -72,7 +72,7 @@ export class Project
 {
   private applicationContext: ApplicationContext;
 
-  public metro: Metro;
+  public metro: MetroLauncher;
   public toolsManager: ToolsManager;
 
   private devtools;
@@ -115,7 +115,7 @@ export class Project
     };
 
     this.devtools = new Devtools();
-    this.metro = new Metro(this.devtools, this);
+    this.metro = new MetroLauncher(this.devtools, this);
     this.start(false, false);
     this.trySelectingInitialDevice();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
@@ -633,7 +633,7 @@ export class Project
       const oldMetro = this.metro;
       const oldToolsManager = this.toolsManager;
       this.devtools = new Devtools();
-      this.metro = new Metro(this.devtools, this);
+      this.metro = new MetroLauncher(this.devtools, this);
       this.toolsManager = new ToolsManager(this.devtools, this.eventEmitter);
       oldToolsManager.dispose();
       oldDevtools.dispose();
@@ -668,7 +668,7 @@ export class Project
     return extensionContext.workspaceState.get<string[] | undefined>(DEEP_LINKS_HISTORY_KEY) ?? [];
   }
 
-  async openDeepLink(link: string, terminateApp: boolean) {
+  async openDeepLink(link: string) {
     const history = await this.getDeepLinksHistory();
     if (history.length === 0 || link !== history[0]) {
       extensionContext.workspaceState.update(
@@ -677,7 +677,7 @@ export class Project
       );
     }
 
-    this.deviceSession?.sendDeepLink(link, terminateApp);
+    this.deviceSession?.sendDeepLink(link);
   }
 
   public dispatchTouches(touches: Array<TouchPoint>, type: "Up" | "Move" | "Down") {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -37,7 +37,7 @@ import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { throttle, throttleAsync } from "../utilities/throttle";
 import { DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
-import { MetroDelegate, MetroLauncher } from "./metro";
+import { Metro, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
 import { AppEvent, DeviceBootError, DeviceSession, EventDelegate } from "./deviceSession";
 import { PanelLocation } from "../common/WorkspaceConfig";
@@ -72,7 +72,7 @@ export class Project
 {
   private applicationContext: ApplicationContext;
 
-  public metro: MetroLauncher;
+  public metro: Metro;
   public toolsManager: ToolsManager;
 
   private devtools;
@@ -115,7 +115,7 @@ export class Project
     };
 
     this.devtools = new Devtools();
-    this.metro = new MetroLauncher(this.devtools, this);
+    this.metro = new Metro(this.devtools, this);
     this.start(false, false);
     this.trySelectingInitialDevice();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
@@ -633,7 +633,7 @@ export class Project
       const oldMetro = this.metro;
       const oldToolsManager = this.toolsManager;
       this.devtools = new Devtools();
-      this.metro = new MetroLauncher(this.devtools, this);
+      this.metro = new Metro(this.devtools, this);
       this.toolsManager = new ToolsManager(this.devtools, this.eventEmitter);
       oldToolsManager.dispose();
       oldDevtools.dispose();
@@ -668,7 +668,7 @@ export class Project
     return extensionContext.workspaceState.get<string[] | undefined>(DEEP_LINKS_HISTORY_KEY) ?? [];
   }
 
-  async openDeepLink(link: string) {
+  async openDeepLink(link: string, terminateApp: boolean) {
     const history = await this.getDeepLinksHistory();
     if (history.length === 0 || link !== history[0]) {
       extensionContext.workspaceState.update(
@@ -677,7 +677,7 @@ export class Project
       );
     }
 
-    this.deviceSession?.sendDeepLink(link);
+    this.deviceSession?.sendDeepLink(link, terminateApp);
   }
 
   public dispatchTouches(touches: Array<TouchPoint>, type: "Up" | "Move" | "Down") {


### PR DESCRIPTION
In #964 we changed the debugger workflow and started using the debugger to also wrap the metro session to allow us reporting bundle errors.

Further #985 and #1001 contributed some changes to the debugger workflows that impacted the way we handle debug commands with assumption there is a separate debug session for metro and a new one for the js debugger.

This PR clears up that assumption and allows for the DebugSession class to work with the parent metro session but also without it. While the latter mode is not used, this refactor is needed to build the new "connect" functionality that allows Radon to work with the externally controlled metro instances. In such scenario we don't get bundle errors and hence can't use the debug session to report these. In addition, we need to handle disconnect events.

In this PR we are introducing a concept of master and JS debug sessions. Previously we'd use a different naming that I find confusing. The master session is the one that is spawned immediately along metro and is used to push errors from the bundler. The js debug session is started as a child session of the master session and is the main one that controls the JS runtime. The important part is that the JS debug session can now also launch without the parent session.

Below are highlights of what we are changing as part of this refactor:
 - DebugAdapter is no longer the owner of the js debug session. Instead, DebugSession is the main class that controlls both parent and child session. This removes some complexity from DebugAdapter and allows to avoid the adapter from acting as a command proxy
 - We update ping implementation introduced in #985 to use response instead of events for communication. This simplifies the implementation and event handling.
 - We extract a logic for starting debug session that also captures the session reference. This shared logic is now used to launch the parent metro session and the JS debugger session.
 - We rename the session that we start for the names to better indicate those sessions are spawned and controlled by Radon IDE
 - We add a new onTerminate event that is triggered when js debug session is disconnected.
 - We move call to `DebugSession.start` from DeviceSession constructor into `start` method. This allow us to await the start of the parent session before we continue with the normal flow. Before we'd rely on the parent session being started before we report first errors but we'd never await it.

Fixes # (issue)

### How Has This Been Tested: 
1. Run RN 78 and Expo 52 to test new debugger setups. Test reload JS functionality
2. Run RN 75 and Expo 51 to test old debuger setup
3. Run Expo Go and test JS reloads to make sure changes from #985 are still in place (see test scenario from #985)


