### PR TITLE
Improve how EAS Build errors are logged

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -1,4 +1,5 @@
 import { Disposable, OutputChannel, window } from "vscode";
+import _ from "lodash";
 import { BuildCache } from "./BuildCache";
 import { AndroidBuildResult, buildAndroid } from "./buildAndroid";
 import { IOSBuildResult, buildIos } from "./buildIOS";
@@ -153,7 +154,7 @@ export class BuildManager {
         cancelToken.cancel();
       },
     };
-    disposableBuild.build.then(onSuccess);
+    disposableBuild.build.then(onSuccess).catch(_.noop);
 
     return disposableBuild;
   }

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -121,23 +121,19 @@ export async function buildAndroid(
     getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
       platform: DevicePlatform.Android,
     });
-    try {
-      const apkPath = await fetchEasBuild(
-        cancelToken,
-        eas.android,
-        DevicePlatform.Android,
-        appRoot,
-        outputChannel
-      );
+    const apkPath = await fetchEasBuild(
+      cancelToken,
+      eas.android,
+      DevicePlatform.Android,
+      appRoot,
+      outputChannel
+    );
 
-      return {
-        apkPath,
-        packageName: await extractPackageName(apkPath, cancelToken),
-        platform: DevicePlatform.Android,
-      };
-    } catch {
-      throw new Error("Failed to build Android app using EAS build.");
-    }
+    return {
+      apkPath,
+      packageName: await extractPackageName(apkPath, cancelToken),
+      platform: DevicePlatform.Android,
+    };
   }
 
   if (await isExpoGoProject(appRoot)) {

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -116,23 +116,19 @@ export async function buildIos(
       platform: DevicePlatform.IOS,
     });
 
-    try {
-      const appPath = await fetchEasBuild(
-        cancelToken,
-        eas.ios,
-        DevicePlatform.IOS,
-        appRoot,
-        outputChannel
-      );
+    const appPath = await fetchEasBuild(
+      cancelToken,
+      eas.ios,
+      DevicePlatform.IOS,
+      appRoot,
+      outputChannel
+    );
 
-      return {
-        appPath,
-        bundleID: await getBundleID(appPath),
-        platform: DevicePlatform.IOS,
-      };
-    } catch {
-      throw new Error("Failed to build iOS app using EAS build.");
-    }
+    return {
+      appPath,
+      bundleID: await getBundleID(appPath),
+      platform: DevicePlatform.IOS,
+    };
   }
 
   if (await isExpoGoProject(appRoot)) {

--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -68,9 +68,13 @@ async function fetchBuild(
     appRoot
   );
   if (!builds || builds.length === 0) {
-    throw new Error(
-      `Failed to find any EAS build artifacts for ${platform} with ${config.profile} profile. If you're building iOS app, make sure you set '"ios.simulator": true' option in eas.json.`
-    );
+    let message = `Failed to find any EAS build artifacts for ${platform} with ${config.profile} profile and matching the fingerprint of the local workspace.`;
+    message +=
+      "\nYou can run `eas fingerprint:compare` in a terminal to check why the fingerprint doesn't match the available builds.";
+    if (platform === DevicePlatform.IOS) {
+      message += `\nMake sure you set '"ios.simulator": true' option for profile '${config.profile}' in eas.json.`;
+    }
+    throw new Error(message);
   }
   if (builds.every((build) => build.expired)) {
     throw new Error(

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -973,7 +973,7 @@ export class Project
         status: "running",
       });
     } catch (e) {
-      Logger.error("Couldn't start device session", e);
+      Logger.error("Couldn't start device session", e instanceof Error ? e.message : e);
 
       const isSelected = this.projectState.selectedDevice === deviceInfo;
       const isNewSession = this.deviceSession === newDeviceSession;


### PR DESCRIPTION
Makes sure the error message for the exception thrown from the `eas` builder is reported in the extension output.
### How Has This Been Tested: 
- open the `expo-52-eas` app
- make the build fail
- verify that when the build fails, the logs end with a verbose explanation of what went wrong


