### PR TITLE
Adapt updated sourceMapOverrides format in old debug adapter

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -26,7 +26,7 @@ import { filePathForProfile } from "./cpuProfiler";
 export type CDPConfiguration = {
   websocketAddress: string;
   expoPreludeLineCount: number;
-  sourceMapAliases: [string, string][];
+  sourceMapPathOverrides: Record<string, string>;
   breakpointsAreRemovedOnContextCleared: boolean;
 };
 
@@ -55,7 +55,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
       cdpConfiguration.websocketAddress,
       {
         expoPreludeLineCount: cdpConfiguration.expoPreludeLineCount,
-        sourceMapAliases: cdpConfiguration.sourceMapAliases,
+        sourceMapPathOverrides: cdpConfiguration.sourceMapPathOverrides,
       },
       {
         breakpointsAreRemovedOnContextCleared:

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -59,12 +59,15 @@ export class CDPSession {
   constructor(
     private delegate: CDPSessionDelegate,
     websocketAddress: string,
-    sourceMapConfiguration: { expoPreludeLineCount: number; sourceMapAliases: [string, string][] },
+    sourceMapConfiguration: {
+      expoPreludeLineCount: number;
+      sourceMapPathOverrides: Record<string, string>;
+    },
     breakpointsConfiguration: { breakpointsAreRemovedOnContextCleared: boolean }
   ) {
     this.sourceMapRegistry = new SourceMapsRegistry(
       sourceMapConfiguration.expoPreludeLineCount,
-      sourceMapConfiguration.sourceMapAliases
+      Object.entries(sourceMapConfiguration.sourceMapPathOverrides)
     );
 
     this.breakpointsController = new BreakpointsController(

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -136,7 +136,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -136,7 +136,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,

--- a/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
+++ b/packages/vscode-extension/src/debugging/SourceMapsRegistry.ts
@@ -148,42 +148,41 @@ export class SourceMapsRegistry {
   }
 
   public toAbsoluteFilePathFromSourceMapAlias(sourceMapPath: string) {
-    if (this.sourceMapPathOverrides) {
-      for (const [overridePattern, absoluteFilePathPattern] of this.sourceMapPathOverrides) {
-        const absoluteFilePath = replacePathWithOverride(
-          sourceMapPath,
-          overridePattern,
-          absoluteFilePathPattern
-        );
-        if (absoluteFilePath) {
-          return absoluteFilePath;
-        }
+    for (const [aliasedPattern, absoluteFilePathPattern] of this.sourceMapPathOverrides) {
+      const absoluteFilePath = replacePrefixPattern(
+        sourceMapPath,
+        aliasedPattern,
+        absoluteFilePathPattern
+      );
+      if (absoluteFilePath) {
+        return absoluteFilePath;
       }
     }
     return sourceMapPath;
   }
 
   private toSourceMapAliasedFilePath(sourceAbsoluteFilePath: string) {
-    if (this.sourceMapPathOverrides) {
-      // we return the first alias from the list
-      for (const [overridePattern, absoluteFilePathPattern] of this.sourceMapPathOverrides) {
-        const aliasedPath = replacePathWithOverride(
-          sourceAbsoluteFilePath,
-          absoluteFilePathPattern,
-          overridePattern
-        );
-        if (aliasedPath) {
-          return aliasedPath;
-        }
+    // we return the first alias from the list
+    for (const [aliasedPattern, absoluteFilePathPattern] of this.sourceMapPathOverrides) {
+      const aliasedPath = replacePrefixPattern(
+        sourceAbsoluteFilePath,
+        absoluteFilePathPattern,
+        aliasedPattern
+      );
+      if (aliasedPath) {
+        return aliasedPath;
       }
     }
     return sourceAbsoluteFilePath;
   }
 }
 
-function replacePathWithOverride(filePath: string, fromPattern: string, toPattern: string) {
-  // This method isn't generic enough. It only supports * at the end of the pattern
-  // as that's the only case we use it for right now.
+/**
+ * This mathod handles the path override pattern replacement logic.
+ * It only supports prefix-only patterns which have * at the end as this is currently
+ * the only case we use it for right now.
+ */
+function replacePrefixPattern(filePath: string, fromPattern: string, toPattern: string) {
   const strippedFromPattern = fromPattern.replace("*", "");
   const strippedToPattern = toPattern.replace("*", "");
 


### PR DESCRIPTION
This PR updates the original debug adapter implementation to support the updated format of source map aliasing.

For the new react native debugger, we use the option `sourceMapOverrides` in order to translate from "/[metro-project]/" alias that the RN devtools introduced. With the old debug adapter, we've been expecting a different format for this, namely, a list of pairs with alias and absolute file location. Given we may want to use the old debug adapter to support the new debugger while keeping an option to rely on vscode-js-debug, we want to unify these formats, such that we don't need to format the parameters differently depending on the debug adapter we use.

This PR adapts ths old debugger implementation to accept the updated format. Now the overrides are provided as `Record<string,string>` and the override patterns may include wildcards. The basic implementation only works with wildcards at the very end of the path, but given we currently generate the patterns on our own and they meet these criteria this seems like a good tradeoff given the complexity of different pattern schemas we'd have to support for full compatibility.

### How Has This Been Tested: 
1. Open app with new debugger (RN 78 for example)
2. In DebugSession change the line: `const debuggerType = OLD_JS_DEBUGGER_TYPE;` to force the old proxy adapter to be used
3. Test breakpoints, logs etc

