### PR TITLE
Improve user experience when pods fail to install

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -122,6 +122,10 @@ export class BuildManager {
           if (installPods) {
             getTelemetryReporter().sendTelemetryEvent("build:install-pods", { platform });
             await this.dependencyManager.installPods(iOSBuildOutputChannel, cancelToken);
+            const installed = await this.dependencyManager.checkPodsInstallationStatus();
+            if (!installed) {
+              throw new Error("Pods could not be installed automatically.");
+            }
             // Installing pods may impact the fingerprint as new pods may be created under the project directory.
             // For this reason we need to recalculate the fingerprint after installing pods.
             buildFingerprint = await this.buildCache.calculateFingerprint(platform);

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -174,7 +174,7 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
     return true;
   }
 
-  public async installPods(buildOutputChannel: OutputChannel, cancelToken: CancelToken) {
+  public async installPods(outputChannel: OutputChannel, cancelToken: CancelToken) {
     const appRoot = this.appRootFolder;
     const iosDirPath = getIosSourceDir(appRoot);
 
@@ -194,7 +194,7 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
           env: { ...env, LANG: "en_US.UTF-8" },
         }
       );
-      lineReader(process).onLineRead((line) => buildOutputChannel.appendLine(line));
+      lineReader(process).onLineRead((line) => outputChannel.appendLine(line));
       await cancelToken.adapt(process);
     } catch (e) {
       Logger.error("Pods not installed", e);

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -69,6 +69,14 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
   }
 
   if (
+    dependencies.pods?.status !== "installed" &&
+    projectState.selectedDevice?.platform === DevicePlatform.IOS
+  ) {
+    description =
+      "Pods are not installed in your project. Run `pod install` in the `ios` directory and reload the app.";
+  }
+
+  if (
     dependencies.android?.status === "notInstalled" &&
     projectState.selectedDevice?.platform === DevicePlatform.Android
   ) {

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -37,7 +37,6 @@ function BuildErrorActions({
           } else {
             project.focusBuildOutput();
           }
-          project.focusBuildOutput();
         }}
         tooltip={{ label: "Open build logs", side: "bottom" }}>
         <span className="codicon codicon-symbol-keyword" />
@@ -72,8 +71,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
     dependencies.pods?.status !== "installed" &&
     projectState.selectedDevice?.platform === DevicePlatform.IOS
   ) {
-    description =
-      "Pods are not installed in your project. Run `pod install` in the `ios` directory and reload the app.";
+    description = "Pods could not be installed in your project. Check the build logs for details.";
   }
 
   if (


### PR DESCRIPTION
Stops iOS build if pods need to be installed, but the `pod install` command doesn't install them successfully.
Adds a descriptive message to the build error alert when pods are not installed.

### How Has This Been Tested: 
React Native 78 app in test-apps has an incorrect pods lockfile, which allows testing pod install failure
- try to run `react-native-78` in a freshly cloned repo on iOS -- the pods failed alert should appear
- try to run `react-native-78` in a freshly cloned repo on iOS, with pods not installed correctly -- the pods failed alert should appear
- try to run `react-native-78` in a freshly cloned repo on Android -- the app should build and run correctly
- try to run `react-native-78` in a freshly cloned repo on iOS after resolving the pods issues -- the app should build and run correctly

Previously:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/c21a01e1-0d0d-4160-895d-d95d1f6db117" />

Currently:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/05e0018e-a734-46a0-a074-3245ac997d91" />
