### PR TITLE
fix EAS in launch config not being set correctly in webview

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -121,16 +121,23 @@ export async function buildAndroid(
     getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
       platform: DevicePlatform.Android,
     });
-    const apkPath = await fetchEasBuild(cancelToken, eas.android, DevicePlatform.Android, appRoot);
-    if (!apkPath) {
+    try {
+      const apkPath = await fetchEasBuild(
+        cancelToken,
+        eas.android,
+        DevicePlatform.Android,
+        appRoot,
+        outputChannel
+      );
+
+      return {
+        apkPath,
+        packageName: await extractPackageName(apkPath, cancelToken),
+        platform: DevicePlatform.Android,
+      };
+    } catch {
       throw new Error("Failed to build Android app using EAS build.");
     }
-
-    return {
-      apkPath,
-      packageName: await extractPackageName(apkPath, cancelToken),
-      platform: DevicePlatform.Android,
-    };
   }
 
   if (await isExpoGoProject(appRoot)) {

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -115,16 +115,24 @@ export async function buildIos(
     getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
       platform: DevicePlatform.IOS,
     });
-    const appPath = await fetchEasBuild(cancelToken, eas.ios, DevicePlatform.IOS, appRoot);
-    if (!appPath) {
+
+    try {
+      const appPath = await fetchEasBuild(
+        cancelToken,
+        eas.ios,
+        DevicePlatform.IOS,
+        appRoot,
+        outputChannel
+      );
+
+      return {
+        appPath,
+        bundleID: await getBundleID(appPath),
+        platform: DevicePlatform.IOS,
+      };
+    } catch {
       throw new Error("Failed to build iOS app using EAS build.");
     }
-
-    return {
-      appPath,
-      bundleID: await getBundleID(appPath),
-      platform: DevicePlatform.IOS,
-    };
   }
 
   if (await isExpoGoProject(appRoot)) {

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -7,16 +7,13 @@ import {
   LaunchConfigEventMap,
   LaunchConfigurationOptions,
 } from "../common/LaunchConfig";
-import {
-  extensionContext,
-  findAppRootCandidates,
-  getCurrentLaunchConfig,
-} from "../utilities/extensionContext";
+import { extensionContext, findAppRootCandidates } from "../utilities/extensionContext";
 import { findXcodeProject, findXcodeScheme } from "../utilities/xcode";
 import { Logger } from "../Logger";
 import { getIosSourceDir } from "../builders/buildIOS";
 import { readEasConfig } from "../utilities/eas";
 import { EasBuildConfig } from "../common/EasConfig";
+import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 
 const CUSTOM_APPLICATION_ROOTS_KEY = "custom_application_roots_key";
 
@@ -26,14 +23,14 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
   private configListener: Disposable;
 
   constructor(private readonly appRootFolder: string) {
-    this.config = getCurrentLaunchConfig();
+    this.config = getLaunchConfiguration();
 
     this.configListener = workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
       if (!event.affectsConfiguration("launch")) {
         return;
       }
 
-      this.config = getCurrentLaunchConfig();
+      this.config = getLaunchConfiguration();
 
       this.eventEmitter.emit("launchConfigChange", this.config);
     });

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -32,7 +32,7 @@ import {
 import { Logger } from "../Logger";
 import { DeviceInfo } from "../common/DeviceManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
-import { extensionContext, getCurrentLaunchConfig } from "../utilities/extensionContext";
+import { extensionContext } from "../utilities/extensionContext";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { throttle, throttleAsync } from "../utilities/throttle";
@@ -54,6 +54,7 @@ import { ApplicationContext } from "./ApplicationContext";
 import { disposeAll } from "../utilities/disposables";
 import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRootFolder";
 import { focusSource } from "../utilities/focusSource";
+import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 
@@ -139,7 +140,7 @@ export class Project
     this.disposables.push(
       workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
         if (event.affectsConfiguration("launch")) {
-          const config = getCurrentLaunchConfig();
+          const config = getLaunchConfiguration();
           const oldAppRoot = this.appRootFolder;
           if (config.appRoot === oldAppRoot) {
             return;

--- a/packages/vscode-extension/src/utilities/extensionContext.ts
+++ b/packages/vscode-extension/src/utilities/extensionContext.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { commands, ExtensionContext, Uri, workspace, window } from "vscode";
 import { Logger } from "../Logger";
 import { getLaunchConfiguration } from "./launchConfiguration";
-import { LaunchConfigurationOptions } from "../common/LaunchConfig";
 
 let _extensionContext: ExtensionContext | null = null;
 
@@ -21,27 +20,6 @@ export const extensionContext = new Proxy<ExtensionContext>({} as ExtensionConte
     return Reflect.get(_extensionContext, prop);
   },
 });
-
-export const getCurrentLaunchConfig = (): LaunchConfigurationOptions => {
-  const launchConfiguration = workspace.getConfiguration(
-    "launch",
-    workspace.workspaceFolders![0].uri
-  );
-
-  const configurations = launchConfiguration.get<Array<Record<string, any>>>("configurations")!;
-
-  const RNIDEConfiguration = configurations.find(
-    ({ type }) => type === "react-native-ide" || type === "radon-ide" // for compatibility we want to support old configuration type name
-  );
-
-  if (!RNIDEConfiguration) {
-    return {};
-  }
-
-  const { android, appRoot, ios, isExpo, metroConfigPath, env } = RNIDEConfiguration;
-
-  return { android, appRoot, ios, isExpo, metroConfigPath, env };
-};
 
 export function findAppRootCandidates(maxSearchDepth: number = 3): string[] {
   const searchedFileNames = [


### PR DESCRIPTION
Fixes an issue where the frontend was never aware of the launch config's EAS settings.
This was caused by the frontend and extension using a different method to read the launch config, one of which picked the fields from the config to send explicitely, and which omitted the `eas` entry.

### How Has This Been Tested: 
- open the `expo-52-eas` app
- go to launch config options
- verify the development profile is picked for EAS build
- try to build the app after changing something which impacts the fingerprint (to force build fail)
- verify an EAS-related error is displayed



