### PR TITLE
Add expo router support for expo 53

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -67,6 +67,8 @@ function transformWrapper({ filename, src, ...rest }) {
       src = `${src};require("__RNIDE_lib__/expo_router_v2_plugin.js");`;
     } else if (version.startsWith("3.") || version.startsWith("4.")) {
       src = `${src};require("__RNIDE_lib__/expo_router_plugin.js");`;
+    } else if (version.startsWith("5.")) {
+      src = `${src};require("__RNIDE_lib__/expo_router_v5_plugin.js");`;
     }
   } else if (
     isTransforming("node_modules/react-native-ide/index.js") || // using react-native-ide for compatibility with old NPM package name

--- a/packages/vscode-extension/lib/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v5_plugin.js
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { useRouter } from "expo-router";
+import { store, useRouteInfo } from "expo-router/build/global-state/router-store.js";
+
+function computeRouteIdentifier(pathname, params) {
+  return pathname + JSON.stringify(params);
+}
+
+function useRouterPluginMainHook({ onNavigationChange }) {
+  const router = useRouter();
+  const routeInfo = useRouteInfo()
+
+  const pathname = routeInfo?.pathname;
+  const params = routeInfo?.params;
+
+  const filteredParams = params ?? {};
+  delete filteredParams.__EXPO_ROUTER_key;
+
+  const displayParams = new URLSearchParams(filteredParams).toString();
+  const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
+
+  useEffect(() => {
+    onNavigationChange({
+      name: displayName,
+      pathname,
+      params,
+      id: computeRouteIdentifier(pathname, params),
+    });
+  }, [pathname, params]);
+
+  function requestNavigationChange({ pathname, params }) {
+    router.navigate(pathname);
+    router.setParams(params);
+  }
+
+  return {
+    getCurrentNavigationDescriptor: () => {
+      const snapshot = store.getRouteInfo();
+      return {
+        name: snapshot.pathname,
+        pathname: snapshot.pathname,
+        params: snapshot.params,
+        id: computeRouteIdentifier(snapshot.pathname, snapshot.params),
+      };
+    },
+    requestNavigationChange: (navigationDescriptor) => {
+      if (store.navigationRef?.isReady()) {
+        requestNavigationChange(navigationDescriptor);
+      } else {
+        const onReady = () => {
+          requestNavigationChange(navigationDescriptor);
+          store.navigationRef?.removeListener("state", onReady);
+        };
+        store.navigationRef?.addListener("state", onReady);
+      }
+    },
+  };
+}
+
+global.__RNIDE_register_navigation_plugin &&
+  global.__RNIDE_register_navigation_plugin("expo-router", { mainHook: useRouterPluginMainHook });


### PR DESCRIPTION
Recently expo released a new version in witch they changed their internal api located in `expo-router/build/global-state/router-store.js`. to acomodate that we add a new `expo_router_v5_plugin.js` and attach it to expo-router entry via our `babel_transformer`

### How Has This Been Tested: 

-run `expo-53` test app and test expo router functionality 


