### PR TITLE
Force use of Radon's original debug adapter implementation

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -9,6 +9,11 @@ const PING_TIMEOUT = 1000;
 
 const MASTER_DEBUGGER_TYPE = "com.swmansion.react-native-debugger";
 const OLD_JS_DEBUGGER_TYPE = "com.swmansion.js-debugger";
+
+// vscode-js-debug based debugger implementation is disabled for now because
+// of a very slow initialization times. We force the use of the original
+// debug adapter implementation here.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PROXY_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
 
 export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
@@ -136,7 +141,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,


### PR DESCRIPTION
In #1001 we introduced a separate implementaton of DebugAdapter that was based on vscode-js-debug project.

While it is better in many aspects from our previous implementation, we discovered that it perform much worse on bigger projects. Specifically the initialization times were very slow as well as JS reloads. For example https://github.com/bluesky-social/social-app project would take as long as 30 seconds on my M3 mac to initialize while both the app and the editor were hanging and waiting for the initialization to complete.

The initialization issue is likely tied to processing source maps as deleting source map information mitigates this problem (although it breaks all other functions like breakpoints, logs, etc). While it requires some additional investigation this PR disables the new vscode-js-debug based implementation and forces the original one for the time being.

Fixes # (issue)

### How Has This Been Tested: 
1. Run project with new debugger (i.e. react-native-78)
2. Test breakpoints, breakpoints after fast refresh, console logging big objects, uncaught exceptions



