### PR TITLE
Fix starting dev version of extension from cursor

### DIFF
--- a/packages/vscode-extension/.vscode/tasks.json
+++ b/packages/vscode-extension/.vscode/tasks.json
@@ -10,8 +10,8 @@
     {
       "label": "kill vite",
       "type": "shell",
-      // kills the processes listening on port 2137 
-      "command": "lsof -n -i :2137 -sTCP:LISTEN | awk '{print $2}' | grep -E '[0-9]+' | xargs kill",
+      // kills the processes listening on port 2137
+      "command": "lsof -n -i :2137 -sTCP:LISTEN | awk '{print $2}' | grep -E '[0-9]+' | xargs kill"
     },
     {
       "label": "build extension",
@@ -38,9 +38,9 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": "ready in \\d+ ms",
-          "endsPattern": ".*Local:\\s+http://localhost:2137/.*"
+          "endsPattern": ".*Local:\\s+http://.*:2137/.*"
         }
       }
-    },
+    }
   ]
 }

--- a/packages/vscode-extension/vite.config.js
+++ b/packages/vscode-extension/vite.config.js
@@ -81,6 +81,7 @@ export default defineConfig({
   },
   server: {
     port: 2137,
+    strictPort: true,
     hmr: {
       host: "127.0.0.1",
     },


### PR DESCRIPTION
After recent updates of VSCode and Cursor we started seeing issues when launching or re-launching the extension in dev mode from VSCode/Cursor.

I noticed that the issue was because the launcher was waiting for the "start webview server" to complete. However, due to the task being configured such that it waits for "localhost:2137" pattern to appear, it'd never go into a "complete" state for some reason.

What I don't understand is why this hasn't been a problem before. The root cause was the change were we modified vite's configuration to use 127.0.0.1 instead of localhost. However that change got merged a long time ago. So I suspect that something has changed in the code that handles the task runner such that it actually waits for this task to be considered as finished before it can proceed to launch the extension.

The fix is to make the pattern more forgiving and to not expect a particular host name or address. This is enough for us to tell that the vite server has started successfully.

We are also adding `strictPort` option to vite to ensure it only starts at the specified port, as we have the port number coded into the task config and into the panel webview code.

### How Has This Been Tested: 
1. Using new version of cursor, build in dev mode and see it launches the window with extension loaded
2. Before, the launcher would be stuck forever waiting for "start webview server" task.


