### PR TITLE
[Radon AI] Add support for monorepos with multiple `node_module` directories

### DIFF
--- a/packages/vscode-extension/src/chat/packages.ts
+++ b/packages/vscode-extension/src/chat/packages.ts
@@ -16,17 +16,17 @@ const packages: Package[] = [];
 let packageJsonHashes: string[] = [];
 
 async function getPackageJsonHashes(): Promise<string[]> {
-  const rootPackageJson = await vscode.workspace.findFiles(
+  const packageJsonFiles = await vscode.workspace.findFiles(
     new RelativePattern(appRootFolder, "package.json"),
     null
   );
 
-  if (!rootPackageJson.length) {
+  if (!packageJsonFiles.length) {
     Logger.error("No package.json found in the workspace");
     return [];
   }
 
-  const hashes = rootPackageJson.map((packageJson) =>
+  const hashes = packageJsonFiles.map((packageJson) =>
     calculateMD5(packageJson.fsPath).then((hash) => hash.digest("hex"))
   );
 


### PR DESCRIPTION
### This PR resolves a [discussion](https://github.com/software-mansion/radon-ide/pull/1000#discussion_r2014231136) in the main Radon AI PR

Changes in this PR includes all node_modules directories into both the search for node_modules, the hash calculation, and the context creation.

Example of the new prompt generated inside the `react-native-reanimated` monorepo:

<details>
<summary>
Collapsed output
</summary>

```
User has the following packages installed in the project:
- expo-application@5.1.1
- expo-keep-awake@12.0.1
- react-native-screens@4.5.0
- babel-preset-expo@9.3.2
- react-native-gesture-handler@2.22.0
- react-native-svg@15.11.1
- react-native-pager-view@6.6.1
- react-native-drawer-layout@4.1.1
- metro-react-native-babel-preset@0.73.9
- react-native-builder-bob@0.33.1
- expo-constants@14.3.0
- react-native-web@0.19.11
- expo-modules-core@1.2.7
- eslint-plugin-react-native@4.1.0
- eslint-plugin-react-native-globals@0.1.2
- expo-font@11.1.1
- react-native-worklets@0.0.1
- expo@48.0.21
- babel-plugin-react-native-web@0.18.12
- react-native-safe-area-context@5.1.0
- react-native-monorepo-tools@1.2.1
- react-native@0.77.0
- expo-asset@8.9.2
- react-native-reanimated@4.0.0-beta.2
- expo-modules-autolinking@1.2.0
- expo-file-system@15.3.0

"apps/macos-example":
- eslint-plugin-react-native@4.1.0
- eslint-plugin-react-native-globals@0.1.2
- react-native@0.75.4
- react-native-macos@0.75.16
- react-native-reanimated@4.0.0-beta.2

"apps/tvos-example":
- react-native-reanimated@4.0.0-beta.2
- react-native-tvos@0.77.0-0

"apps/web-example":
- babel-preset-expo@12.0.0
- react-native-web@0.19.13
- expo-font@13.0.1
- expo-modules-core@2.0.1
- expo-constants@17.0.2
- expo@52.0.4
- babel-plugin-react-native-web@0.19.13
- expo-asset@11.0.1
- expo-keep-awake@14.0.1
- expo-modules-autolinking@2.0.1
- expo-file-system@18.0.2

"packages/docs-reanimated":
- babel-preset-expo@9.2.2
- react-native-gesture-handler@2.18.0
- react-native-svg@15.4.0
- deprecated-react-native-prop-types@3.0.1
- babel-preset-react-native@4.0.1
- metro-react-native-babel-preset@0.73.8
- react-native-web@0.18.12
- metro-react-native-babel-transformer@0.73.8
- babel-plugin-react-native-web@0.18.12
- react-native-gradle-plugin@0.71.16
- react-native@0.71.4
- css-to-react-native@3.2.0
- react-native-reanimated@3.15.0-nightly-20240722-a15e0edec
- react-native-codegen@0.71.5

"packages/react-native-worklets":
- react-native@0.77.0

```

</details>