### PR TITLE
fix debugger always restarting after app reload

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -339,6 +339,13 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
   }
 
   private async ping() {
+    // NOTE: This is a temporary workaround to avoid issues with source maps
+    // breaking after a JS reload happens.
+    // This causes the debugger session to always restart after a JS reload happens.
+    const ALWAYS_FAIL = true;
+    if (ALWAYS_FAIL) {
+      return false;
+    }
     if (!this.cdpSession) {
       Logger.warn("[DebugAdapter] [ping] The CDPSession was not initialized yet");
       return;

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -385,7 +385,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
           this.sendEvent(new Event("RNIDE_profilingCPUStopped", { filePath }));
         }
         break;
-      case "RNIDE_ping":
+      case "RNIDE_respondsAfterJsRestart":
         response.body.result = await this.ping();
         break;
       default:

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -339,13 +339,6 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
   }
 
   private async ping() {
-    // NOTE: This is a temporary workaround to avoid issues with source maps
-    // breaking after a JS reload happens.
-    // This causes the debugger session to always restart after a JS reload happens.
-    const ALWAYS_FAIL = true;
-    if (ALWAYS_FAIL) {
-      return false;
-    }
     if (!this.cdpSession) {
       Logger.warn("[DebugAdapter] [ping] The CDPSession was not initialized yet");
       return;
@@ -386,6 +379,13 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
         }
         break;
       case "RNIDE_respondsAfterJsRestart":
+        // NOTE: This is a temporary workaround to avoid issues with source maps
+        // breaking after a JS reload happens.
+        // This causes the debugger session to always restart after a JS reload happens.
+        const ALWAYS_FAIL = true;
+        if (ALWAYS_FAIL) {
+          return false;
+        }
         response.body.result = await this.ping();
         break;
       default:

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -197,10 +197,12 @@ export class DebugSession implements Disposable {
       return false;
     }
     const resultPromise = this.jsDebugSession.customRequest("RNIDE_ping").then((response) => {
-      return !!response.body.result;
+      return !!response.result;
     });
-    const timeout = sleep(PING_TIMEOUT).then(() => false);
-    return Promise.any([resultPromise, timeout]);
+    const timeout = sleep(PING_TIMEOUT).then(() => {
+      throw new Error("Ping timeout");
+    });
+    return Promise.race([resultPromise, timeout]).catch((_e) => false);
   }
 
   public async startProfilingCPU() {

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -196,9 +196,11 @@ export class DebugSession implements Disposable {
     if (!this.jsDebugSession) {
       return false;
     }
-    const resultPromise = this.jsDebugSession.customRequest("RNIDE_ping").then((response) => {
-      return !!response.result;
-    });
+    const resultPromise = this.jsDebugSession
+      .customRequest("RNIDE_respondsAfterJsRestart")
+      .then((response) => {
+        return !!response.result;
+      });
     const timeout = sleep(PING_TIMEOUT).then(() => {
       throw new Error("Ping timeout");
     });

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -294,7 +294,7 @@ export class ProxyDebugAdapter extends DebugSession {
       case "RNIDE_stopProfiling":
         await this.stopProfiling();
         break;
-      case "RNIDE_ping":
+      case "RNIDE_respondsAfterJsRestart":
         response.body.result = await this.ping();
         break;
     }

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -238,12 +238,20 @@ export class ProxyDebugAdapter extends DebugSession {
 
   private async ping() {
     try {
-      const result = await this.cdpProxy.injectDebuggerCommand({
+      const response = await this.cdpProxy.injectDebuggerCommand({
         method: "Runtime.evaluate",
         params: {
           expression: "('ping')",
         },
       });
+      if (
+        !("result" in response) ||
+        typeof response.result !== "object" ||
+        response.result === null
+      ) {
+        return false;
+      }
+      const result = response.result;
       if ("value" in result && result.value === "ping") {
         return true;
       }


### PR DESCRIPTION
Currently, the logic for reconnecting the debugger after the application is reloaded always restarts the debug session.
This was uncaught since the behaviour is _technically correct_ (in that in the end, we'll always have a debug session connected to the application after reload), but undesirable (we'd rather reuse the existing debug session since its initialization is relatively slow).
This PR fixes the minor bugs which caused the issue.

Right now, after this fix is applied, the current debugger implementation breaks after JS reload, presumably due to issues with how source maps are cleaned up.
This surfaces by not mapping the sources correctly in the Debug Console (instead always mapping to `__source__`)
This PR also makes the debug session always restart on the old debugger as a workaround for that issue.

### How Has This Been Tested: 
- use the `PROXY_JS_DEBUGGER_TYPE` in `DebugSession.startJSDebugSession` to enable the new `js-debug`-based debugger
- add log points to `DeviceSession.reconnectJSDebuggerIfNeeded`
- check that after "Reload JS" is triggered in Radon, the function returns early (without calling `this.connectJSDebugger`)