### PR TITLE
Support EAS local builds

### DIFF
--- a/packages/docs/docs/guides/configuration.md
+++ b/packages/docs/docs/guides/configuration.md
@@ -202,6 +202,7 @@ Example with EAS local build:
 - `profile` – required, used for [selecting builds](https://docs.expo.dev/build/eas-json/#development-builds) suitable for running in simulators.
 - `buildUUID` – when specified, the build with the specified ID will be used.
   Otherwise, Radon IDE will attempt to find a compatible build and use that.
+- `local` – when set to `true`, passes the `--local` flag to `eas build` in order to build the application locally. See the [EAS Build docs](https://docs.expo.dev/build-reference/local-builds/) for details.
 
 Below is an example that replaces iOS and Android local builds with builds from EAS:
 

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -85,7 +85,11 @@ export class BuildManager {
     }
 
     if (easBuildConfig) {
-      return BuildType.Eas;
+      if (easBuildConfig.local) {
+        return BuildType.EasLocal;
+      } else {
+        return BuildType.Eas;
+      }
     }
 
     if (await isExpoGoProject(appRoot)) {
@@ -155,6 +159,22 @@ export class BuildManager {
           env,
           type: BuildType.Eas,
           config: easBuildConfig,
+        };
+      }
+      case BuildType.EasLocal: {
+        const easBuildConfig = eas?.[platformKey];
+        if (easBuildConfig === undefined) {
+          throw new BuildError(
+            "A local EAS build was initialized but no EAS build config was specified in the launch configuration.",
+            BuildType.EasLocal
+          );
+        }
+        return {
+          appRoot,
+          platform,
+          env,
+          type: BuildType.EasLocal,
+          profile: easBuildConfig.profile,
         };
       }
       case BuildType.Custom: {

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -14,7 +14,7 @@ import { EXPO_GO_PACKAGE_NAME, downloadExpoGo } from "./expoGo";
 import { DevicePlatform } from "../common/DeviceManager";
 import { getReactNativeVersion } from "../utilities/reactNative";
 import { runExternalBuild } from "./customBuild";
-import { fetchEasBuild } from "./eas";
+import { fetchEasBuild, performLocalEasBuild } from "./eas";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { AndroidBuildConfig, AndroidLocalBuildConfig, BuildType } from "../common/BuildConfig";

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -131,6 +131,24 @@ export async function buildAndroid(
         platform: DevicePlatform.Android,
       };
     }
+    case BuildType.EasLocal: {
+      getTelemetryReporter().sendTelemetryEvent("build:eas-local-build-requested", {
+        platform: DevicePlatform.Android,
+      });
+      const apkPath = await performLocalEasBuild(
+        buildConfig.profile,
+        DevicePlatform.Android,
+        appRoot,
+        outputChannel,
+        cancelToken
+      );
+
+      return {
+        apkPath,
+        packageName: await extractPackageName(apkPath, cancelToken),
+        platform: DevicePlatform.Android,
+      };
+    }
     case BuildType.ExpoGo: {
       getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
         platform: DevicePlatform.Android,

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -127,6 +127,24 @@ export async function buildIos(
         platform: DevicePlatform.IOS,
       };
     }
+    case BuildType.EasLocal: {
+      getTelemetryReporter().sendTelemetryEvent("build:eas-local-build-requested", {
+        platform: DevicePlatform.IOS,
+      });
+      const appPath = await performLocalEasBuild(
+        buildConfig.profile,
+        DevicePlatform.IOS,
+        appRoot,
+        outputChannel,
+        cancelToken
+      );
+
+      return {
+        appPath,
+        bundleID: await getBundleID(appPath),
+        platform: DevicePlatform.IOS,
+      };
+    }
     case BuildType.ExpoGo: {
       getTelemetryReporter().sendTelemetryEvent("build:expo-go-requested", {
         platform: DevicePlatform.IOS,

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -9,7 +9,7 @@ import { DevicePlatform } from "../common/DeviceManager";
 import { EXPO_GO_BUNDLE_ID, downloadExpoGo } from "./expoGo";
 import { findXcodeProject, findXcodeScheme, IOSProjectInfo } from "../utilities/xcode";
 import { runExternalBuild } from "./customBuild";
-import { fetchEasBuild } from "./eas";
+import { fetchEasBuild, performLocalEasBuild } from "./eas";
 import { getXcodebuildArch } from "../utilities/common";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";

--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -16,6 +16,7 @@ import {
   listEasBuilds,
   viewEasBuild,
   generateFingerprint,
+  buildLocal,
 } from "./easCommand";
 import { extractTarApp } from "./utils";
 
@@ -32,12 +33,14 @@ export async function fetchEasBuild(
     );
   }
 
-  const build = await fetchBuild(config, platform, appRoot);
-
-  let easBinaryPath = await downloadAppFromEas(build, platform, cancelToken);
-
-  Logger.debug(`Using built app from EAS: '${easBinaryPath}'`);
-  return easBinaryPath;
+  try {
+    const build = await fetchBuild(config, platform, appRoot);
+    let easBinaryPath = await downloadAppFromEas(build, platform, cancelToken);
+    Logger.debug(`Using built app from EAS: '${easBinaryPath}'`);
+    return easBinaryPath;
+  } catch {
+    return performLocalBuild(config, platform, appRoot, outputChannel, cancelToken);
+  }
 }
 
 async function fetchBuild(
@@ -101,6 +104,24 @@ async function fetchBuild(
   return build;
 }
 
+async function performLocalBuild(
+  config: EasConfig,
+  platform: DevicePlatform,
+  appRoot: string,
+  outputChannel: OutputChannel,
+  cancelToken: CancelToken
+) {
+  const tmpDirectory = await mkdtemp(path.join(os.tmpdir(), "rn-ide-eas-build-"));
+  const outputBase = `eas-${config.profile}`;
+  const outputPath =
+    platform === DevicePlatform.Android
+      ? path.join(tmpDirectory, `${outputBase}.apk`)
+      : path.join(tmpDirectory, `${outputBase}.tar.gz`);
+  await buildLocal({ platform, profile: config.profile, outputPath }, appRoot, outputChannel);
+
+  return maybeExtractBinary(platform, outputPath, tmpDirectory);
+}
+
 async function downloadAppFromEas(
   build: EASBuild,
   platform: DevicePlatform,
@@ -120,6 +141,14 @@ async function downloadAppFromEas(
       `EAS build was found at '${binaryUrl}' but could not be downloaded. Verify your Internet connection is stable and try again.`
     );
   }
+  return maybeExtractBinary(platform, binaryPath, tmpDirectory);
+}
+
+async function maybeExtractBinary(
+  platform: DevicePlatform,
+  binaryPath: string,
+  tmpDirectory: string
+) {
   // on iOS we need to extract the .tar.gz archive to get the .app file
   const shouldExtractArchive = platform === DevicePlatform.IOS;
   if (!shouldExtractArchive) {

--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -101,19 +101,19 @@ async function fetchBuild(
 }
 
 export async function performLocalEasBuild(
-  config: EasConfig,
+  profile: string,
   platform: DevicePlatform,
   appRoot: string,
   outputChannel: OutputChannel,
   cancelToken: CancelToken
 ) {
   const tmpDirectory = await mkdtemp(path.join(os.tmpdir(), "rn-ide-eas-build-"));
-  const outputBase = `eas-${config.profile}`;
+  const outputBase = `eas-${profile}`;
   const outputPath =
     platform === DevicePlatform.Android
       ? path.join(tmpDirectory, `${outputBase}.apk`)
       : path.join(tmpDirectory, `${outputBase}.tar.gz`);
-  await buildLocal({ platform, profile: config.profile, outputPath }, appRoot, outputChannel);
+  await buildLocal({ platform, profile, outputPath }, appRoot, outputChannel);
 
   return maybeExtractBinary(platform, outputPath, tmpDirectory);
 }

--- a/packages/vscode-extension/src/builders/eas.ts
+++ b/packages/vscode-extension/src/builders/eas.ts
@@ -33,14 +33,10 @@ export async function fetchEasBuild(
     );
   }
 
-  try {
-    const build = await fetchBuild(config, platform, appRoot);
-    let easBinaryPath = await downloadAppFromEas(build, platform, cancelToken);
-    Logger.debug(`Using built app from EAS: '${easBinaryPath}'`);
-    return easBinaryPath;
-  } catch {
-    return performLocalBuild(config, platform, appRoot, outputChannel, cancelToken);
-  }
+  const build = await fetchBuild(config, platform, appRoot);
+  let easBinaryPath = await downloadAppFromEas(build, platform, cancelToken);
+  Logger.debug(`Using built app from EAS: '${easBinaryPath}'`);
+  return easBinaryPath;
 }
 
 async function fetchBuild(
@@ -104,7 +100,7 @@ async function fetchBuild(
   return build;
 }
 
-async function performLocalBuild(
+export async function performLocalEasBuild(
   config: EasConfig,
   platform: DevicePlatform,
   appRoot: string,

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -4,6 +4,7 @@ export enum BuildType {
   Local = "local",
   ExpoGo = "expoGo",
   Eas = "eas",
+  EasLocal = "easLocal",
   Custom = "custom",
 }
 
@@ -28,6 +29,11 @@ export type EasBuildConfig = {
   config: { profile: string; buildUUID?: string };
 } & BuildConfigCommon;
 
+export type EasLocalBuildConfig = {
+  type: BuildType.EasLocal;
+  profile: string;
+} & BuildConfigCommon;
+
 export type AndroidLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.Android;
@@ -48,6 +54,7 @@ export type BuildConfig =
   | CustomBuildConfig
   | ExpoGoBuildConfig
   | EasBuildConfig
+  | EasLocalBuildConfig
   | AndroidLocalBuildConfig
   | IOSLocalBuildConfig;
 

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -1,6 +1,6 @@
 import { EasBuildConfig } from "./EasConfig";
 
-export type EasConfig = { profile: string; buildUUID?: string };
+export type EasConfig = { profile: string; buildUUID?: string; local?: boolean };
 export type CustomBuild = {
   buildCommand?: string;
   fingerprintCommand?: string;

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -111,13 +111,14 @@ export function lineReader(childProcess: ExecaChildProcess<string>) {
 export function exec(
   name: string,
   args?: string[],
-  options?: execa.Options & { allowNonZeroExit?: boolean }
+  options?: execa.Options & { allowNonZeroExit?: boolean; quietErrorsOnExit?: boolean }
 ) {
   const subprocess = execa(
     name,
     args,
     Platform.select({ macos: overrideEnv(options), windows: options, linux: options })
   );
+
   const allowNonZeroExit = options?.allowNonZeroExit;
   async function printErrorsOnExit() {
     try {
@@ -137,7 +138,10 @@ export function exec(
       }
     }
   }
-  printErrorsOnExit(); // don't want to await here not to block the outer method
+  if (!options?.quietErrorsOnExit) {
+    printErrorsOnExit(); // don't want to await here not to block the outer method
+  }
+
   return subprocess;
 }
 

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -64,7 +64,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
   if (projectState.status === "buildError") {
     const { buildType, message } = projectState.buildError;
     description = message;
-    if (buildType && [BuildType.Local, BuildType.Custom].includes(buildType)) {
+    if (buildType && [BuildType.Local, BuildType.EasLocal, BuildType.Custom].includes(buildType)) {
       logsButtonDestination = "build";
     } else {
       logsButtonDestination = "extension";

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -420,9 +420,12 @@ function EasBuildConfiguration({
 }: easBuildConfigurationProps) {
   const DISABLED = "Disabled" as const;
   const CUSTOM = "Custom" as const;
+  const YES = "Yes" as const;
+  const NO = "No" as const;
 
   const profile = eas?.[platform]?.profile;
   const buildUUID = eas?.[platform]?.buildUUID;
+  const local = eas?.[platform]?.local;
 
   const [selectedProfile, setSelectedProfile] = useState<string>(() => {
     if (profile === undefined) {
@@ -440,7 +443,9 @@ function EasBuildConfiguration({
   const updateEasConfig = (configUpdate: Partial<EasConfig>) => {
     const currentPlaftormConfig = eas?.[platform] ?? {};
     const newPlatformConfig = Object.fromEntries(
-      Object.entries({ ...currentPlaftormConfig, ...configUpdate }).filter(([_k, v]) => !!v)
+      Object.entries({ ...currentPlaftormConfig, ...configUpdate }).filter(
+        ([_k, v]) => !!v || v === false
+      )
     );
     if ("profile" in newPlatformConfig) {
       update("eas", { ...eas, [platform]: newPlatformConfig });
@@ -478,6 +483,11 @@ function EasBuildConfiguration({
     updateEasConfig({ buildUUID: newBuildUUID });
   };
 
+  const onBuildLocallyChange = (selection: string) => {
+    const newLocal = selection === YES ? true : undefined;
+    updateEasConfig({ local: newLocal });
+  };
+
   const availableEasBuildProfiles = Object.entries(easBuildProfiles).map(
     ([buildProfile, config]) => {
       const canRunInSimulator =
@@ -489,6 +499,11 @@ function EasBuildConfiguration({
 
   availableEasBuildProfiles.push({ value: DISABLED, label: DISABLED, disabled: false });
   availableEasBuildProfiles.push({ value: CUSTOM, label: CUSTOM, disabled: false });
+
+  const buildLocallyOptions = [
+    { value: YES, label: YES },
+    { value: NO, label: NO },
+  ];
 
   return (
     <div className="launch-configuration-container">
@@ -516,15 +531,25 @@ function EasBuildConfiguration({
       )}
       {selectedProfile !== DISABLED && (
         <>
-          <div className="setting-description">{prettyPlatformName(platform)} Build UUID:</div>
-          <Input
-            ref={buildUUIDInputRef}
-            className="input-configuration"
-            type="string"
-            defaultValue={buildUUID ?? ""}
-            placeholder="Auto (build with matching fingerprint)"
-            onBlur={onBuildUUIDInputBlur}
-          />
+          <div className="setting-description">Build locally:</div>
+          <Select
+            value={local ? YES : NO}
+            onChange={onBuildLocallyChange}
+            items={buildLocallyOptions}
+            className="scheme"></Select>
+          {!local && (
+            <>
+              <div className="setting-description">{prettyPlatformName(platform)} Build UUID:</div>
+              <Input
+                ref={buildUUIDInputRef}
+                className="input-configuration"
+                type="string"
+                defaultValue={buildUUID ?? ""}
+                placeholder="Auto (build with matching fingerprint)"
+                onBlur={onBuildUUIDInputBlur}
+              />
+            </>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
- Allows configuring EAS apps to build locally instead of downloading from the EAS Build server.
- Allows setting the EAS build `local` flag through UI.
- Updates the docs to include the new flag.

![image](https://github.com/user-attachments/assets/7155cc92-39a3-46a0-85db-d376b36d442f)

## How Has This Been Tested:
- open the `expo-52-eas` test app
- add a `"local": true` entry to `eas.ios` or `eas.android` launch config
- check that the app is built locally for the platform
- open the "Launch Configuration" menu
- verify you can select "Build Locally > Yes/No" under the EAS options and that the setting is respected
