### PR TITLE
Handle call frames when logs don't use radon's runtime

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -28,6 +28,7 @@ export type CDPConfiguration = {
   expoPreludeLineCount: number;
   sourceMapAliases: [string, string][];
   breakpointsAreRemovedOnContextCleared: boolean;
+  skipFiles: string[];
 };
 
 const ERROR_RESPONSE_FAIL_TO_RETRIEVE_VARIABLE_ID = 4000;
@@ -50,18 +51,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
   }
 
   private startCDPSession(cdpConfiguration: CDPConfiguration) {
-    this.cdpSession = new CDPSession(
-      this,
-      cdpConfiguration.websocketAddress,
-      {
-        expoPreludeLineCount: cdpConfiguration.expoPreludeLineCount,
-        sourceMapAliases: cdpConfiguration.sourceMapAliases,
-      },
-      {
-        breakpointsAreRemovedOnContextCleared:
-          cdpConfiguration.breakpointsAreRemovedOnContextCleared,
-      }
-    );
+    this.cdpSession = new CDPSession(this, cdpConfiguration);
   }
   //#region CDPDelegate
 

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -13,9 +13,10 @@ import { Logger } from "../Logger";
 import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { BreakpointsController } from "./BreakpointsController";
 import { VariableStore } from "./variableStore";
-import { CDPDebuggerScope, CDPRemoteObject } from "./cdp";
+import { CDPCallFrame, CDPDebuggerScope, CDPRemoteObject } from "./cdp";
 import { typeToCategory } from "./DebugAdapter";
 import { annotateLocations } from "./cpuProfiler";
+import { EventEmitter } from "vscode";
 
 type ResolveType<T = unknown> = (result: T) => void;
 type RejectType = (error: unknown) => void;
