### PR TITLE
Fix reload after bundle error

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -229,6 +229,7 @@ export class DeviceSession implements Disposable {
     if (this.devtools.hasConnectedClient) {
       try {
         await this.reloadMetro();
+        this.isLaunching = false;
         return true;
       } catch (e) {
         Logger.error("Failed to reload JS", e);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -229,7 +229,6 @@ export class DeviceSession implements Disposable {
     if (this.devtools.hasConnectedClient) {
       try {
         await this.reloadMetro();
-        this.isLaunching = false;
         return true;
       } catch (e) {
         Logger.error("Failed to reload JS", e);

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -133,7 +133,7 @@ function BundleErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          deviceSessionsManager.reload("autoReload");
+          deviceSessionsManager.reload("restartProcess");
         }}
         tooltip={{ label: "Reload Metro", side: "bottom" }}>
         <span className="codicon codicon-refresh" />


### PR DESCRIPTION
This PR fixes an issue with how launch completion was reported that prevented users from using preview functionality in the following scenario:
- cause a bundle error 
- try to reload in that state 
- fix the bundle error 
- run auto-reload 
- now the app is launched but `isLaunching` prop is set to `true`


### How Has This Been Tested: 

run the reproduction and check if it works



