### PR TITLE
Fix js debug startup delay and reenable js-debug for new debugger targets

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -9,11 +9,6 @@ const PING_TIMEOUT = 1000;
 
 const MASTER_DEBUGGER_TYPE = "com.swmansion.react-native-debugger";
 const OLD_JS_DEBUGGER_TYPE = "com.swmansion.js-debugger";
-
-// vscode-js-debug based debugger implementation is disabled for now because
-// of a very slow initialization times. We force the use of the original
-// debug adapter implementation here.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const PROXY_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
 
 export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
@@ -141,7 +136,7 @@ export class DebugSession implements Disposable {
     }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
-    const debuggerType = OLD_JS_DEBUGGER_TYPE;
+    const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
     this.jsDebugSession = await startDebugging(
       undefined,

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -160,7 +160,10 @@ export class ProxyDebugAdapter extends DebugSession {
           continueOnAttach: true,
           sourceMapPathOverrides: args.sourceMapPathOverrides,
           resolveSourceMapLocations: ["**", "!**/node_modules/!(expo)/**"],
-          skipFiles: this.session.configuration.skipFiles,
+          // NOTE: setting skipFiles increases startup time _significantly_, so we omit them until we figure out
+          // how to work around this problem
+          skipFiles: [],
+          outFiles: [],
         },
         {
           suppressDebugStatusbar: true,

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -59,7 +59,10 @@ export class ProxyDebugAdapter extends DebugSession {
       sourceMapAliases
     );
 
-    const proxyDelegate = new RadonCDPProxyDelegate(this.sourceMapRegistry);
+    const proxyDelegate = new RadonCDPProxyDelegate(
+      this.sourceMapRegistry,
+      this.session.configuration.skipFiles
+    );
 
     this.cdpProxy = new CDPProxy(
       "127.0.0.1",

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -4,12 +4,13 @@ import _ from "lodash";
 import { CDPProxyDelegate, ProxyTunnel } from "./CDPProxy";
 import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { Logger } from "../Logger";
+import { Minimatch } from "minimatch";
 
 export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   private debuggerPausedEmitter = new EventEmitter<{ reason: "breakpoint" | "exception" }>();
   private debuggerResumedEmitter = new EventEmitter();
   private consoleAPICalledEmitter = new EventEmitter();
-  private blackBoxPatterns: RegExp[] = [];
+  private ignoredPatterns: Minimatch[] = [];
 
   private justCalledStepOver = false;
   private resumeEventTimeout: NodeJS.Timeout | undefined;
@@ -18,7 +19,12 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   public onDebuggerResumed = this.debuggerResumedEmitter.event;
   public onConsoleAPICalled = this.consoleAPICalledEmitter.event;
 
-  constructor(private sourceMapRegistry: SourceMapsRegistry) {}
+  constructor(
+    private sourceMapRegistry: SourceMapsRegistry,
+    patterns: string[]
+  ) {
+    this.ignoredPatterns = patterns.map((pattern) => new Minimatch(pattern));
+  }
 
   public async handleApplicationCommand(
     applicationCommand: IProtocolCommand,
@@ -55,7 +61,15 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       lineNumber + 1,
       columnNumber ?? 0
     );
-    const shouldSkipFile = this.blackBoxPatterns.some((p) => p.exec(sourceURL)?.length);
+    const shouldSkipFile = this.ignoredPatterns.reduce((shouldSkip, p) => {
+      if (p.negate) {
+        // if a negated pattern is _not_ matched (meaning the path matches the _negated_ part of the pattern),
+        // the file should not be skipped (unless it matches some further pattern)
+        return shouldSkip && p.match(sourceURL);
+      } else {
+        return shouldSkip || p.match(sourceURL);
+      }
+    }, false);
     return shouldSkipFile;
   }
 
@@ -128,10 +142,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         return command;
       }
       // NOTE: setBlackbox* commands (as of 0.78) are not handled correctly by the Hermes debugger, so we need to disable them.
-      // Instead, we handle exception pauses in the blackboxed files explicitely in the `handleDebuggerPaused` method.
       case "Debugger.setBlackboxPatterns": {
-        const params = command.params as Cdp.Debugger.SetBlackboxPatternsParams;
-        this.blackBoxPatterns = params.patterns.map((p) => new RegExp(p));
         command.params = {
           patterns: [],
         };

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -125,7 +125,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
     command: IProtocolCommand,
     tunnel: ProxyTunnel
   ): Promise<IProtocolCommand> {
-    switch (command.method) {
+    const { method } = command;
+    switch (method) {
       case "Debugger.stepOver": {
         // setting this will cause the "resume" event from being slightly delayed as we
         // expect the "paused" event to be fired almost immediately.

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -21,9 +21,9 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
 
   constructor(
     private sourceMapRegistry: SourceMapsRegistry,
-    patterns: string[]
+    skipFiles: string[]
   ) {
-    this.ignoredPatterns = patterns.map((pattern) => new Minimatch(pattern));
+    this.ignoredPatterns = skipFiles.map((pattern) => new Minimatch(pattern, { flipNegate: true }));
   }
 
   public async handleApplicationCommand(
@@ -63,9 +63,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
     );
     const shouldSkipFile = this.ignoredPatterns.reduce((shouldSkip, p) => {
       if (p.negate) {
-        // if a negated pattern is _not_ matched (meaning the path matches the _negated_ part of the pattern),
-        // the file should not be skipped (unless it matches some further pattern)
-        return shouldSkip && p.match(sourceURL);
+        // don't skip the file if some negated pattern matches it
+        return shouldSkip && !p.match(sourceURL);
       } else {
         return shouldSkip || p.match(sourceURL);
       }


### PR DESCRIPTION
This PR fixes the issue of _excruciatingly_ long debug startup on larger applications when using the `js-debug`-based debugger implementation and reenables it for React Native apps using the new ("Fusebox") debugger.

It also updates the version of `js-debug` used and applies patches which should improve startup performance in the React Native case, as described in the PR: https://github.com/software-mansion-labs/vscode-js-debug/pull/4

### How Has This Been Tested: 
- launch `social-app` (or another large application)
- set some breakpoints
- restart the application a couple of times in various ways (JS reload, full app restart, IDE restart)
- verify that the delay before the set breakpoints are active (indicated in the UI by the breakpoint dot turning red) takes on the order of seconds, and not tens-of-seconds


