### PR TITLE
Improve user interface in case of old node version

### DIFF
--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -98,6 +98,12 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
     };
   }
 
+  if (dependencies.nodejs?.status === "notInstalled") {
+    description =
+      "Node.js was not found, or the version in the PATH does not satisfy minimum version requirements.";
+    logsButtonDestination = "extension";
+  }
+
   const isEasBuild =
     (!!eas?.android && projectState.selectedDevice?.platform === DevicePlatform.Android) ||
     (!!eas?.ios && projectState.selectedDevice?.platform === DevicePlatform.IOS);


### PR DESCRIPTION
This PR adds information to the build error baner that informs the user about missing node installation, or that it is too old to suport react native applications.

### How Has This Been Tested: 

- use command `nvm alias default 17` and open vscode from new shell 
- test `react-native-79` test app 
- the new description shows app correctly 


