### PR TITLE
Properly trigger resume events to support Overlay CDP methods

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -25,6 +25,11 @@ export type DebugSessionDelegate = {
   onDebugSessionTerminated(): void;
 };
 
+export interface DebugExtraConfiguration {
+  websocketAddress?: string;
+  displayDebuggerOverlay?: boolean;
+}
+
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
 
 /**
@@ -165,12 +170,12 @@ export class DebugSession implements Disposable {
       .then(() => disposeAll(this.disposables));
   }
 
-  public async startJSDebugSession(metro: Metro) {
+  public async startJSDebugSession(metro: Metro, extraConfiguration?: DebugExtraConfiguration) {
     if (this.jsDebugSession) {
       await this.restart();
     }
 
-    const websocketAddress = await metro.getDebuggerURL();
+    let websocketAddress = extraConfiguration?.websocketAddress || (await metro.getDebuggerURL());
     if (!websocketAddress) {
       return false;
     }
@@ -197,6 +202,7 @@ export class DebugSession implements Disposable {
         sourceMapPathOverrides,
         websocketAddress,
         expoPreludeLineCount: metro.expoPreludeLineCount,
+        displayDebuggerOverlay: extraConfiguration?.displayDebuggerOverlay,
       },
       {
         parentSession: this.parentDebugSession,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -175,7 +175,7 @@ export class DebugSession implements Disposable {
       await this.restart();
     }
 
-    let websocketAddress = extraConfiguration?.websocketAddress || (await metro.getDebuggerURL());
+    const websocketAddress = extraConfiguration?.websocketAddress || (await metro.getDebuggerURL());
     if (!websocketAddress) {
       return false;
     }

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -69,11 +69,25 @@ export class ProxyDebugAdapter extends DebugSession {
     this.disposables.push(
       proxyDelegate.onDebuggerPaused(({ reason }) => {
         this.sendEvent(new Event(DEBUG_PAUSED, { reason }));
+        if (this.session.configuration.displayDebuggerOverlay) {
+          this.cdpProxy.injectDebuggerCommand({
+            method: "Overlay.setPausedInDebuggerMessage",
+            params: {
+              message: "Paused in debugger",
+            },
+          });
+        }
       })
     );
     this.disposables.push(
       proxyDelegate.onDebuggerResumed(() => {
         this.sendEvent(new Event(DEBUG_RESUMED));
+        if (this.session.configuration.displayDebuggerOverlay) {
+          this.cdpProxy.injectDebuggerCommand({
+            method: "Overlay.setPausedInDebuggerMessage",
+            params: {},
+          });
+        }
       })
     );
     this.disposables.push(

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -50,9 +50,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
           // In order to prevent the paused event from being fired immediately resulting
           // in the overlay blinking for a fraction of second, we wait for a short period
           // just in case the paused event is never fired.
-          this.justCalledStepOver = true;
+          this.justCalledStepOver = false;
           this.resumeEventTimeout = setTimeout(() => {
-            this.justCalledStepOver = false;
             this.debuggerResumedEmitter.fire({});
           }, 100);
         } else {


### PR DESCRIPTION
This PR adds support for built-in Overlay (via CDP) that displays debugger paused status. This only applies to the new debugger.

While the code for supporting this API is added, there is no place in the codebase currectly that'd use this.

As a part of this change however, we had to refactor support for paused/resume events.
Before this change, we'd only fire resume event when debugger runs the Debugger.resume command.
This wasn't ideal as there are other ways how debugger can resume including the Overlay that displays resume button.

The obvious solution would be to rely on debugger's `Debugger.resumed` event. 
This event however comes also when we perform step-over debugging. 
This causes the overlay to blink for a fraction of a second as the debugger is resumed to perform a single step.

To workaround this, we're delaying emitter from triggering resumed event in the case we perform step-over.
Otherwise, we trigger the event immediately.
In case the debugger takes longer to pause after step over, we will still trigger resume event, but this is very unlikely and it still seems like a better choice to dismiss the overlay intermittently then to get the overlay completely out of sync with the debugger state.

### How Has This Been Tested: 
1. Use RN 78 example
2. Set breakpoint, test step-over functionality. Verify the overlay doesn't "blink" when stepping over and it always gets dismissed.


