### PR TITLE
Prevent device select dropdown from staying focused after change

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -137,7 +137,10 @@ function DeviceSelect() {
       </Select.Trigger>
 
       <Select.Portal>
-        <Select.Content className="device-select-content" position="popper">
+        <Select.Content
+          className="device-select-content"
+          position="popper"
+          onCloseAutoFocus={(e) => e.preventDefault()}>
           <Select.ScrollUpButton className="device-select-scroll">
             <span className="codicon codicon-chevron-up" />
           </Select.ScrollUpButton>


### PR DESCRIPTION
This PR fixes a UI glitch where the device selection button would stay in focused state after being dismissed or when changing devices.

Before this change when you tap on the device select button and dismiss or select item from it, it'd stay focused / highlighted:
<img width="346" alt="image" src="https://github.com/user-attachments/assets/6cb2b29e-8b7f-43dc-b5d9-c5589b8a185f" />

Now it is no longer in the focused state after interacting:
<img width="291" alt="image" src="https://github.com/user-attachments/assets/e009c48f-a6cd-46d0-8516-5eb8030a81c7" />

We use the same technique as with other dropdown buttons where we use `onCloseAutoFocus` to dismiss the focus propagation.

### How Has This Been Tested: 
1. Click device select button, dismiss the menu, see it no longer stay highlighted


