### PR TITLE
Refactor build type selection logic to happen outside the builders

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -60,7 +60,7 @@ export class BuildManager {
     return false;
   }
 
-  private async guessBuildType(
+  private async inferBuildType(
     appRoot: string,
     platform: DevicePlatform,
     launchConfiguration: LaunchConfigurationOptions
@@ -221,7 +221,7 @@ export class BuildManager {
 
       let buildResult: BuildResult;
       let buildFingerprint = currentFingerprint;
-      const buildType = await this.guessBuildType(appRoot, platform, launchConfiguration);
+      const buildType = await this.inferBuildType(appRoot, platform, launchConfiguration);
       try {
         if (platform === DevicePlatform.Android) {
           this.buildOutputChannel = window.createOutputChannel("Radon IDE (Android build)", {

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -84,7 +84,6 @@ export class BuildManager {
       return {
         appRoot,
         platform,
-        forceCleanBuild,
         env,
         type: BuildType.Custom,
         buildCommand: customBuildConfig.buildCommand,
@@ -96,7 +95,6 @@ export class BuildManager {
       return {
         appRoot,
         platform,
-        forceCleanBuild,
         env,
         type: BuildType.Eas,
         config: easBuildConfig,
@@ -107,7 +105,6 @@ export class BuildManager {
       return {
         appRoot,
         platform,
-        forceCleanBuild,
         env,
         type: BuildType.ExpoGo,
       };

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -113,29 +113,26 @@ export class BuildManager {
       };
     }
 
-    switch (platform) {
-      case DevicePlatform.IOS: {
-        return {
-          appRoot,
-          platform: platform as DevicePlatform.IOS & Platform,
-          forceCleanBuild,
-          env,
-          type: BuildType.Local,
-          scheme: ios?.scheme,
-          configuration: ios?.configuration,
-        };
-      }
-      case DevicePlatform.Android: {
-        return {
-          appRoot,
-          platform: platform as DevicePlatform.Android & Platform,
-          forceCleanBuild,
-          env,
-          type: BuildType.Local,
-          productFlavor: android?.productFlavor,
-          buildType: android?.buildType,
-        };
-      }
+    if (platform === DevicePlatform.IOS) {
+      return {
+        appRoot,
+        platform: platform as DevicePlatform.IOS & Platform,
+        forceCleanBuild,
+        env,
+        type: BuildType.Local,
+        scheme: ios?.scheme,
+        configuration: ios?.configuration,
+      };
+    } else {
+      return {
+        appRoot,
+        platform: platform as DevicePlatform.Android & Platform,
+        forceCleanBuild,
+        env,
+        type: BuildType.Local,
+        productFlavor: android?.productFlavor,
+        buildType: android?.buildType,
+      };
     }
   }
 

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -27,10 +27,7 @@ type BuildOptions = {
 };
 
 export class BuildError extends Error {
-  constructor(
-    message: string,
-    public readonly buildType: BuildType
-  ) {
+  constructor(message: string, public readonly buildType: BuildType | null) {
     super(message);
   }
 }
@@ -64,7 +61,7 @@ export class BuildManager {
     appRoot: string,
     platform: DevicePlatform,
     launchConfiguration: LaunchConfigurationOptions
-  ): Promise<Exclude<BuildType, BuildType.Unknown>> {
+  ): Promise<BuildType> {
     const { customBuild, eas } = launchConfiguration;
     const platformMapping = {
       [DevicePlatform.Android]: "android",
@@ -76,7 +73,7 @@ export class BuildManager {
     if (customBuildConfig && easBuildConfig) {
       throw new BuildError(
         `Both custom custom builds and EAS builds are configured for ${platform}. Please use only one build method.`,
-        BuildType.Unknown
+        null
       );
     }
 
@@ -100,7 +97,7 @@ export class BuildManager {
     platform: Platform,
     forceCleanBuild: boolean,
     launchConfiguration: LaunchConfigurationOptions,
-    buildType: Exclude<BuildType, BuildType.Unknown>
+    buildType: BuildType
   ): BuildConfig & { platform: Platform } {
     const { customBuild, eas, env, android, ios } = launchConfiguration;
     const platformMapping = {
@@ -298,7 +295,7 @@ export class BuildManager {
         if (e instanceof BuildError) {
           throw e;
         }
-        throw new BuildError(e.message, BuildType.Unknown);
+        throw new BuildError(e.message, null);
       }),
       dispose: () => {
         cancelToken.cancel();

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -156,14 +156,13 @@ async function buildLocal(
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void
 ): Promise<AndroidBuildResult> {
-  let { appRoot, forceCleanBuild, env, productFlavor, buildType } = buildConfig;
+  let { appRoot, forceCleanBuild, env, productFlavor = "", buildType = "debug" } = buildConfig;
   const androidSourceDir = getAndroidSourceDir(appRoot);
   const androidAppName = loadConfig({
     projectRoot: appRoot,
     selectedPlatform: "android",
   }).platforms.android?.projectConfig(appRoot)?.appName;
-  productFlavor ??= "";
-  buildType ??= "debug";
+
   const gradleArgs = [
     "-x",
     "lint",

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -10,8 +10,7 @@ import { exec, lineReader } from "../utilities/subprocess";
 import { CancelToken } from "./cancelToken";
 import { extensionContext } from "../utilities/extensionContext";
 import { BuildAndroidProgressProcessor } from "./BuildAndroidProgressProcessor";
-import { getLaunchConfiguration } from "../utilities/launchConfiguration";
-import { EXPO_GO_PACKAGE_NAME, downloadExpoGo, isExpoGoProject } from "./expoGo";
+import { EXPO_GO_PACKAGE_NAME, downloadExpoGo } from "./expoGo";
 import { DevicePlatform } from "../common/DeviceManager";
 import { getReactNativeVersion } from "../utilities/reactNative";
 import { runExternalBuild } from "./customBuild";
@@ -19,8 +18,7 @@ import { fetchEasBuild } from "./eas";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildError } from "./BuildManager";
-import { LaunchConfigurationOptions } from "../common/LaunchConfig";
-import { BuildType } from "../common/BuildConfig";
+import { AndroidBuildConfig, AndroidLocalBuildConfig, BuildType } from "../common/BuildConfig";
 
 export type AndroidBuildResult = {
   platform: DevicePlatform.Android;
@@ -83,121 +81,103 @@ function makeBuildTaskName(productFlavor: string, buildType: string, appName?: s
 }
 
 export async function buildAndroid(
-  appRoot: string,
-  forceCleanBuild: boolean,
+  buildConfig: AndroidBuildConfig,
   cancelToken: CancelToken,
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void,
   dependencyManager: DependencyManager
 ): Promise<AndroidBuildResult> {
-  const launchConfiguration = getLaunchConfiguration();
-  const { customBuild, eas, env } = launchConfiguration;
-
-  if (customBuild?.android && eas?.android) {
-    throw new BuildError(
-      "Both custom custom builds and EAS builds are configured for Android. Please use only one build method.",
-      BuildType.Unknown
-    );
-  }
-
-  if (customBuild?.android?.buildCommand) {
-    getTelemetryReporter().sendTelemetryEvent("build:custom-build-requested", {
-      platform: DevicePlatform.Android,
-    });
-    const apkPath = await runExternalBuild(
-      cancelToken,
-      customBuild.android.buildCommand,
-      env,
-      DevicePlatform.Android,
-      appRoot,
-      outputChannel
-    );
-    if (!apkPath) {
-      throw new BuildError(
-        "Failed to build Android app using custom script. See the build logs for details.",
-        BuildType.Custom
-      );
-    }
-
-    return {
-      apkPath,
-      packageName: await extractPackageName(apkPath, cancelToken),
-      platform: DevicePlatform.Android,
-    };
-  }
-
-  if (eas?.android) {
-    try {
-      getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
+  const { appRoot, env, type: buildType } = buildConfig;
+  switch (buildType) {
+    case BuildType.Custom: {
+      getTelemetryReporter().sendTelemetryEvent("build:custom-build-requested", {
         platform: DevicePlatform.Android,
       });
-      const apkPath = await fetchEasBuild(
+      const apkPath = await runExternalBuild(
         cancelToken,
-        eas.android,
+        buildConfig.buildCommand,
+        env,
         DevicePlatform.Android,
         appRoot,
         outputChannel
       );
+      if (!apkPath) {
+        throw new BuildError(
+          "Failed to build Android app using custom script. See the build logs for details.",
+          BuildType.Custom
+        );
+      }
 
       return {
         apkPath,
         packageName: await extractPackageName(apkPath, cancelToken),
         platform: DevicePlatform.Android,
       };
-    } catch (e) {
-      throw new BuildError((e as Error).message, BuildType.Eas);
     }
-  }
+    case BuildType.Eas: {
+      try {
+        getTelemetryReporter().sendTelemetryEvent("build:eas-build-requested", {
+          platform: DevicePlatform.Android,
+        });
+        const apkPath = await fetchEasBuild(
+          cancelToken,
+          buildConfig.config,
+          DevicePlatform.Android,
+          appRoot,
+          outputChannel
+        );
 
-  if (await isExpoGoProject(appRoot)) {
-    getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
-      platform: DevicePlatform.Android,
-    });
-    try {
-      const apkPath = await downloadExpoGo(DevicePlatform.Android, cancelToken, appRoot);
-      return { apkPath, packageName: EXPO_GO_PACKAGE_NAME, platform: DevicePlatform.Android };
-    } catch (e) {
-      throw new BuildError((e as Error).message, BuildType.ExpoGo);
+        return {
+          apkPath,
+          packageName: await extractPackageName(apkPath, cancelToken),
+          platform: DevicePlatform.Android,
+        };
+      } catch (e) {
+        throw new BuildError((e as Error).message, BuildType.Eas);
+      }
     }
-  }
+    case BuildType.ExpoGo: {
+      getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
+        platform: DevicePlatform.Android,
+      });
+      try {
+        const apkPath = await downloadExpoGo(DevicePlatform.Android, cancelToken, appRoot);
+        return { apkPath, packageName: EXPO_GO_PACKAGE_NAME, platform: DevicePlatform.Android };
+      } catch (e) {
+        throw new BuildError((e as Error).message, BuildType.ExpoGo);
+      }
+    }
+    case BuildType.Local: {
+      if (!(await dependencyManager.checkAndroidDirectoryExits())) {
+        throw new BuildError(
+          'Your project does not have "android" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure an external build source using launch configuration.',
+          BuildType.Local
+        );
+      }
 
-  if (!(await dependencyManager.checkAndroidDirectoryExits())) {
-    throw new BuildError(
-      'Your project does not have "android" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure an external build source using launch configuration.',
-      BuildType.Local
-    );
-  }
-
-  try {
-    return await buildLocal(
-      appRoot,
-      forceCleanBuild,
-      launchConfiguration,
-      cancelToken,
-      outputChannel,
-      progressListener
-    );
-  } catch (e) {
-    throw new BuildError((e as Error).message, BuildType.Local);
+      try {
+        return await buildLocal(buildConfig, cancelToken, outputChannel, progressListener);
+      } catch (e) {
+        throw new BuildError((e as Error).message, BuildType.Local);
+      }
+    }
   }
 }
 
 async function buildLocal(
-  appRoot: string,
-  forceCleanBuild: boolean,
-  launchConfiguration: LaunchConfigurationOptions,
+  buildConfig: AndroidLocalBuildConfig,
   cancelToken: CancelToken,
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void
 ): Promise<AndroidBuildResult> {
-  const { android, env } = launchConfiguration;
+  let { appRoot, forceCleanBuild, env, productFlavor, buildType } = buildConfig;
   const androidSourceDir = getAndroidSourceDir(appRoot);
   const androidAppName = loadConfig({
     projectRoot: appRoot,
     selectedPlatform: "android",
   }).platforms.android?.projectConfig(appRoot)?.appName;
-  const productFlavor = android?.productFlavor || "";
-  const buildType = android?.buildType || "debug";
+  productFlavor ??= "";
+  buildType ??= "debug";
   const gradleArgs = [
     "-x",
     "lint",

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -20,7 +20,7 @@ import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildError } from "./BuildManager";
 import { LaunchConfigurationOptions } from "../common/LaunchConfig";
-import { BuildType } from "../common/Project";
+import { BuildType } from "../common/BuildConfig";
 
 export type AndroidBuildResult = {
   platform: DevicePlatform.Android;

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -158,7 +158,7 @@ async function buildLocal(
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void
 ): Promise<IOSBuildResult> {
-  let { appRoot, scheme, forceCleanBuild, configuration } = buildConfig;
+  const { appRoot, forceCleanBuild, configuration = "Debug" } = buildConfig;
 
   const sourceDir = getIosSourceDir(appRoot);
 
@@ -183,8 +183,8 @@ async function buildLocal(
     }`
   );
 
-  scheme ??= (await findXcodeScheme(xcodeProject))[0];
-  configuration ??= "Debug";
+  const scheme = buildConfig.scheme ?? (await findXcodeScheme(xcodeProject))[0];
+
   Logger.debug(`Xcode build will use "${scheme}" scheme`);
 
   const buildProcess = cancelToken.adapt(

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -15,7 +15,7 @@ import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildError } from "./BuildManager";
 import { LaunchConfigurationOptions } from "../common/LaunchConfig";
-import { BuildType } from "../common/Project";
+import { BuildType } from "../common/BuildConfig";
 
 export type IOSBuildResult = {
   platform: DevicePlatform.IOS;

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -5,7 +5,6 @@ export enum BuildType {
   ExpoGo = "expoGo",
   Eas = "eas",
   Custom = "custom",
-  Unknown = "unknown",
 }
 
 interface BuildConfigCommon {
@@ -62,7 +61,4 @@ type SupportedIOSBuildType = IOSBuildConfig["type"];
 type SupportedAndroidBuildType = AndroidBuildConfig["type"];
 type SupportedBuildType = SupportedIOSBuildType & SupportedAndroidBuildType;
 
-type _SupportsAllBuildTypes = IsSuperTypeOf<
-  SupportedBuildType,
-  Exclude<BuildType, BuildType.Unknown>
->;
+type _SupportsAllBuildTypes = IsSuperTypeOf<SupportedBuildType, BuildType>;

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -10,7 +10,6 @@ export enum BuildType {
 
 interface BuildConfigCommon {
   appRoot: string;
-  forceCleanBuild: boolean;
   platform: DevicePlatform;
   env?: Record<string, string>;
 }
@@ -33,6 +32,7 @@ export type EasBuildConfig = {
 export type AndroidLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.Android;
+  forceCleanBuild: boolean;
   buildType?: string;
   productFlavor?: string;
 } & BuildConfigCommon;
@@ -40,6 +40,7 @@ export type AndroidLocalBuildConfig = {
 export type IOSLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.IOS;
+  forceCleanBuild: boolean;
   scheme?: string;
   configuration?: string;
 } & BuildConfigCommon;

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -33,15 +33,15 @@ export type EasBuildConfig = {
 export type AndroidLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.Android;
-  buildType: string;
-  productFlavor: string;
+  buildType?: string;
+  productFlavor?: string;
 } & BuildConfigCommon;
 
-export type IOSLocaBuildConfig = {
+export type IOSLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.IOS;
-  scheme: string | null;
-  configuration: string | null;
+  scheme?: string;
+  configuration?: string;
 } & BuildConfigCommon;
 
 export type BuildConfig =
@@ -49,13 +49,14 @@ export type BuildConfig =
   | ExpoGoBuildConfig
   | EasBuildConfig
   | AndroidLocalBuildConfig
-  | IOSLocaBuildConfig;
+  | IOSLocalBuildConfig;
+
+export type IOSBuildConfig = BuildConfig & { platform: DevicePlatform.IOS };
+export type AndroidBuildConfig = BuildConfig & { platform: DevicePlatform.Android };
 
 // NOTE: we let typescript verify that the `BuildConfig` union covers all the `BuildType` variants for both platforms
 type Satisfy<Base, T extends Base> = T;
 
-type IOSBuildConfig = BuildConfig & { platform: DevicePlatform.IOS };
-type AndroidBuildConfig = BuildConfig & { platform: DevicePlatform.Android };
 type _CoversBuildTypes = Satisfy<
   IOSBuildConfig["type"] & AndroidBuildConfig["type"],
   Exclude<BuildType, BuildType.Unknown>

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -1,0 +1,62 @@
+import { DevicePlatform } from "./DeviceManager";
+
+export enum BuildType {
+  Local = "local",
+  ExpoGo = "expoGo",
+  Eas = "eas",
+  Custom = "custom",
+  Unknown = "unknown",
+}
+
+interface BuildConfigCommon {
+  appRoot: string;
+  forceCleanBuild: boolean;
+  platform: DevicePlatform;
+  env?: Record<string, string>;
+}
+
+export type CustomBuildConfig = {
+  type: BuildType.Custom;
+  buildCommand: string;
+  fingerprintCommand?: string;
+} & BuildConfigCommon;
+
+export type ExpoGoBuildConfig = {
+  type: BuildType.ExpoGo;
+} & BuildConfigCommon;
+
+export type EasBuildConfig = {
+  type: BuildType.Eas;
+  config: { profile: string; buildUUID?: string };
+} & BuildConfigCommon;
+
+export type AndroidLocalBuildConfig = {
+  type: BuildType.Local;
+  platform: DevicePlatform.Android;
+  buildType: string;
+  productFlavor: string;
+} & BuildConfigCommon;
+
+export type IOSLocaBuildConfig = {
+  type: BuildType.Local;
+  platform: DevicePlatform.IOS;
+  scheme: string | null;
+  configuration: string | null;
+} & BuildConfigCommon;
+
+export type BuildConfig =
+  | CustomBuildConfig
+  | ExpoGoBuildConfig
+  | EasBuildConfig
+  | AndroidLocalBuildConfig
+  | IOSLocaBuildConfig;
+
+// NOTE: we let typescript verify that the `BuildConfig` union covers all the `BuildType` variants for both platforms
+type Satisfy<Base, T extends Base> = T;
+
+type IOSBuildConfig = BuildConfig & { platform: DevicePlatform.IOS };
+type AndroidBuildConfig = BuildConfig & { platform: DevicePlatform.Android };
+type _CoversBuildTypes = Satisfy<
+  IOSBuildConfig["type"] & AndroidBuildConfig["type"],
+  Exclude<BuildType, BuildType.Unknown>
+>;

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -55,9 +55,13 @@ export type IOSBuildConfig = BuildConfig & { platform: DevicePlatform.IOS };
 export type AndroidBuildConfig = BuildConfig & { platform: DevicePlatform.Android };
 
 // NOTE: we let typescript verify that the `BuildConfig` union covers all the `BuildType` variants for both platforms
-type Satisfy<Base, T extends Base> = T;
+type IsSuperTypeOf<Base, T extends Base> = T;
 
-type _CoversBuildTypes = Satisfy<
-  IOSBuildConfig["type"] & AndroidBuildConfig["type"],
+type SupportedIOSBuildType = IOSBuildConfig["type"];
+type SupportedAndroidBuildType = AndroidBuildConfig["type"];
+type SupportedBuildType = SupportedIOSBuildType & SupportedAndroidBuildType;
+
+type _SupportsAllBuildTypes = IsSuperTypeOf<
+  SupportedBuildType,
   Exclude<BuildType, BuildType.Unknown>
 >;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -1,3 +1,4 @@
+import { BuildType } from "./BuildConfig";
 import { DeviceInfo, DevicePlatform } from "./DeviceManager";
 
 export type Locale = string;
@@ -55,14 +56,6 @@ type ProjectStateBuildError = {
     buildType: BuildType;
   };
 } & ProjectStateCommon;
-
-export enum BuildType {
-  Local = "local",
-  ExpoGo = "expoGo",
-  Eas = "eas",
-  Custom = "custom",
-  Unknown = "unknown",
-}
 
 export type ZoomLevelType = number | "Fit";
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -53,7 +53,7 @@ type ProjectStateBuildError = {
   buildError: {
     message: string;
     platform: DevicePlatform;
-    buildType: BuildType;
+    buildType: BuildType | null;
   };
 } & ProjectStateCommon;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -18,7 +18,6 @@ import { minimatch } from "minimatch";
 import { isEqual } from "lodash";
 import {
   AppPermissionType,
-  BuildType,
   DeviceButtonType,
   DeviceSettings,
   InspectData,
@@ -58,6 +57,7 @@ import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRoo
 import { focusSource } from "../utilities/focusSource";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { BuildError } from "../builders/BuildManager";
+import { BuildType } from "../common/BuildConfig";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -57,7 +57,6 @@ import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRoo
 import { focusSource } from "../utilities/focusSource";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { BuildError } from "../builders/BuildManager";
-import { BuildType } from "../common/BuildConfig";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 
@@ -1011,7 +1010,7 @@ export class Project
             status: "buildError",
             buildError: {
               message: (e as Error).message,
-              buildType: BuildType.Unknown,
+              buildType: null,
               platform: deviceInfo.platform,
             },
           });

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -64,13 +64,13 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
   if (projectState.status === "buildError") {
     const { buildType, message } = projectState.buildError;
     description = message;
-    if ([BuildType.Local, BuildType.Custom].includes(buildType)) {
+    if (buildType && [BuildType.Local, BuildType.Custom].includes(buildType)) {
       logsButtonDestination = "build";
     } else {
       logsButtonDestination = "extension";
     }
 
-    if (buildType === BuildType.Unknown && !ios?.scheme && xcodeSchemes.length > 1) {
+    if (buildType === null && !ios?.scheme && xcodeSchemes.length > 1) {
       description = `Your project uses multiple build schemas. Currently used scheme: '${xcodeSchemes[0]}'. You can change it in the launch configuration.`;
     }
   }

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -5,7 +5,7 @@ import IconButton from "../components/shared/IconButton";
 import { useModal } from "../providers/ModalProvider";
 import LaunchConfigurationView from "../views/LaunchConfigurationView";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
-import { BuildType } from "../../common/Project";
+import { BuildType } from "../../common/BuildConfig";
 
 type LogsButtonDestination = "build" | "extension";
 


### PR DESCRIPTION
Previously, the "builders" (`buildIos` and `buildAndroid` functions) were responsible for selecting the "type" of the build they should perform, based on the radon Launch Configuration and the application workspace. This resulted in a lot of duplicated logic between these functions and makes it impossible for the callers of these functions to control which type of build should be run.

This PR changes these functions to accept a `BuildConfig` parameter which specifies the build type instead, and moves the build type selection logic to the `BuildManager`.

## Test plan:
- open test apps from the test app repo and verify the correct build type is used
