### PR TITLE
Only fetch builds from eas with matching fingerprint

### DIFF
--- a/packages/vscode-extension/src/builders/easCommand.ts
+++ b/packages/vscode-extension/src/builders/easCommand.ts
@@ -61,7 +61,7 @@ export async function isEasCliInstalled(appRoot: string) {
   }
 }
 
-type ListEasBuildsOptions = { profile: string; fingerprintHash?: string };
+type ListEasBuildsOptions = { profile: string; fingerprintHash: string };
 
 export async function listEasBuilds(
   platform: DevicePlatform,
@@ -78,11 +78,9 @@ export async function listEasBuilds(
     platformMapping[platform],
     "--profile",
     profile,
+    "--fingerprint-hash",
+    fingerprintHash,
   ];
-
-  if (fingerprintHash !== undefined) {
-    commandArgs.push("--fingerprint-hash", fingerprintHash);
-  }
 
   const { stdout } = await exec("eas", commandArgs, { cwd: appRoot });
   return parseEasBuildOutput(stdout, platform);


### PR DESCRIPTION
When fetching builds from EAS Build automatically (i.e. without providing a specific build id), we filter the available builds by the fingerprint returned by the `eas-cli fingerprint:generate` command.

### How Has This Been Tested: 
- run `expo-52-eas` test app on Android
- open launch configuration and select "EAS Build -> Android Build Profile -> development"
- the build should download from EAS Build successfully
- make a change which invalidates the fingerprint
- clean rebuild the app
- the build should fail, and the logs should indicate no build with matching fingerprint was found


