### PR TITLE
downgrade vscode types package

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -39,7 +39,7 @@
         "@types/sinon": "^17.0.4",
         "@types/tar": "^6.1.13",
         "@types/uuid": "^10.0.0",
-        "@types/vscode": "^1.99.1",
+        "@types/vscode": "^1.75.0",
         "@types/ws": "^8.18.1",
         "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.30.1",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -756,7 +756,7 @@
     "@types/sinon": "^17.0.4",
     "@types/tar": "^6.1.13",
     "@types/uuid": "^10.0.0",
-    "@types/vscode": "^1.99.1",
+    "@types/vscode": "^1.75.0",
     "@types/ws": "^8.18.1",
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.30.1",


### PR DESCRIPTION
Downgrades the vscode API type definitions to the version which matches the targeted VSCode version (as specified by `engines.vscode` in `package.json`).