### PR TITLE
Add support for expo go in expo 53

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -231,7 +231,12 @@ export class Metro {
     const newDebuggerPages = this.filterNewDebuggerPages(listJson);
     if (newDebuggerPages.length > 0) {
       const description = newDebuggerPages[0].description;
-      const isExpoGo = description === EXPO_GO_BUNDLE_ID || description === EXPO_GO_PACKAGE_NAME;
+      const appId = newDebuggerPages[0]?.appId;
+      const isExpoGo =
+        description === EXPO_GO_BUNDLE_ID ||
+        description === EXPO_GO_PACKAGE_NAME ||
+        appId === EXPO_GO_BUNDLE_ID ||
+        appId === EXPO_GO_PACKAGE_NAME;
       if (isExpoGo) {
         // Expo go apps using the new debugger could report more then one page,
         // if it exist the first one being the Expo Go host runtime.


### PR DESCRIPTION
In RN 77 there were changes to how runtimes descriptions are generated that we addressed in #864. As the new expo go on expo-53 is using a newer version of react native those changes where interfering with how we recognize that the runtime is expo-go, this PR fixes that by additionally using `appId` filed missing from older versions. 

### How Has This Been Tested: 

-Run  `expo-53` test app in expo go mode (without prebuilt) and test debugger on ios



