### PR TITLE
Improve Bundle error experience when auto save is enabled

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -53,6 +53,7 @@ import { UtilsInterface } from "../common/utils";
 import { ApplicationContext } from "./ApplicationContext";
 import { disposeAll } from "../utilities/disposables";
 import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRootFolder";
+import { isAutoSaveEnabled } from "../utilities/isAutoSaveEnabled";
 import { focusSource } from "../utilities/focusSource";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
@@ -407,8 +408,10 @@ export class Project
   ): Promise<void> {
     await this.deviceSession?.appendDebugConsoleEntry(message, "error", source);
 
-    this.focusDebugConsole();
-    focusSource(source);
+    if (!isAutoSaveEnabled()) {
+      this.focusDebugConsole();
+      focusSource(source);
+    }
 
     Logger.error("[Bundling Error]", message);
     // if bundle build failed, we don't want to change the status

--- a/packages/vscode-extension/src/utilities/isAutoSaveEnabled.ts
+++ b/packages/vscode-extension/src/utilities/isAutoSaveEnabled.ts
@@ -1,0 +1,5 @@
+import { workspace } from "vscode";
+
+export function isAutoSaveEnabled(): boolean {
+  return workspace.getConfiguration().get("files.autoSave") !== "off";
+}

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -161,7 +161,7 @@ function BundleErrorActions() {
         onClick={() => {
           project.focusDebugConsole();
         }}
-        tooltip={{ label: "Open extension logs", side: "bottom" }}>
+        tooltip={{ label: "Open debug console", side: "bottom" }}>
         <span className="codicon codicon-output" />
       </IconButton>
       <IconButton

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -159,7 +159,7 @@ function BundleErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          project.focusExtensionLogsOutput();
+          project.focusDebugConsole();
         }}
         tooltip={{ label: "Open extension logs", side: "bottom" }}>
         <span className="codicon codicon-output" />


### PR DESCRIPTION
This PR does two things:
1) disables triggering on source of bundle error when auto focus is enabled, as users give as feedback that this functionality disrupts their flow
2) replaces focus on IDE logs with focus on debug console in Bundle error actions as the bundle error logs are now visible in the console.

### How Has This Been Tested: 

- turn on auto save and trigger bundle errors you can now write without stoping to move the pointer



