### PR TITLE
Fix CDP Proxy port assignment strategy

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -33,10 +33,12 @@ export interface CDPProxyDelegate {
 export class CDPProxy {
   private server: Server | null = null;
   private tunnel: ProxyTunnel | null = null;
+  public get port() {
+    return this.server?.address.port;
+  }
 
   constructor(
     public readonly hostAddress: string,
-    public readonly port: number,
     private browserInspectUri: string,
     private cdpProxyDelegate: CDPProxyDelegate
   ) {}

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -58,12 +58,10 @@ export class ProxyDebugAdapter extends DebugSession {
       sourceMapAliases
     );
 
-    const cdpProxyPort = Math.round(Math.random() * 40000 + 3000);
     const proxyDelegate = new RadonCDPProxyDelegate(this.sourceMapRegistry);
 
     this.cdpProxy = new CDPProxy(
       "127.0.0.1",
-      cdpProxyPort,
       this.session.configuration.websocketAddress,
       proxyDelegate
     );
@@ -153,7 +151,7 @@ export class ProxyDebugAdapter extends DebugSession {
           type: CHILD_SESSION_TYPE,
           name: "Radon IDE Debugger",
           request: "attach",
-          port: this.cdpProxy.port,
+          port: this.cdpProxy.port!,
           continueOnAttach: true,
           sourceMapPathOverrides: args.sourceMapPathOverrides,
           resolveSourceMapLocations: ["**", "!**/node_modules/!(expo)/**"],


### PR DESCRIPTION
Makes CDP Proxy use an ephemeral port assigned by the OS instead of picking a random port and hoping it's open.

### How Has This Been Tested: 
- open an application
- verify the debugger connects correctly


