### PR TITLE
Add mapping for android SDK 36

### DIFF
--- a/packages/vscode-extension/src/utilities/sdkmanager.ts
+++ b/packages/vscode-extension/src/utilities/sdkmanager.ts
@@ -24,6 +24,8 @@ const ANDROID_CODENAMES_TO_API_LEVELS = {
 // Temporary solution due to sdkmanager not having information about android version.
 function mapApiLevelToAndroidVersion(apiLevel: number): number | undefined {
   switch (apiLevel) {
+    case 36:
+      return 16;
     case 35:
       return 15;
     case 34:


### PR DESCRIPTION
This PR adds information that android sdk 36 is android 16 

### How Has This Been Tested: 

run extension and add device with sdk 36