@@ -55,6 +56,9 @@ export class CDPSession {
   private sourceMapRegistry: SourceMapsRegistry;
 
   private breakpointsController: BreakpointsController;
+
+  private debugSessionReady = false;
+  private debugSessionReadyEmitter = new EventEmitter<void>();
 
   constructor(
     private delegate: CDPSessionDelegate,
@@ -136,6 +140,8 @@ export class CDPSession {
         );
 
         if (isMainBundle) {
+          this.debugSessionReady = true;
+          this.debugSessionReadyEmitter.fire();
           this.delegate.onDebugSessionReady();
         }
 
@@ -158,7 +164,13 @@ export class CDPSession {
         this.delegate.onExecutionContextsCleared();
         break;
       case "Runtime.consoleAPICalled":
-        this.handleConsoleAPICall(message);
+        if (this.debugSessionReady) {
+          this.handleConsoleAPICall(message);
+        } else {
+          this.debugSessionReadyEmitter.event(() => {
+            this.handleConsoleAPICall(message);
+          });
+        }
         break;
       default:
         break;
@@ -198,27 +210,55 @@ export class CDPSession {
 
       output = new OutputEvent(formattedOutput.output, typeToCategory(message.params.type));
 
-      output.body = {
+      Object.assign(output.body, {
         ...formattedOutput,
         //@ts-ignore source, line, column and group are valid fields
         source: new Source(sourceURL, sourceURL),
         line: this.linesStartAt1 ? lineNumber1Based : lineNumber1Based - 1,
         column: this.columnsStartAt1 ? columnNumber0Based + 1 : columnNumber0Based,
-      };
+      });
     } else {
-      const variablesRefDapID = await this.createVariableForOutputEvent(message.params.args);
-
       const formattedOutput = await this.formatDefaultString(message.params.args);
 
       output = new OutputEvent(formattedOutput.output, typeToCategory(message.params.type));
-
-      output.body = {
+      Object.assign(output.body, {
         ...formattedOutput,
-        //@ts-ignore source, line, column and group are valid fields
-        variablesReference: variablesRefDapID,
-      };
+      });
+
+      if (message.params.stackTrace) {
+        const stackTrace = message.params.stackTrace;
+        const { sourceURL, lineNumber1Based, columnNumber0Based } =
+          this.findFirstCallFramePositionFromApp(stackTrace.callFrames);
+        Object.assign(output.body, {
+          //@ts-ignore source, line, column and group are valid fields
+          source: new Source(sourceURL, sourceURL),
+          line: this.linesStartAt1 ? lineNumber1Based : lineNumber1Based - 1,
+          column: this.columnsStartAt1 ? columnNumber0Based + 1 : columnNumber0Based,
+        });
+      }
     }
     this.delegate.sendOutputEvent(output);
+  }
+
+  private findFirstCallFramePositionFromApp(callFrames: CDPCallFrame[]) {
+    let firstPosition;
+    for (const frame of callFrames) {
+      const originalPosition = this.sourceMapRegistry!.findOriginalPosition(
+        frame.scriptId,
+        frame.lineNumber + 1, // cdp line and column numbers are 0-based
+        frame.columnNumber
+      );
+      if (
+        originalPosition.sourceURL !== "__source__" &&
+        !originalPosition.sourceURL.includes("node_modules")
+      ) {
+        return originalPosition;
+      } else if (!firstPosition) {
+        firstPosition = originalPosition;
+      }
+    }
+    // return the first position if none of the frames are from the app
+    return firstPosition!;
   }
 
   private async handleDebuggerPaused(message: any) {
@@ -386,7 +426,7 @@ export class CDPSession {
     const output = formatResult.result + "\n";
 
     if (formatResult.usedAllSubs && !args.some(previewAsObject)) {
-      return { output };
+      return { output, variablesReference: undefined };
     } else {
       const outputVar = await this.createVariableForOutputEvent(args as CDPRemoteObject[]);
 

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -1,6 +1,7 @@
 import WebSocket from "ws";
 import { OutputEvent, Source, StackFrame } from "@vscode/debugadapter";
 import { DebugProtocol } from "@vscode/debugprotocol";
+import { Minimatch } from "minimatch";
 import { Cdp } from "vscode-js-debug/out/cdp/index";
 import { AnyObject } from "vscode-js-debug/out/adapter/objectPreview/betterTypes";
 import { formatMessage } from "vscode-js-debug/out/adapter/messageFormat";
@@ -17,7 +18,6 @@ import { CDPCallFrame, CDPDebuggerScope, CDPRemoteObject } from "./cdp";
 import { typeToCategory } from "./DebugAdapter";
 import { annotateLocations } from "./cpuProfiler";
 import { CDPConfiguration } from "./CDPDebugAdapter";
-import { Minimatch } from "minimatch";
 
 type ResolveType<T = unknown> = (result: T) => void;
 type RejectType = (error: unknown) => void;

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -136,7 +136,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,
@@ -149,6 +149,15 @@ export class DebugSession implements Disposable {
         websocketAddress: configuration.websocketAddress,
         expoPreludeLineCount: configuration.expoPreludeLineCount,
         displayDebuggerOverlay: configuration.displayDebuggerOverlay,
+        skipFiles: [
+          "__source__",
+          "**/extension/lib/**/*.js",
+          "**/vscode-extension/lib/**/*.js",
+          "**/ReactFabric-dev.js",
+          "**/ReactNativeRenderer-dev.js",
+          "**/node_modules/**/*",
+          "!**/node_modules/expo-router/**/*",
+        ],
       },
       {
         parentSession: this.parentDebugSession,

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -136,7 +136,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -160,14 +160,7 @@ export class ProxyDebugAdapter extends DebugSession {
           continueOnAttach: true,
           sourceMapPathOverrides: args.sourceMapPathOverrides,
           resolveSourceMapLocations: ["**", "!**/node_modules/!(expo)/**"],
-          skipFiles: [
-            "**/extension/lib/**/*.js",
-            "**/vscode-extension/lib/**/*.js",
-            "**/ReactFabric-dev.js",
-            "**/ReactNativeRenderer-dev.js",
-            "**/node_modules/**/*",
-            "!**/node_modules/expo-router/**/*",
-          ],
+          skipFiles: this.session.configuration.skipFiles,
         },
         {
           suppressDebugStatusbar: true,


### PR DESCRIPTION
When connecting to the new RN debugger without Radon's runtime, the logs wouldn't appear in the debug console.

The reason was that we improperly transform the output event because we had a special path for creating events that only works when extra parameters are provided via our `wrapConsole` override from `runtime.js`.

However, when we connect to existing metro instance, the override doesn't work, yet we still need to handle the console events. There were a few problems with that:
1) In #846 we changed the way we handle variable references. This was updated in the main path that relied on the call frame being provided from the runtime but not in the `else` branch.
2) When source frame isn't provided via runtime, we never attempt to read the call frame from CDP call which now is properly populated in the new RN debugger.
3) Finally, when connecting to the new debugger, upon connection is sends a number of console API calls from before the debugger was connected. Apparently, before we have the source maps processed we are unable to properly decipher the stack frame.

We do the following to address these problems:
1) We update the `else` branch in CDPDebugSession where no stack information is provided in the console api call. We basically just need to delete the manual handling of the variable reference as it was done for the main branch in #846 
2) We adapt `skipFiles` option and when processing `message.params.callFrame` from CDP message we filter the first frame that doesn't match the skipFiles list.
3) To addess the last issue, we delay handling of console API calls until we get "debug ready" event.

### How Has This Been Tested: 
1. This can only be change with the new Radon connection functionality that will publish a diff off as a follow up
2. The test relies on connecting to existing metro instance and seeing the logs with proper stack frame links


