### PR TITLE
Fix device sesstion start

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -139,19 +139,19 @@ export class DeviceSession implements Disposable {
 
   private makeDevtools() {
     const devtools = new Devtools();
-    this.devtools.onEvent("RNIDE_appReady", () => {
+    devtools.onEvent("RNIDE_appReady", () => {
       Logger.debug("App ready");
     });
     // We don't need to store event disposables here as they are tied to the lifecycle
     // of the devtools instance, which is disposed when we recreate the devtools or
     // when the device session is disposed
-    this.devtools.onEvent("RNIDE_navigationChanged", (payload) => {
+    devtools.onEvent("RNIDE_navigationChanged", (payload) => {
       this.deviceSessionDelegate.onAppEvent("navigationChanged", payload);
     });
-    this.devtools.onEvent("RNIDE_fastRefreshStarted", () => {
+    devtools.onEvent("RNIDE_fastRefreshStarted", () => {
       this.deviceSessionDelegate.onAppEvent("fastRefreshStarted", undefined);
     });
-    this.devtools.onEvent("RNIDE_fastRefreshComplete", () => {
+    devtools.onEvent("RNIDE_fastRefreshComplete", () => {
       this.deviceSessionDelegate.onAppEvent("fastRefreshComplete", undefined);
     });
     return devtools;


### PR DESCRIPTION
A last minute addition I made in #1110 introduced a regression where the device session fails to start. The reason was that I extracted code that was meant to control creating devtools instance, but it should not rely on the devtools instance already set on `this` but rather the new devtools instance created in that method.

### How Has This Been Tested: 
1. Start any project, see the panel launches normally. Before the panel would get start on 'initializing device" step.


