### PR TITLE
Fix debug session sticking around after unsucesful restarts

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -23,7 +23,7 @@ import { throttle } from "../utilities/throttle";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildCache } from "../builders/BuildCache";
-import { CancelToken } from "../builders/cancelToken";
+import { CancelError, CancelToken } from "../builders/cancelToken";
 import { DevicePlatform } from "../common/DeviceManager";
 import { ToolsDelegate, ToolsManager } from "./tools";
 import { extensionContext } from "../utilities/extensionContext";
@@ -330,6 +330,11 @@ export class DeviceSession implements Disposable {
         this.deviceSessionDelegate.onReloadCompleted(this.device.deviceInfo.id);
       }
     } catch (e) {
+      if (e instanceof CancelError) {
+        // when restart process is cancelled, we don't want to fallback into
+        // restarting the session again
+        return;
+      }
       // finally in case of any errors, the last resort is performing project
       // restart and device selection (we still avoid forcing clean builds, and
       // only do clean build when explicitly requested).


### PR DESCRIPTION
This problem fixes issue introduced in #1084 where we started handling cancellation for restart tasks. This issue results in debug session sticking around in certain condition and here is why:

1. When we restart the process we use cancel tokens to cancel previous restarts
2. When there's a bundle error, the restart logic await in `restartProcess` that never resolves
3. On subsequent restart, we'd cancel the token that results in the previous `restartProcess` awaiting, this causes the `restartProcess` promise to reject
4. Since we have the logic in place that after an error in `restartProcess` triggers `restart` call again in the catch block, cancelling that previous token results in two restart calls being called in parallel
5. This in turn results in two debug session being created while only one is assigned to `parentDebugSession` in DebugSession.ts
6. Finally, we never stop one of those sessions.

### How Has This Been Tested: 
1. Run RN-78 example on iOS
2. Cause bundle error
3. Click "reload" without fixing bundle error
4. Do that several times
5. Before this fix, we'd end up seeing a dozen of debug session being listed under "Debug Output" panel. Now we only see the ones that are active.
6. After fixing the error eventually, there should remain only one debug session