### PR TITLE
Rework how bundle errors are triggered 

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -32,7 +32,6 @@ export type ProjectState =
         | "starting"
         | "running"
         | "bootError"
-        | "bundleBuildFailedError"
         | "bundlingError"
         | "debuggerPaused"
         | "refreshing";

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -20,7 +20,6 @@ const FAKE_EDITOR = "RADON_IDE_FAKE_EDITOR";
 const OPENING_IN_FAKE_EDITOR_REGEX = new RegExp(`Opening (.+) in ${FAKE_EDITOR}`);
 
 export interface MetroDelegate {
-  onBundleBuildFailedError(): void;
   onBundlingError(message: string, source: DebugSource, errorModulePath: string): void;
 }
 
@@ -496,9 +495,6 @@ export class MetroLauncher extends Metro implements Disposable {
             case "RNIDE_watch_folders":
               this._watchFolders = event.watchFolders;
               Logger.info("Captured metro watch folders", this._watchFolders);
-              break;
-            case "bundle_build_failed":
-              this.delegate.onBundleBuildFailedError();
               break;
             case "bundling_error":
               const message = stripAnsi(event.message);

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -55,7 +55,6 @@ import { UtilsInterface } from "../common/utils";
 import { ApplicationContext } from "./ApplicationContext";
 import { disposeAll } from "../utilities/disposables";
 import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRootFolder";
-import { isAutoSaveEnabled } from "../utilities/isAutoSaveEnabled";
 import { focusSource } from "../utilities/focusSource";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { BuildError } from "../builders/BuildManager";

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -403,10 +403,6 @@ export class Project
     await this.utils.showToast("Copied from device clipboard", 2000);
   }
 
-  onBundleBuildFailedError(): void {
-    this.updateProjectState({ status: "bundleBuildFailedError" });
-  }
-
   async onBundlingError(
     message: string,
     source: DebugSource,
@@ -414,17 +410,13 @@ export class Project
   ): Promise<void> {
     await this.deviceSession?.appendDebugConsoleEntry(message, "error", source);
 
-    if (!isAutoSaveEnabled()) {
+    if (this.projectState.status === "starting") {
       this.focusDebugConsole();
       focusSource(source);
     }
 
     Logger.error("[Bundling Error]", message);
-    // if bundle build failed, we don't want to change the status
-    // bundlingError status should be set only when bundleBuildFailedError status is not set
-    if (this.projectState.status === "bundleBuildFailedError") {
-      return;
-    }
+
     this.updateProjectState({ status: "bundlingError" });
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -411,7 +411,6 @@ export class Project
     await this.deviceSession?.appendDebugConsoleEntry(message, "error", source);
 
     if (this.projectState.status === "starting") {
-      this.focusDebugConsole();
       focusSource(source);
     }
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -203,11 +203,7 @@ function Preview({
   }
 
   const shouldPreventInputEvents =
-    debugPaused ||
-    hasBundlingError ||
-    projectStatus === "refreshing" ||
-    !showDevicePreview ||
-    !!replayData;
+    debugPaused || projectStatus === "refreshing" || !showDevicePreview || !!replayData;
 
   const shouldPreventFromSendingTouch = isInspecting || !!inspectFrame;
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -92,23 +92,19 @@ function Preview({
   const hasBuildError = projectStatus === "buildError";
   const hasBootError = projectStatus === "bootError";
   const hasBundlingError = projectStatus === "bundlingError";
-  const hasBundleBuildFailedError = projectStatus === "bundleBuildFailedError";
 
   const debugPaused = projectStatus === "debuggerPaused";
 
   const previewURL = projectState.previewURL;
 
-  const isStarting =
-    hasBundleBuildFailedError || hasBundlingError
-      ? false
-      : !projectState || projectState.status === "starting";
+  const isStarting = hasBundlingError ? false : !projectState || projectState.status === "starting";
   const showDevicePreview =
     projectState?.previewURL &&
     (showPreviewRequested || (!isStarting && !hasBuildError && !hasBootError));
 
   useBuildErrorAlert(hasBuildError);
   useBootErrorAlert(hasBootError);
-  useBundleErrorAlert(hasBundleBuildFailedError || hasBundlingError);
+  useBundleErrorAlert(hasBundlingError);
 
   const openRebuildAlert = useNativeRebuildAlert();
 
@@ -208,7 +204,6 @@ function Preview({
 
   const shouldPreventInputEvents =
     debugPaused ||
-    hasBundleBuildFailedError ||
     hasBundlingError ||
     projectStatus === "refreshing" ||
     !showDevicePreview ||
@@ -553,27 +548,6 @@ function Preview({
               {debugPaused && (
                 <div className="phone-screen phone-debug-overlay">
                   <Debugger />
-                </div>
-              )}
-              {/* TODO: Add different label in case of bundle/incremental bundle error */}
-              {hasBundleBuildFailedError && (
-                <div className="phone-screen phone-debug-overlay phone-error-overlay">
-                  <button
-                    className="uncaught-button"
-                    onClick={() => {
-                      project.restart(false);
-                    }}>
-                    Bundle error&nbsp;
-                    <span className="codicon codicon-refresh" />
-                  </button>
-                </div>
-              )}
-              {hasBundlingError && (
-                <div className="phone-screen phone-debug-overlay phone-error-overlay">
-                  <button className="uncaught-button" onClick={() => project.restart(false)}>
-                    Bundle error&nbsp;
-                    <span className="codicon codicon-refresh" />
-                  </button>
                 </div>
               )}
             </div>


### PR DESCRIPTION
This PR introduces the following changes: 
1) bundle error over lay is removed and we instead rely on build in error message box 
2) We no longer focus on debug console and terminal when bundlingError happens, unless during the startup process, then we focus on the error source 
3) we remove redundant hasBundleBuildFailedError, it was always triggered in pair with  bundlingError and bundlingError was enough to throw ide into error  (display error baner and overlay) so we remove it.
4) because the build in error message box contains clickable elements we list the block on sending inputs to the device while in bundlingError state


<img width="586" alt="image" src="https://github.com/user-attachments/assets/73782c8c-91db-4e9c-aa0f-9ae6338c30b3" />


### How Has This Been Tested: 

- run `react-native-79` test app and force bundle errors in startup and non startup scenario



