### PR TITLE
Fix license modal sizing issue

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Modal.css
+++ b/packages/vscode-extension/src/webview/components/shared/Modal.css
@@ -20,9 +20,9 @@ input {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 90vw;
+  width: 75%;
   max-width: 450px;
-  max-height: 85vh;
+  max-height: 85%;
   padding: 25px;
   animation: contentShow 175ms cubic-bezier(0.16, 1, 0.3, 1);
   box-shadow: var(--swm-backdrop-shadow);

--- a/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
+++ b/packages/vscode-extension/src/webview/views/ActivateLicenseView.css
@@ -10,7 +10,6 @@
   flex: 1;
   background-color: var(--swm-input-background);
   color: var(--swm-default-text);
-  width: 100%;
   padding-top: 7px;
   padding-bottom: 7px;
   border: 1px;


### PR DESCRIPTION
This PR fixes styles for modals and for the activate license modal in particular.

This addresses the issue with scroll bars appearing on modals when IDE panel is narrow.

This PR makes the following changes to the styles:
 - we use percentage to set width and height of the modal (there's a px max limit that we keep). This way they don't reach the very edges of the view which makes it hard to notice the modal edges.
 - we allow license key input to scale on its own instead of using 100% which cased it to always expand past the boundaries of the modal (because it also has borders and paddings).

### How Has This Been Tested: 
1. Open activate license modal, manage device modal, diagnostics modal and launch config modals
2. Resize the window to see it looks ok with both wide and narrow settings

Before:
<img width="608" alt="image" src="https://github.com/user-attachments/assets/b914ad74-6d35-495e-ad95-e1c5bf894510" />
<img width="316" alt="image" src="https://github.com/user-attachments/assets/478da670-f906-416a-999c-27c9acff4d22" />


After:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/93706ed3-e1cd-4d16-8c6e-47e66f54dcf0" />
<img width="617" alt="image" src="https://github.com/user-attachments/assets/c6f0df6d-6fc2-4b55-a9c6-a190ce42e54a" />

This change doesn't seem to impact other modals significantly. They looked ok apart from reaching the very edge of the window on narrow screens, now they have some paddings:

Before:
<img width="482" alt="image" src="https://github.com/user-attachments/assets/f22e4017-e7e8-4ac3-962a-f26750543154" />

After:
<img width="473" alt="image" src="https://github.com/user-attachments/assets/3b87f7e8-bb7e-472e-a79e-605e35d45cd2" />



