### PR TITLE
Add iPhone 16 Pro to device list

### DIFF
--- a/packages/vscode-extension/src/webview/utilities/consts.ts
+++ b/packages/vscode-extension/src/webview/utilities/consts.ts
@@ -56,31 +56,42 @@ export type DeviceProperties = {
 // in config.ini for Android and 'deviceType' in device.plist for iOS.
 
 // iOS devices names should match supportedDeviceTypes inside the runtime
+
+// Shared properties for iPhone 15 Pro and iPhone 16 Pro
+const iphone15And16ProShared = {
+  platform: DevicePlatform.IOS,
+  screenWidth: 1178,
+  screenHeight: 2556,
+  maskImage: iphone15promask,
+  screenImage: iphone15proscreen,
+  bezel: {
+    type: "mask" as const,
+    width: 1186,
+    height: 2564,
+    offsetX: 4,
+    offsetY: 4,
+    image: iphone15probezel,
+  },
+  skin: {
+    type: "skin" as const,
+    width: 1285,
+    height: 2663,
+    offsetX: 55,
+    offsetY: 55,
+    image: iphone15pro,
+  },
+};
+
 export const iOSSupportedDevices: DeviceProperties[] = [
+  {
+    modelName: "iPhone 16 Pro",
+    modelId: "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
+    ...iphone15And16ProShared,
+  },
   {
     modelName: "iPhone 15 Pro",
     modelId: "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro",
-    platform: DevicePlatform.IOS,
-    screenWidth: 1178,
-    screenHeight: 2556,
-    maskImage: iphone15promask,
-    screenImage: iphone15proscreen,
-    bezel: {
-      type: "mask",
-      width: 1186,
-      height: 2564,
-      offsetX: 4,
-      offsetY: 4,
-      image: iphone15probezel,
-    },
-    skin: {
-      type: "skin",
-      width: 1285,
-      height: 2663,
-      offsetX: 55,
-      offsetY: 55,
-      image: iphone15pro,
-    },
+    ...iphone15And16ProShared,
   },
   {
     modelName: "iPhone SE (3rd generation)",


### PR DESCRIPTION
This PR adds iPhone 16 Pro to device list. We simply copy the configuration from iPhone 15 as all the dimensions and bazels are the same.

### How Has This Been Tested: 
1. Open device creation flow, select iPhone 16
2. Run the newly created device on one project, test text/dark mode settings work ok.


