### PR TITLE
Fix startup cycle

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -29,6 +29,7 @@ export type ToolsState = {
 export type ProjectState =
   | ({
       status:
+        | "starting"
         | "running"
         | "bootError"
         | "bundleBuildFailedError"
@@ -36,7 +37,6 @@ export type ProjectState =
         | "debuggerPaused"
         | "refreshing";
     } & ProjectStateCommon)
-  | ProjectStateStarting
   | ProjectStateBuildError;
 
 type ProjectStateCommon = {
@@ -44,13 +44,9 @@ type ProjectStateCommon = {
   selectedDevice: DeviceInfo | undefined;
   initialized: boolean;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
+  startupMessage: StartupMessage | undefined;
+  stageProgress: number | undefined;
 };
-
-type ProjectStateStarting = {
-  status: "starting";
-  startupMessage: StartupMessage;
-  stageProgress: number;
-} & ProjectStateCommon;
 
 type ProjectStateBuildError = {
   status: "buildError";

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -842,7 +842,7 @@ export class Project
   }
 
   private reportStageProgress(stageProgress: number, stage: string) {
-    if (this.projectState.status !== "starting" || stage !== this.projectState.startupMessage) {
+    if (stage !== this.projectState.startupMessage) {
       return;
     }
     this.updateProjectState({ stageProgress });

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -83,55 +83,53 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
   const isBuilding = startupMessage === StartupMessage.Building;
 
   return (
-    projectState.status === "starting" && (
-      <>
-        <div className="preview-loader-center-pad" />
-        <button className="preview-loader-container" onClick={handleLoaderClick}>
-          <div className="preview-loader-button-group">
-            <StartupMessageComponent
-              className={classNames(
-                "preview-loader-message",
-                isLoadingSlowly && "preview-loader-slow-progress"
-              )}>
-              {projectState.startupMessage}
-              {isLoadingSlowly && isBuilding ? " (open logs)" : ""}
-            </StartupMessageComponent>
-            {projectState.stageProgress !== undefined && (
-              <div className="preview-loader-stage-progress">
-                {(projectState.stageProgress * 100).toFixed(1)}%
-              </div>
-            )}
-          </div>
-        </button>
-        <ProgressBar progress={progress} />
-        <div className="preview-loader-center-pad">
-          {isLoadingSlowly && isWaitingForApp && (
-            <>
-              <div className="preview-loader-submessage">
-                Loading app takes longer than expected. If nothing happens after a while try the
-                below options to troubleshoot:
-              </div>
-              <div className="preview-loader-waiting-actions">
-                <Button type="secondary" onClick={() => project.focusExtensionLogsOutput()}>
-                  <span className="codicon codicon-output" /> Open Radon IDE Logs
-                </Button>
-                <Button type="secondary" onClick={onRequestShowPreview}>
-                  <span className="codicon codicon-open-preview" /> Force show device screen
-                </Button>
-                <a href="https://ide.swmansion.com/docs/guides/troubleshooting" target="_blank">
-                  <Button type="secondary">
-                    <span className="codicon codicon-browser" /> Visit troubleshoot guide
-                  </Button>
-                </a>
-                <Button type="secondary" onClick={() => project.restart("all")}>
-                  <span className="codicon codicon-refresh" /> Clean rebuild project
-                </Button>
-              </div>
-            </>
+    <>
+      <div className="preview-loader-center-pad" />
+      <button className="preview-loader-container" onClick={handleLoaderClick}>
+        <div className="preview-loader-button-group">
+          <StartupMessageComponent
+            className={classNames(
+              "preview-loader-message",
+              isLoadingSlowly && "preview-loader-slow-progress"
+            )}>
+            {projectState.startupMessage}
+            {isLoadingSlowly && isBuilding ? " (open logs)" : ""}
+          </StartupMessageComponent>
+          {projectState.stageProgress !== undefined && (
+            <div className="preview-loader-stage-progress">
+              {(projectState.stageProgress * 100).toFixed(1)}%
+            </div>
           )}
         </div>
-      </>
-    )
+      </button>
+      <ProgressBar progress={progress} />
+      <div className="preview-loader-center-pad">
+        {isLoadingSlowly && isWaitingForApp && (
+          <>
+            <div className="preview-loader-submessage">
+              Loading app takes longer than expected. If nothing happens after a while try the below
+              options to troubleshoot:
+            </div>
+            <div className="preview-loader-waiting-actions">
+              <Button type="secondary" onClick={() => project.focusExtensionLogsOutput()}>
+                <span className="codicon codicon-output" /> Open Radon IDE Logs
+              </Button>
+              <Button type="secondary" onClick={onRequestShowPreview}>
+                <span className="codicon codicon-open-preview" /> Force show device screen
+              </Button>
+              <a href="https://ide.swmansion.com/docs/guides/troubleshooting" target="_blank">
+                <Button type="secondary">
+                  <span className="codicon codicon-browser" /> Visit troubleshoot guide
+                </Button>
+              </a>
+              <Button type="secondary" onClick={() => project.restart("all")}>
+                <span className="codicon codicon-refresh" /> Clean rebuild project
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
   );
 }
 

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -21,13 +21,9 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
   const [isLoadingSlowly, setIsLoadingSlowly] = useState(false);
 
-  const startupMessage =
-    projectState.status === "starting" ? projectState.startupMessage : undefined;
+  const startupMessage = projectState.startupMessage;
 
   useEffect(() => {
-    if (projectState.status !== "starting") {
-      return;
-    }
     if (projectState.startupMessage === StartupMessage.Restarting) {
       setProgress(0);
     } else {


### PR DESCRIPTION
This PR removes redundant conditional render introduced in #1068, as `previewLoader` is already rendered conditionally in the fallowing code:  
```js
  {!showDevicePreview && !hasBuildError && !hasBootError && (
          <Device device={device!} resizableProps={resizableProps}>
            <div className="phone-sized phone-content-loading-background" />
            <div className="phone-sized phone-content-loading ">
              <PreviewLoader onRequestShowPreview={() => setShowPreviewRequested(true)} />
            </div>
          </Device>
        )}`
```
 
the additional check introduced in #1068 causes problems as our startup cycle still has some unhandled errors that do not cause the whole process to crash but do remove "starting" status from `projectState`. We plan to catch all of those edge cases as soon as possible but to unblock user experience for now we need to remove additional condition


### Before - After

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/08de3602-c533-4e7e-8ba3-c63a58d4edfd" /> | <video src=https://github.com/user-attachments/assets/80f8b5c3-6b94-4269-aea2-243eb9f43447 />|


### How Has This Been Tested: 

- run `react-native-78` test app and smash reinstall button until process fails for a second before recovering 



