### PR TITLE
Fix Navigation from preview on expo go

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -252,10 +252,11 @@ export function AppWrapper({ children, initialProps, fabric }) {
         rootTag,
         initialProps: {
           __RNIDE_onLayout: () => {
+            const originalClosePromiseResolve = closePromiseResolve;
             const layoutPromise = new Promise((resolve) => {
               closePromiseResolve = resolve;
             });
-            closePromiseResolve(layoutPromise);
+            originalClosePromiseResolve(() => layoutPromise);
           },
         },
         fabric,
@@ -312,19 +313,20 @@ export function AppWrapper({ children, initialProps, fabric }) {
       }
       const navigationDescriptor = navigationHistory.get(payload.id);
 
-      let layoutPromise = closePreview();
+      let layoutPromise = closePreview;
 
       let tryCount = 0;
 
       async function navigate() {
         tryCount++;
-        layoutPromise = await layoutPromise;
+        layoutPromise = await layoutPromise();
         try {
           navigationDescriptor && requestNavigationChange(navigationDescriptor);
         } catch (e) {
           if (tryCount >= MAX_NAVIGATION_RETRY_COUNT) {
             throw e;
           }
+          console.log("frytki")
           navigate();
         }
       }


### PR DESCRIPTION
_Why is this a draft? 
This approach is not quite correct as the navigation is not propagated from the place the navigation is requested_

This PR solves an issue of expo router throwing an error when navigating from a preview to main application with a use of urlBar feature on expo go. The problem does not appear consistently, so it might be hard to reproduce, but here is a reproduction that worked for us sometimes:
- run `expo-53`  test app
- select preview from `mainScreen` 
- use urlBar to navigate home

This problem is caused by components necessary for navigation not being rendered on time. We previously 
tried to mitigate this by awaiting `onLayout` event in our `AppWrapper` component, unfortunately it seems that is nome setups (namely in expo go) layout is calculated twice on first run of the application and the first one being complete does not indicate that navigation is ready. To combat that issue we implement retry logic into navigation function that allows to try on the second layout if the first was not ready yet. 

### How Has This Been Tested: 

Run the reproduction from the description 



