### PR TITLE
fix debugger not ignoring injected files correctly

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { disposeAll } from "../utilities/disposables";
 import { sleep } from "../utilities/retry";
 import { startDebugging } from "./startDebugging";
+import { extensionContext } from "../utilities/extensionContext";
 
 const PING_TIMEOUT = 1000;
 
@@ -138,6 +139,8 @@ export class DebugSession implements Disposable {
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
     const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
+    const extensionPath = extensionContext.extensionUri.path;
+
     this.jsDebugSession = await startDebugging(
       undefined,
       {
@@ -151,10 +154,7 @@ export class DebugSession implements Disposable {
         displayDebuggerOverlay: configuration.displayDebuggerOverlay,
         skipFiles: [
           "__source__",
-          "**/extension/lib/**/*.js",
-          "**/vscode-extension/lib/**/*.js",
-          "**/ReactFabric-dev.js",
-          "**/ReactNativeRenderer-dev.js",
+          `${extensionPath}/**/*`,
           "**/node_modules/**/*",
           "!**/node_modules/expo-router/**/*",
         ],

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -23,7 +23,9 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
     private sourceMapRegistry: SourceMapsRegistry,
     skipFiles: string[]
   ) {
-    this.ignoredPatterns = skipFiles.map((pattern) => new Minimatch(pattern, { flipNegate: true }));
+    this.ignoredPatterns = skipFiles.map(
+      (pattern) => new Minimatch(pattern, { flipNegate: true, dot: true })
+    );
   }
 
   public async handleApplicationCommand(


### PR DESCRIPTION
Due to the difference in paths between development mode and packaged extensions, the `lib/` directory of the extension was not correctly ignored when the extension was installed from a package (rather than running in the Extension Development Host).
This PR fixes that.

### How was this tested?
- build an install an extension `.vsix` package
- open a test app from `radon-ide-test-apps`
- check "Uncaught exceptions" breakpoint
- click the "Check uncaught exceptions" button
- verify the debugger doesn't pause inside RN renderer