### PR TITLE
Add options to trigger home button and appswitcher buttons

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -81,6 +81,18 @@
         "enablement": "RNIDE.extensionIsActive"
       },
       {
+        "command": "RNIDE.deviceHomeButtonPress",
+        "title": "Trigger home button press on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
+        "command": "RNIDE.deviceAppSwitchButtonPress",
+        "title": "Open app switcher on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
         "command": "RNIDE.captureReplay",
         "title": "Capture Replay",
         "category": "Radon IDE",
@@ -120,6 +132,11 @@
         "command": "RNIDE.performFailedBiometricAuthorization",
         "key": "ctrl+shift+N",
         "mac": "cmd+shift+N"
+      },
+      {
+        "command": "RNIDE.deviceHomeButtonPress",
+        "key": "ctrl+shift+H",
+        "mac": "cmd+shift+H"
       },
       {
         "command": "RNIDE.captureReplay",

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -73,6 +73,8 @@ export type ZoomLevelType = number | "Fit";
 
 export type AppPermissionType = "all" | "location" | "photos" | "contacts" | "calendar";
 
+export type DeviceButtonType = "home" | "back" | "appSwitch" | "volumeUp" | "volumeDown";
+
 // important: order of values in this enum matters
 export enum StartupMessage {
   InitializingDevice = "Initializing device",
@@ -179,7 +181,7 @@ export interface ProjectInterface {
 
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
-  sendBiometricAuthorization(match: boolean): Promise<void>;
+  runCommand(command: string): Promise<void>;
 
   getToolsState(): Promise<ToolsState>;
   updateToolEnabledState(toolName: keyof ToolsState, enabled: boolean): Promise<void>;

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { Disposable } from "vscode";
 import { Preview } from "./preview";
 import { BuildResult } from "../builders/BuildManager";
-import { AppPermissionType, DeviceSettings, TouchPoint } from "../common/Project";
+import { AppPermissionType, DeviceSettings, TouchPoint, DeviceButtonType } from "../common/Project";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
 
@@ -136,6 +136,10 @@ export abstract class DeviceBase implements Disposable {
     } else {
       this.preview?.sendKey(keyCode, direction);
     }
+  }
+
+  public sendButton(button: DeviceButtonType, direction: "Up" | "Down") {
+    this.preview?.sendButton(button, direction);
   }
 
   public async sendClipboard(text: string) {

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { Disposable, workspace } from "vscode";
 import { exec, ChildProcess, lineReader } from "../utilities/subprocess";
 import { Logger } from "../Logger";
-import { MultimediaData, TouchPoint } from "../common/Project";
+import { MultimediaData, TouchPoint, DeviceButtonType } from "../common/Project";
 import { simulatorServerBinary } from "../utilities/simulatorServerBinary";
 import { watchLicenseTokenChange } from "../utilities/license";
 
@@ -189,6 +189,10 @@ export class Preview implements Disposable {
 
   public sendKey(keyCode: number, direction: "Up" | "Down") {
     this.subprocess?.stdin?.write(`key ${direction} ${keyCode}\n`);
+  }
+
+  public sendButton(button: DeviceButtonType, direction: "Up" | "Down") {
+    this.subprocess?.stdin?.write(`button ${direction} ${button}\n`);
   }
 
   public sendClipboard(text: string) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -151,6 +151,12 @@ export async function activate(context: ExtensionContext) {
       performFailedBiometricAuthorization
     )
   );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceHomeButtonPress", deviceHomeButtonPress)
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceAppSwitchButtonPress", deviceAppSwitchButtonPress)
+  );
   context.subscriptions.push(commands.registerCommand("RNIDE.openDevMenu", openDevMenu));
   context.subscriptions.push(commands.registerCommand("RNIDE.closePanel", closeIDEPanel));
   context.subscriptions.push(commands.registerCommand("RNIDE.openPanel", showIDEPanel));
@@ -317,6 +323,18 @@ async function performBiometricAuthorization() {
 
 async function performFailedBiometricAuthorization() {
   IDE.getInstanceIfExists()?.project.sendBiometricAuthorization(false);
+}
+
+async function deviceHomeButtonPress() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("home", "Down");
+  project?.dispatchButton("home", "Up");
+}
+
+async function deviceAppSwitchButtonPress() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("appSwitch", "Down");
+  project?.dispatchButton("appSwitch", "Up");
 }
 
 async function captureReplay() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -10,6 +10,7 @@ import {
   ReloadAction,
   StartupMessage,
   TouchPoint,
+  DeviceButtonType,
 } from "../common/Project";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
@@ -413,6 +414,10 @@ export class DeviceSession implements Disposable {
 
   public sendKey(keyCode: number, direction: "Up" | "Down") {
     this.device.sendKey(keyCode, direction);
+  }
+
+  public sendButton(button: DeviceButtonType, direction: "Up" | "Down") {
+    this.device.sendButton(button, direction);
   }
 
   public sendClipboard(text: string) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -19,6 +19,7 @@ import { isEqual } from "lodash";
 import {
   AppPermissionType,
   BuildType,
+  DeviceButtonType,
   DeviceSettings,
   InspectData,
   ProjectEventListener,
@@ -690,6 +691,10 @@ export class Project
     this.deviceSession?.sendKey(keyCode, direction);
   }
 
+  public dispatchButton(button: DeviceButtonType, direction: "Up" | "Down") {
+    this.deviceSession?.sendButton(button, direction);
+  }
+
   public dispatchWheel(point: TouchPoint, deltaX: number, deltaY: number) {
     this.deviceSession?.sendWheel(point, deltaX, deltaY);
   }
@@ -835,6 +840,10 @@ export class Project
     if (this.projectState.selectedDevice?.id === deviceInfo.id) {
       this.updateProjectState({ selectedDevice: deviceInfo });
     }
+  }
+
+  public async runCommand(command: string): Promise<void> {
+    await commands.executeCommand(command);
   }
 
   public async sendBiometricAuthorization(isMatch: boolean) {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -13,7 +13,7 @@ import "./shared/SwitchGroup.css";
 import Label from "./shared/Label";
 import { useProject } from "../providers/ProjectProvider";
 import { useWorkspaceConfig } from "../providers/WorkspaceConfigProvider";
-import { AppPermissionType, DeviceSettings } from "../../common/Project";
+import { AppPermissionType, DeviceSettings, ProjectInterface } from "../../common/Project";
 import { DeviceLocationView } from "../views/DeviceLocationView";
 import { useModal } from "../providers/ModalProvider";
 import { DevicePlatform } from "../../common/DeviceManager";
@@ -126,6 +126,18 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             </div>
             <div className="device-settings-margin" />
           </form>
+          <CommandItem
+            project={project}
+            commandName="RNIDE.deviceHomeButtonPress"
+            label="Press Home Button"
+            icon="home"
+          />
+          <CommandItem
+            project={project}
+            commandName="RNIDE.deviceAppSwitchButtonPress"
+            label="Open App Switcher"
+            icon="chrome-restore"
+          />
           {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
           <DropdownMenu.Item
             className="dropdown-menu-item"
@@ -228,6 +240,32 @@ const LocalizationItem = () => {
   );
 };
 
+function CommandItem({
+  project,
+  commandName,
+  label,
+  icon,
+}: {
+  project: ProjectInterface;
+  commandName: string;
+  label: string;
+  icon: string;
+}) {
+  return (
+    <DropdownMenu.Item
+      className="dropdown-menu-item"
+      onSelect={() => {
+        project.runCommand(commandName);
+      }}>
+      <span className="dropdown-menu-item-wraper">
+        <span className={`codicon codicon-${icon}`} />
+        {label}
+        <KeybindingInfo commandName={commandName} />
+      </span>
+    </DropdownMenu.Item>
+  );
+}
+
 const BiometricsItem = () => {
   const { project, deviceSettings } = useProject();
 
@@ -255,32 +293,18 @@ const BiometricsItem = () => {
               <span className="codicon codicon-check right-slot" />
             )}
           </DropdownMenu.Item>
-          <DropdownMenu.Item
-            className="dropdown-menu-item"
-            onSelect={() => {
-              project.sendBiometricAuthorization(true);
-            }}>
-            <span className="dropdown-menu-item-wraper">
-              <span className="codicon codicon-layout-sidebar-left" />
-              <div className="dropdown-menu-item-content">
-                Matching ID
-                <KeybindingInfo commandName="RNIDE.performBiometricAuthorization" />
-              </div>
-            </span>
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            className="dropdown-menu-item"
-            onSelect={() => {
-              project.sendBiometricAuthorization(false);
-            }}>
-            <span className="dropdown-menu-item-wraper">
-              <span className="codicon codicon-layout-sidebar-left" />
-              <div className="dropdown-menu-item-content">
-                Non-Matching ID
-                <KeybindingInfo commandName="RNIDE.performFailedBiometricAuthorization" />
-              </div>
-            </span>
-          </DropdownMenu.Item>
+          <CommandItem
+            project={project}
+            commandName="RNIDE.performBiometricAuthorization"
+            label="Matching ID"
+            icon="layout-sidebar-left"
+          />
+          <CommandItem
+            project={project}
+            commandName="RNIDE.performFailedBiometricAuthorization"
+            label="Non-Matching ID"
+            icon="layout-sidebar-left"
+          />
         </DropdownMenu.SubContent>
       </DropdownMenu.Portal>
     </DropdownMenu.Sub>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -259,8 +259,10 @@ function CommandItem({
       }}>
       <span className="dropdown-menu-item-wraper">
         <span className={`codicon codicon-${icon}`} />
-        {label}
-        <KeybindingInfo commandName={commandName} />
+        <div className="dropdown-menu-item-content">
+          {label}
+          <KeybindingInfo commandName={commandName} />
+        </div>
       </span>
     </DropdownMenu.Item>
   );


### PR DESCRIPTION
This PR adds options in device settings menu that can trigger home and appSwitch button presses on active device.

We utilize the recently updated sim-server for this purpose that now supports new `button` command.

While it may not be the optimal place to add such buttons, they aren't used as frequenly, so we can alter this location once we get more feedback from the users. On top of that we're setting a shortcut that is compatible with iOS simulator for the home button press: Cmd+Shift+H

This change refactors the Project interface and removes method for biometric auth in favor of more generic method that allows us to run a command. This way we can hook into the commands API easily w/o expanding this interface further.

Here's how the new options look like in the device settings menu:
<img width="318" alt="image" src="https://github.com/user-attachments/assets/3d410565-cb30-45b5-91cd-f46edd071c4e" />

### How Has This Been Tested: 
1. Run Android, test home and app switch
2. Do the same on iOS


