### PR TITLE
Change the default failed biometric auth keybind

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -136,8 +136,8 @@
       },
       {
         "command": "RNIDE.performFailedBiometricAuthorization",
-        "key": "ctrl+shift+N",
-        "mac": "cmd+shift+N"
+        "key": "ctrl+alt+shift+M",
+        "mac": "cmd+alt+shift+M"
       },
       {
         "command": "RNIDE.deviceHomeButtonPress",


### PR DESCRIPTION
Currently, we set the default keyboard shortcut for "Perform failed biometric authorization" action to "Cmd+Shift+N" (or "Ctrl+Shift+N" on windows), which conflicts with the default vscode "Open new window" shortcut.
Since opening a new window is an action which many users rely on in their usual workflows, this is undesirable.
This PR changes the default keybind to a less-likely-to-conflict "Cmd+Option+Shift+M" (which is "Perform biometric authorization" + "Shift").
Fixes #1039 

### How Has This Been Tested: 
- open a project in Radon IDE
- press "Cmd+Shift+N"
- a new vscode window should open (provided you use the default keybind)