### PR TITLE
Hide internal error popup from production version 

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -37,7 +37,7 @@ import { Connector } from "./connect/Connector";
 const OPEN_PANEL_ON_ACTIVATION = "open_panel_on_activation";
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
 
-function handleUncaughtErrors() {
+function handleUncaughtErrors(context: ExtensionContext) {
   process.on("unhandledRejection", (error) => {
     Logger.error("Unhandled promise rejection", error);
   });
@@ -51,7 +51,9 @@ function handleUncaughtErrors() {
     }
     Logger.error("Uncaught exception", error);
     Logger.openOutputPanel();
-    window.showErrorMessage("Internal extension error.", "Dismiss");
+    if (context.extensionMode === ExtensionMode.Development) {
+      window.showErrorMessage("Internal extension error.", "Dismiss");
+    }
   });
 }
 
@@ -65,7 +67,7 @@ export function deactivate(context: ExtensionContext): undefined {
 }
 
 export async function activate(context: ExtensionContext) {
-  handleUncaughtErrors();
+  handleUncaughtErrors(context);
   await activateJsDebug(context);
 
   if (Platform.OS !== "macos" && Platform.OS !== "windows" && Platform.OS !== "linux") {


### PR DESCRIPTION
This PR hides internal error popup form production version of the IDE, as not every unhandled exception is necessary fatal. 

### How Has This Been Tested: 

- modify the `activate` function to look like this:
```js
export async function activate(context: ExtensionContext) {
  handleUncaughtErrors(context);
  setImmediate(()=>{throw new Error("test")});
...
}
```
- run it in development mode and observe the popup 
- build the package and open the vscode with the new package installed, popup does not appear

