### PR TITLE
Fix home screen when xcode is not installed

### DIFF
--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -118,7 +118,7 @@ function getErrors(statuses: DependencyRecord) {
     .forEach(([dependency, _info]) => {
       switch (dependency) {
         case "xcode":
-          setFirstError(dependency, "emulator");
+          setFirstError(dependency, "simulator");
         /* fallthrough */
         case "cocoaPods":
         case "pods":


### PR DESCRIPTION
This PR fixes a mistake introduced in #586, causing missing xcode installation to be registered as emulator and not simulator error.

### How Has This Been Tested: 

- Uninstall Xcode form your machine 
- run `react-native-79` test app and remove all devices 
- click `add iPhone` and `add android` and check if it works



