### PR TITLE
Fix build error dialog not appearing on reload

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -78,6 +78,15 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
     } catch (e) {
       if (e instanceof CancelError) {
         return false;
+      } else if (e instanceof BuildError) {
+        this.updateProjectState({
+          status: "buildError",
+          buildError: {
+            message: e.message,
+            buildType: e.buildType,
+            platform: this.selectedDeviceSession.platform,
+          },
+        });
       }
       Logger.error("Failed to reload device", e);
       throw e;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -117,6 +117,10 @@ export class DeviceSession implements Disposable {
     return this.device.previewURL;
   }
 
+  public get platform(): DevicePlatform {
+    return this.device.platform;
+  }
+
   constructor(
     private readonly appRootFolder: string,
     private readonly device: DeviceBase,

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -507,7 +507,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   async resetAppPermissions(permissionType: AppPermissionType) {
     const needsRestart = await this.deviceSession?.resetAppPermissions(permissionType);
     if (needsRestart) {
-      this.deviceSessionsManager.reload("restartProcess");
+      await this.deviceSessionsManager.reload("restartProcess");
     }
   }
 


### PR DESCRIPTION
Currently, when a build error happens during a reload, we fail to display the error dialog, instead hanging on "Building...".
The root cause was us not catching the error in `DeviceSessionsManager.reload`, meaning we never set the project state to "build error".
This PR fixes that.

### How Has This Been Tested: 
- have an app which fails to build
- open it in Radon
- wait for the build to fail
- reload the app (either from the error dialog or with the Reload button in the URL bar)
- the build error dialog should appear again <- previously, the build would appear to hang instead


