### PR TITLE
Fix android builds not finding metro server 

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -849,6 +849,10 @@ async function waitForEmulatorOnline(serial: string, timeoutMs: number) {
 
     await process;
 
+    // If booting device and building the application was fast enough, the emulators network internals
+    // would not be loaded before the start of the application. This in turn would cause PackagerStatusCheck
+    // (https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt)
+    // to fail and the application would think that there is no metro server.
     process = exec(ADB_PATH, [
       "-s",
       serial,


### PR DESCRIPTION
This PR solves the android application not finding metro when build cache was hit and the application is small enough. 

## What caused the problem? 
If we booting device and building the application was fast enough, the emulators network internals would not be loaded before the start of the application.  This in turn would cause [PackagerStatusCheck](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt) to fail and the application would think that there is no metro server. 

![image](https://github.com/user-attachments/assets/7ec3aeee-9200-46da-8a9b-c67b7154e565)

## Solution 
To solve this problem we do not allow the IDE process to think that the emulator is ready until network is operational. 

### How Has This Been Tested: 

- run `react-native-78` test app and switch android devices multiple times to try and caouse the error
- change the behavior of the final condition to expose whats going on like so: 
```
process = exec(ADB_PATH, [
      "-s",
      serial,
      "shell",
      `while ! ping -c 1 10.0.2.2; do sleep 0.5; done;`,
    ]);

    const { stdout, stderr } = await process;
    Logger.debug("wait  for metro", stdout, stderr)

```

- observe multiple failed connections before one successful one



