### PR TITLE
fix: use Uri.fsPath for filesystem operations

### DIFF
--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
@@ -43,7 +43,7 @@ function generateWebviewContent(
 ): string {
   const nonce = getNonce();
   const baseUri = getUri(webview, extensionUri, [PATH]);
-  const files = fs.readdirSync(baseUri.path, { recursive: true });
+  const files = fs.readdirSync(baseUri.fsPath, { recursive: true });
   const cssFiles = files
     .filter((file) => typeof file === "string")
     .filter((file) => file.endsWith(".css"));

--- a/packages/vscode-extension/src/utilities/extensionContext.ts
+++ b/packages/vscode-extension/src/utilities/extensionContext.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { commands, ExtensionContext, Uri, workspace, window } from "vscode";
 import { Logger } from "../Logger";
 import { getLaunchConfiguration } from "./launchConfiguration";
@@ -118,7 +119,7 @@ function searchForFilesDirectory(
       })
       .forEach((dir) => {
         searchQueue.push({
-          path: currentDir.path + "/" + dir.name,
+          path: path.join(currentDir.path, dir.name),
           searchDepth: currentDir.searchDepth + 1,
         });
       });

--- a/packages/vscode-extension/src/utilities/extensionContext.ts
+++ b/packages/vscode-extension/src/utilities/extensionContext.ts
@@ -63,7 +63,7 @@ export function findAppRootCandidates(maxSearchDepth: number = 3): string[] {
   }
 
   const searchDirectories: SearchItem[] = workspaceFolders.map((workspaceFolder) => {
-    return { path: workspaceFolder.uri.path, searchDepth: 0 };
+    return { path: workspaceFolder.uri.fsPath, searchDepth: 0 };
   });
 
   const candidates = searchForFilesDirectory(


### PR DESCRIPTION
VSCode's `Uri.path` includes a leading `/` on Windows (i.e `/c:/things/thing`), causing filesystem operations on file paths obtained from them to fail.
This PR fixes this issue by using `Uri.fsPath`, which is meant to be used with filesystem operations (according to [the API reference](https://code.visualstudio.com/api/references/vscode-api#Uri))

Fixes #1050

### How Has This Been Tested: 
- Open the extension on Windows
- Don't crash immediately