### PR TITLE
Decouple metro and debug session classes

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -120,20 +120,6 @@ export class DebugSession implements Disposable {
     return this.currentWsTarget;
   }
 
-  public async reconnectJSDebuggerIfNeeded(configuration: JSDebugConfiguration) {
-    if (configuration.websocketAddress === this.currentWsTarget) {
-      // if the websocket address is the same, it means that the old endpoint is still listed
-      // however, the record might be stale as Metro often lists endpoints for some time after
-      // they've been terminated. We need to check if the endpoint is responding before we decide
-      // whether we need to reconnect.
-    }
-    const isAlive = await this.isJsDebugSessionAlive(metro);
-    if (!isAlive) {
-      return this.startJSDebugSession(metro);
-    }
-    return true;
-  }
-
   public async startParentDebugSession() {
     assert(
       !this.jsDebugSession,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import path from "path";
 import { commands, debug, DebugConsoleMode, DebugSessionCustomEvent, Disposable } from "vscode";
 import * as vscode from "vscode";
 import { disposeAll } from "../utilities/disposables";

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -25,9 +25,12 @@ export type DebugSessionDelegate = {
   onDebugSessionTerminated(): void;
 };
 
-export interface DebugExtraConfiguration {
-  websocketAddress?: string;
-  displayDebuggerOverlay?: boolean;
+export interface JSDebugConfiguration {
+  websocketAddress: string;
+  watchFolders: string[];
+  displayDebuggerOverlay: boolean;
+  isUsingNewDebugger: boolean;
+  expoPreludeLineCount: number;
 }
 
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
@@ -113,7 +116,17 @@ export class DebugSession implements Disposable {
     );
   }
 
-  public async reconnectJSDebuggerIfNeeded(metro: Metro) {
+  public get websocketTarget() {
+    return this.currentWsTarget;
+  }
+
+  public async reconnectJSDebuggerIfNeeded(configuration: JSDebugConfiguration) {
+    if (configuration.websocketAddress === this.currentWsTarget) {
+      // if the websocket address is the same, it means that the old endpoint is still listed
+      // however, the record might be stale as Metro often lists endpoints for some time after
+      // they've been terminated. We need to check if the endpoint is responding before we decide
+      // whether we need to reconnect.
+    }
     const isAlive = await this.isJsDebugSessionAlive(metro);
     if (!isAlive) {
       return this.startJSDebugSession(metro);
@@ -170,21 +183,16 @@ export class DebugSession implements Disposable {
       .then(() => disposeAll(this.disposables));
   }
 
-  public async startJSDebugSession(metro: Metro, extraConfiguration?: DebugExtraConfiguration) {
+  public async startJSDebugSession(configuration: JSDebugConfiguration) {
     if (this.jsDebugSession) {
       await this.restart();
     }
 
-    const websocketAddress = extraConfiguration?.websocketAddress || (await metro.getDebuggerURL());
-    if (!websocketAddress) {
-      return false;
-    }
-
-    const isUsingNewDebugger = metro.isUsingNewDebugger;
+    const isUsingNewDebugger = configuration.isUsingNewDebugger;
     const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
     const sourceMapPathOverrides: Record<string, string> = {};
-    const metroWatchFolders = metro.watchFolders;
+    const metroWatchFolders = configuration.watchFolders;
     if (isUsingNewDebugger && metroWatchFolders.length > 0) {
       sourceMapPathOverrides["/[metro-project]/*"] = `${metroWatchFolders[0]}${path.sep}*`;
       metroWatchFolders.forEach((watchFolder, index) => {
@@ -200,9 +208,9 @@ export class DebugSession implements Disposable {
         request: "attach",
         breakpointsAreRemovedOnContextCleared: isUsingNewDebugger ? false : true, // new debugger properly keeps all breakpoints in between JS reloads
         sourceMapPathOverrides,
-        websocketAddress,
-        expoPreludeLineCount: metro.expoPreludeLineCount,
-        displayDebuggerOverlay: extraConfiguration?.displayDebuggerOverlay,
+        websocketAddress: configuration.websocketAddress,
+        expoPreludeLineCount: configuration.expoPreludeLineCount,
+        displayDebuggerOverlay: configuration.displayDebuggerOverlay,
       },
       {
         parentSession: this.parentDebugSession,
@@ -215,7 +223,7 @@ export class DebugSession implements Disposable {
       }
     );
 
-    this.currentWsTarget = websocketAddress;
+    this.currentWsTarget = configuration.websocketAddress;
 
     return true;
   }
@@ -230,41 +238,6 @@ export class DebugSession implements Disposable {
     commands.executeCommand("workbench.action.debug.stepOver", undefined, {
       sessionId: this.jsDebugSession?.id,
     });
-  }
-
-  public async isJsDebugSessionAlive(metro: Metro): Promise<boolean> {
-    /**
-     * We use a combination of two check to determine if the js debug session is alive and active:
-     * 1. we use "ping" command that executes a simple JS code using Runtime.evaluate to determine that the runtime responds.
-     * 2. we check if the runtime is listed on the ws targets list.
-     *
-     * Apparently, the sole existence of the runtime on the list doesn't tell if it is really running. Metro has some
-     * internal logic that keeps the runtimes listed for some time after they've been terminated. However, when the
-     * runtime is not listed it is sufficient to conclude that it is not running.
-     *
-     * We therefore use Promise.any for this check and expect the 2nd check to only return when the runtime isn't listed
-     * but otherwise we want it to throw and wait for the ping check to finish. In addition the ping check is guarded by
-     * a timeout as when the runtime is disconnected the evaluate call is never picked up bu the runtime and we will never
-     * get a response back.
-     */
-    return Promise.any([
-      this.pingJsDebugSessionWithTimeout(),
-      this.isCurrentWsTargetStillVisible(metro),
-    ]);
-  }
-
-  public async isCurrentWsTargetStillVisible(metro: Metro) {
-    const possibleWsTargets = await metro.fetchWsTargets();
-    const hasCurrentWsAddress = possibleWsTargets?.some(
-      (runtime) => runtime.webSocketDebuggerUrl === this.currentWsTarget
-    );
-
-    if (!this.currentWsTarget || !hasCurrentWsAddress) {
-      return false;
-    }
-    // We're rejecting as shouldDebuggerReconnect uses .any which waits for first promise to resolve.
-    // And th fact that current wsTarget is on the list is not enough, it might be stale, so in this case we wait for ping.
-    throw new Error("current ws target is still");
   }
 
   public async pingJsDebugSessionWithTimeout() {

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -27,7 +27,7 @@ export type DebugSessionDelegate = {
 
 export interface JSDebugConfiguration {
   websocketAddress: string;
-  watchFolders: string[];
+  sourceMapPathOverrides: Record<string, string>;
   displayDebuggerOverlay: boolean;
   isUsingNewDebugger: boolean;
   expoPreludeLineCount: number;
@@ -139,15 +139,6 @@ export class DebugSession implements Disposable {
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
     const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
-    const sourceMapPathOverrides: Record<string, string> = {};
-    const metroWatchFolders = configuration.watchFolders;
-    if (isUsingNewDebugger && metroWatchFolders.length > 0) {
-      sourceMapPathOverrides["/[metro-project]/*"] = `${metroWatchFolders[0]}${path.sep}*`;
-      metroWatchFolders.forEach((watchFolder, index) => {
-        sourceMapPathOverrides[`/[metro-watchFolders]/${index}/*`] = `${watchFolder}${path.sep}*`;
-      });
-    }
-
     this.jsDebugSession = await startDebugging(
       undefined,
       {
@@ -155,7 +146,7 @@ export class DebugSession implements Disposable {
         name: "React Native JS Debugger",
         request: "attach",
         breakpointsAreRemovedOnContextCleared: isUsingNewDebugger ? false : true, // new debugger properly keeps all breakpoints in between JS reloads
-        sourceMapPathOverrides,
+        sourceMapPathOverrides: configuration.sourceMapPathOverrides,
         websocketAddress: configuration.websocketAddress,
         expoPreludeLineCount: configuration.expoPreludeLineCount,
         displayDebuggerOverlay: configuration.displayDebuggerOverlay,

--- a/packages/vscode-extension/src/debugging/startDebugging.ts
+++ b/packages/vscode-extension/src/debugging/startDebugging.ts
@@ -9,7 +9,7 @@ export async function startDebugging(
   folder: vscode.WorkspaceFolder | undefined,
   nameOrConfiguration: string | vscode.DebugConfiguration,
   parentSessionOrOptions?: vscode.DebugSession | vscode.DebugSessionOptions
-) {
+): Promise<vscode.DebugSession> {
   const debugSessionType =
     typeof nameOrConfiguration === "string" ? nameOrConfiguration : nameOrConfiguration.type;
   let debugSession: vscode.DebugSession | undefined;

--- a/packages/vscode-extension/src/debugging/startDebugging.ts
+++ b/packages/vscode-extension/src/debugging/startDebugging.ts
@@ -1,0 +1,41 @@
+import assert from "assert";
+import * as vscode from "vscode";
+import { debug, Disposable } from "vscode";
+
+/**
+ * Helper function that starts a debug session and returns the session object upon sucesfull start
+ */
+export async function startDebugging(
+  folder: vscode.WorkspaceFolder | undefined,
+  nameOrConfiguration: string | vscode.DebugConfiguration,
+  parentSessionOrOptions?: vscode.DebugSession | vscode.DebugSessionOptions
+) {
+  const debugSessionType =
+    typeof nameOrConfiguration === "string" ? nameOrConfiguration : nameOrConfiguration.type;
+  let debugSession: vscode.DebugSession | undefined;
+  let didStartHandler: Disposable | null = debug.onDidStartDebugSession((session) => {
+    if (session.type === debugSessionType) {
+      didStartHandler?.dispose();
+      didStartHandler = null;
+      debugSession = session;
+    }
+  });
+  try {
+    const debugStarted = await debug.startDebugging(
+      folder,
+      nameOrConfiguration,
+      parentSessionOrOptions
+    );
+
+    if (debugStarted) {
+      // NOTE: this is safe, because `debugStarted` means the session started successfully,
+      // and we set the session in the `onDidStartDebugSession` handler
+      assert(debugSession, "Expected debug session to be set");
+      return debugSession;
+    } else {
+      throw new Error("Failed to start debug session");
+    }
+  } finally {
+    didStartHandler?.dispose();
+  }
+}

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -326,7 +326,7 @@ export class DeviceSession implements Disposable {
       displayDebuggerOverlay: false,
       isUsingNewDebugger: this.metro.isUsingNewDebugger,
       expoPreludeLineCount: this.metro.expoPreludeLineCount,
-      watchFolders: this.metro.watchFolders,
+      sourceMapPathOverrides: this.metro.sourceMapPathOverrides,
     });
 
     if (connected) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -135,11 +135,37 @@ export class DeviceSession implements Disposable {
 
   private launchAppCancelToken: CancelToken | undefined;
 
+  private async reconnectJSDebuggerIfNeeded() {
+    // after reloading JS, we sometimes need to reconnect the JS debugger. This is
+    // needed specifically in Expo Go based environments where the reloaded runtime
+    // will be listed as a new target.
+    // Additionally, in some cases the old websocket endpoint would still be listed
+    // despite the runtime being terminated.
+    // In order to properly handle this case we first check if the websocket endpoint
+    // is still listed and if it is, we verify that the runtime is responding by
+    // requesting to execute some simple JS snippet.
+    const currentWsTarget = this.debugSession?.websocketTarget;
+    if (currentWsTarget) {
+      const possibleWsTargets = await this.metro.fetchWsTargets();
+      const currentWsTargetStillVisible = possibleWsTargets?.some(
+        (runtime) => runtime.webSocketDebuggerUrl === currentWsTarget
+      );
+      if (currentWsTargetStillVisible) {
+        // verify the runtime is responding
+        const isRuntimeResponding = await this.debugSession.pingJsDebugSessionWithTimeout();
+        if (isRuntimeResponding) {
+          return;
+        }
+      }
+    }
+    return this.connectJSDebugger();
+  }
+
   private async reloadMetro() {
     this.eventDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
     await Promise.all([this.metro.reload(), this.devtools.appReady()]);
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
-    await this.debugSession?.reconnectJSDebuggerIfNeeded(this.metro);
+    return this.reconnectJSDebuggerIfNeeded();
   }
 
   private async launchApp(previewReadyCallback?: PreviewReadyCallback) {
@@ -290,7 +316,18 @@ export class DeviceSession implements Disposable {
   }
 
   private async connectJSDebugger() {
-    const connected = await this.debugSession.startJSDebugSession(this.metro);
+    const websocketAddress = await this.metro.getDebuggerURL();
+    if (!websocketAddress) {
+      Logger.error("Couldn't find a proper debugger URL to connect to");
+      return;
+    }
+    const connected = await this.debugSession.startJSDebugSession({
+      websocketAddress,
+      displayDebuggerOverlay: false,
+      isUsingNewDebugger: this.metro.isUsingNewDebugger,
+      expoPreludeLineCount: this.metro.expoPreludeLineCount,
+      watchFolders: this.metro.watchFolders,
+    });
 
     if (connected) {
       // TODO(jgonet): Right now, we ignore start failure

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -158,14 +158,14 @@ export class DeviceSession implements Disposable {
         }
       }
     }
-    return this.connectJSDebugger();
+    await this.connectJSDebugger();
   }
 
   private async reloadMetro() {
     this.eventDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
     await Promise.all([this.metro.reload(), this.devtools.appReady()]);
     this.eventDelegate.onStateChange(StartupMessage.AttachingDebugger);
-    return this.reconnectJSDebuggerIfNeeded();
+    await this.reconnectJSDebuggerIfNeeded();
   }
 
   private async launchApp(previewReadyCallback?: PreviewReadyCallback) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -370,7 +370,7 @@ export class DeviceSession implements Disposable {
       await this.device.sendDeepLink(link, this.maybeBuildResult, terminateApp);
 
       if (terminateApp) {
-        this.debugSession?.reconnectJSDebuggerIfNeeded(this.metro);
+        this.reconnectJSDebuggerIfNeeded();
       }
     }
   }

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -99,11 +99,18 @@ export class Metro implements Disposable {
     return this._port;
   }
 
-  public get watchFolders() {
+  public get sourceMapPathOverrides() {
     if (this._watchFolders === undefined) {
-      throw new Error("Attempting to read watchFolders before metro has started");
+      throw new Error("Attempting to read sourceMapPathOverrides before metro has started");
     }
-    return this._watchFolders;
+    const sourceMapPathOverrides: Record<string, string> = {};
+    if (this.isUsingNewDebugger && this._watchFolders.length > 0) {
+      sourceMapPathOverrides["/[metro-project]/*"] = `${this._watchFolders[0]}${path.sep}*`;
+      this._watchFolders.forEach((watchFolder, index) => {
+        sourceMapPathOverrides[`/[metro-watchFolders]/${index}/*`] = `${watchFolder}${path.sep}*`;
+      });
+    }
+    return sourceMapPathOverrides;
   }
 
   public get expoPreludeLineCount() {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -83,7 +83,7 @@ export class Metro implements Disposable {
   private _port = 0;
   private _watchFolders: string[] | undefined = undefined;
   private startPromise: Promise<void> | undefined;
-  private usesNewDebugger?: Boolean;
+  private usesNewDebugger?: boolean;
   private _expoPreludeLineCount = 0;
 
   constructor(private readonly devtools: Devtools, private readonly delegate: MetroDelegate) {}


### PR DESCRIPTION
This PR cleans up the code preparing for changes that'd allow Radon to use existing metro.

In this PR we are decoupling debug session to no longer take metro as argument. This is needed such that we have better control over debug session w/o need of maintaining up-to-date instances of metro class. Eventually, we may want to refactor metro class entirely such that it has a cleaner interface as now it mutates it states when it searches for debugger URL which can be a bit misleading. Regardless – this is out of the scope for this change as we only extract debug session such that it can work based on the session configuration as opposed to fetching details via metro instance.

What's changed:
1. We simplify and move reconnect logic to device session class. Instead of doing promise race we just list the endpoints first. It doesn't seem like the complexity of that code is justified given listing metro endpoints only takes a few milliseconds. The logic is now much simpler as we fetch the endpoints first, and only when our old endpoint is listed we perform ping to check if it is alive. If reconnection is needed we just start a new JS debugger session and debugSession handles that correctly.
2. We extract startDebugging helper method to separate file such that it can be used by ProxyDebugAdapter – this also simplifies the logic as the adapter class no longer needs to have try/finally block and get the session instance via the callback – this is something that the helper method we added recently takes care of.

The main goal of this change was to be able to delete metro import from debugSession file.

### How Has This Been Tested: 
1. Test new debugger connection work as expected including JS reloads (tested on RN78 example)
2. Test reloads on expo go app – make sure debugger stays connected after reloads.

