### PR TITLE
Correct sim server binary name when fetching from releases

### DIFF
--- a/packages/vscode-extension/scripts/build-sim-server-debug.sh
+++ b/packages/vscode-extension/scripts/build-sim-server-debug.sh
@@ -16,13 +16,13 @@ latest_tag=$(git describe --tags --abbrev=0)
 download_base_url="https://github.com/software-mansion/radon-ide/releases/download/${latest_tag}/"
 
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
-    product_path="$output_dir/simulator-server-${latest_tag}-windows.exe"
+    product_path="$output_dir/simulator-server-windows.exe"
     download_url="${download_base_url}simulator-server-windows.exe"
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    product_path="$output_dir/simulator-server-${latest_tag}-macos"
+    product_path="$output_dir/simulator-server-macos"
     download_url="${download_base_url}simulator-server-macos"
 else
-    product_path="$output_dir/simulator-server-${latest_tag}-linux"
+    product_path="$output_dir/simulator-server-linux"
     download_url="${download_base_url}simulator-server-linux"
 fi
 


### PR DESCRIPTION
This PR fixes the Github URL from which the simulation server is fetched when running `build-sim-server-debug.sh` on development setup. In the previous version, the script tried to download from `https://github.com/software-mansion/radon-ide/releases/download/<version>/simulator-server-<version>-<platform>`, but the file name doesn't contain the version tag.

### How Has This Been Tested: 

Following the steps specified on the [Development](https://ide.swmansion.com/docs/guides/development) docs page, run `npm run build:sim-server-debug`. The server binary is now being fetched successfully.

