### PR TITLE
Add launch arguments as a configuration on iOS.

### DIFF
--- a/packages/docs/docs/guides/configuration.md
+++ b/packages/docs/docs/guides/configuration.md
@@ -77,6 +77,7 @@ The following attributes can be set within the `ios` object:
 
 - `scheme` - Scheme name (from xcode project) the IDE will use for iOS builds, defaults to xcworkspace base file name.
 - `configuration` – Build configuration name (from xcode project) the IDE will use for iOS builds, defaults to "Debug".
+- `launchArguments` - Arguments passed to the app when launching it.
 
 Here is how the launch configuration could look like with some custom iOS build options:
 
@@ -90,7 +91,8 @@ Here is how the launch configuration could look like with some custom iOS build 
       "name": "Radon IDE panel",
       "ios": {
         "scheme": "AcmeApp",
-        "configuration": "Staging"
+        "configuration": "Staging",
+        "launchArguments": ["-FIRDebugEnabled"]
       }
     }
   ]
@@ -134,7 +136,7 @@ options.
 #### Using `customBuild`
 
 The requirement for scripts is to output the absolute path to the built app as
-the last line of the standard output. If multiple paths are provided, just the first one is used. The path should point to `.app`, `.apk` (for iOS and Android consecutively), or `.tar.gz` archive, which must contain one of the previous.  
+the last line of the standard output. If multiple paths are provided, just the first one is used. The path should point to `.app`, `.apk` (for iOS and Android consecutively), or `.tar.gz` archive, which must contain one of the previous.
 
 If custom fingerprint script is used, it
 should output fingerprint (a string identifying the build) as the last line of the standard output. When
@@ -174,22 +176,22 @@ Example with EAS local build:
 
 ```json
 {
-   "version": "0.2.0",
-   "configurations": [
-      {
-         "type": "radon-ide",
-         "request": "launch",
-         "name": "Radon IDE panel",
-         "customBuild": {
-            "ios": {
-               "buildCommand": "npx eas build --platform ios --profile development --local --non-interactive",
-            },
-            "android": {
-               "buildCommand": "npx eas build --platform android --profile development --local --non-interactive",
-            }
-         }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "radon-ide",
+      "request": "launch",
+      "name": "Radon IDE panel",
+      "customBuild": {
+        "ios": {
+          "buildCommand": "npx eas build --platform ios --profile development --local --non-interactive"
+        },
+        "android": {
+          "buildCommand": "npx eas build --platform android --profile development --local --non-interactive"
+        }
       }
-   ]
+    }
+  ]
 }
 ```
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -463,6 +463,10 @@
                   "configuration": {
                     "type": "string",
                     "description": "Build configuration name (from xcode project) the IDE will use for iOS builds, defaults to \"Debug\"."
+                  },
+                  "launchArguments": {
+                    "type": "array",
+                    "description": "Arguments passed to the app when launching it. This is used for passing custom arguments to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
                   }
                 }
               },
@@ -556,6 +560,10 @@
                   "configuration": {
                     "type": "string",
                     "description": "Build configuration name (from xcode project) the IDE will use for iOS builds, defaults to \"Debug\"."
+                  },
+                  "launchArguments": {
+                    "type": "array",
+                    "description": "Arguments passed to the app when launching it. This is used for passing custom arguments to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
                   }
                 }
               },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -466,7 +466,7 @@
                   },
                   "launchArguments": {
                     "type": "array",
-                    "description": "Arguments passed to the app when launching it. This is used for passing custom arguments to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
+                    "description": "Arguments passed to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
                   }
                 }
               },
@@ -563,7 +563,7 @@
                   },
                   "launchArguments": {
                     "type": "array",
-                    "description": "Arguments passed to the app when launching it. This is used for passing custom arguments to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
+                    "description": "Arguments passed to the app when launching it. Note: this configuration is only applied for applications that are launched using a build and not those opened with expo deep link."
                   }
                 }
               },

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -22,6 +22,7 @@ export type LaunchConfigurationOptions = {
   ios?: {
     scheme?: string;
     configuration?: string;
+    launchArguments?: string[];
   };
   isExpo?: boolean;
   android?: {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -13,6 +13,7 @@ import { BuildResult } from "../builders/BuildManager";
 import { AppPermissionType, DeviceSettings, Locale } from "../common/Project";
 import { EXPO_GO_BUNDLE_ID, fetchExpoLaunchDeeplink } from "../builders/expoGo";
 import { IOSBuildResult } from "../builders/buildIOS";
+import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 
 interface SimulatorInfo {
   availability?: string;
@@ -348,7 +349,9 @@ export class IosSimulatorDevice extends DeviceBase {
 
     this.nativeLogsOutputChannel.clear();
 
-    this.runningAppProcess = exec("xcrun", [
+    const applicationArguments = getLaunchConfiguration().ios?.launchArguments ?? [];
+
+    const launchAppArgs = [
       "simctl",
       "--set",
       deviceSetLocation,
@@ -357,7 +360,10 @@ export class IosSimulatorDevice extends DeviceBase {
       "--terminate-running-process",
       this.deviceUDID,
       build.bundleID,
-    ]);
+      ...applicationArguments,
+    ];
+
+    this.runningAppProcess = exec("xcrun", launchAppArgs);
 
     lineReader(this.runningAppProcess).onLineRead(this.nativeLogsOutputChannel.appendLine);
   }


### PR DESCRIPTION
This PR adds a launch arguments to launch configuration on iOS, for now it only works with non expo applications, but as we'll move away from utilizing expo deep links we can add it to them as well. 

This configuration is useful for projects that use firebase and for full debugging  need to add `-FIRDebugEnabled` argument to launch command. https://firebase.google.com/docs/analytics/debugview

### How Has This Been Tested: 

1) add this configuration to `react-native-79` test app and check if it breaks anything 
2) breakpoint in `launchApp` method and see if the argument is passed as expected
3) watch the preview of the documentation on vercel



