### PR TITLE
Fix order in which theme.css is applied

### DIFF
--- a/packages/vscode-extension/src/network/App.tsx
+++ b/packages/vscode-extension/src/network/App.tsx
@@ -1,5 +1,4 @@
 import "./App.css";
-import "../webview/styles/theme.css";
 import { useMemo, useState } from "react";
 import NetworkBar from "./components/NetworkBar";
 import NetworkRequestLog from "./components/NetworkRequestLog";

--- a/packages/vscode-extension/src/network/index.jsx
+++ b/packages/vscode-extension/src/network/index.jsx
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import NetworkProvider from "./providers/NetworkProvider";
 
+import "../webview/styles/theme.css";
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <NetworkProvider>

--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -68,8 +68,8 @@ export function generateWebviewContent(
                       script-src 'nonce-${nonce}';
                       ${wsEndpoint ? `connect-src ws://${wsEndpoint} ${webview.cspSource};` : ""}
                       font-src vscode-resource: https:;" />
-        <link rel="stylesheet" type="text/css" href="${webviewName}.css" />
         <link rel="stylesheet" type="text/css" href="theme.css" />
+        <link rel="stylesheet" type="text/css" href="${webviewName}.css" />
         `
         }
       </head>

--- a/packages/vscode-extension/src/webview/index.jsx
+++ b/packages/vscode-extension/src/webview/index.jsx
@@ -9,10 +9,11 @@ import ProjectProvider from "./providers/ProjectProvider";
 import AlertProvider from "./providers/AlertProvider";
 import WorkspaceConfigProvider from "./providers/WorkspaceConfigProvider";
 
-import "./styles/theme.css";
 import { UtilsProvider, installLogOverrides } from "./providers/UtilsProvider";
 import { TelemetryProvider } from "./providers/TelemetryProvider";
 import LaunchConfigProvider from "./providers/LaunchConfigProvider";
+
+import "./styles/theme.css";
 
 installLogOverrides();
 


### PR DESCRIPTION
In #1057 a change was added that cause CSS rollup to start splitting CSS into [input].css and theme.css for webview and network inputs. Because of that, in the generated HTML we added theme.css as an extra source of our CSS. However, this change resulted in some UI glitches that started appearing on the release build that were due to the fact the order of CSS changed.

In CSS, when multiple class names are set for an item, and the two classes specify the same property. The class that is defined "later" takes precedence for this particular property. 

The fact that theme.css was listed after the main css bundle, impacted the way some styles were applied in release mode.

In particular, styles for the CPU profiler button were impacted where we use `input-button` and `button-recording-on` classes that both define `width`. We normally expected `button-recording-on` to override `width` property but since `input-button` have width specified in `theme.css`, it was taking the precedence in release builds.

This PR fixes the issue by reordering the CSS imports such that theme.css will always come first.
We also move import of `theme.css` to main network panel entry file, such that we are sure it is always imported first in the dev builds.

### How Has This Been Tested: 
1. Run app, test CPU Profiler button
2. Run `build:webview` script and set IS_DEV to `false` in `webviewContentGenerator` to test how it will look like in release mode.


Before (`IS_DEV = false`):
<img width="545" alt="image" src="https://github.com/user-attachments/assets/39a2bf3e-58a4-4237-bcd5-d890d912821e" />


After (`IS_DEV = false`):
<img width="553" alt="image" src="https://github.com/user-attachments/assets/28edc06a-d77b-4eab-82a5-627132f16c1a" />



