### PR TITLE
Fix CDP debug session always restarting on JS reload

### DIFF
--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -379,13 +379,6 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
         }
         break;
       case "RNIDE_respondsAfterJsRestart":
-        // NOTE: This is a temporary workaround to avoid issues with source maps
-        // breaking after a JS reload happens.
-        // This causes the debugger session to always restart after a JS reload happens.
-        const ALWAYS_FAIL = true;
-        if (ALWAYS_FAIL) {
-          return false;
-        }
         response.body.result = await this.ping();
         break;
       default:

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -378,7 +378,7 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
           this.sendEvent(new Event("RNIDE_profilingCPUStopped", { filePath }));
         }
         break;
-      case "RNIDE_respondsAfterJsRestart":
+      case "RNIDE_ping":
         response.body.result = await this.ping();
         break;
       default:

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -169,6 +169,10 @@ export class CDPSession {
 
         // inform debug adapter that context was Cleared
         this.delegate.onExecutionContextsCleared();
+
+        // since we cleared the source maps, we should wait for the next main bundle to be loaded
+        // before we can start sending console logs to the debug adapter
+        this.debugSessionReady = false;
         break;
       case "Runtime.consoleAPICalled":
         if (this.debugSessionReady) {

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -196,11 +196,9 @@ export class DebugSession implements Disposable {
     if (!this.jsDebugSession) {
       return false;
     }
-    const resultPromise = this.jsDebugSession
-      .customRequest("RNIDE_respondsAfterJsRestart")
-      .then((response) => {
-        return !!response.result;
-      });
+    const resultPromise = this.jsDebugSession.customRequest("RNIDE_ping").then((response) => {
+      return !!response.result;
+    });
     const timeout = sleep(PING_TIMEOUT).then(() => {
       throw new Error("Ping timeout");
     });

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -294,7 +294,7 @@ export class ProxyDebugAdapter extends DebugSession {
       case "RNIDE_stopProfiling":
         await this.stopProfiling();
         break;
-      case "RNIDE_respondsAfterJsRestart":
+      case "RNIDE_ping":
         response.body.result = await this.ping();
         break;
     }


### PR DESCRIPTION
This PR fixes the issue mentioned in #1120 by waiting for the new main bundle to load before logging to console after a JS reload.

### How Has This Been Tested: 
- add log points to `DeviceSession.reconnectJSDebuggerIfNeeded`
- check that after "Reload JS" is triggered in Radon, the function returns early (without calling `this.connectJSDebugger`)
- check that logs in the "Debug Console" are mapped to the source correctly