### PR TITLE
Improve window management

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -19,7 +19,8 @@
     "workspaceContains:**/metro.config.js",
     "workspaceContains:**/metro.config.ts",
     "workspaceContains:**/app.config.js",
-    "workspaceContains:**/app.config.ts"
+    "workspaceContains:**/app.config.ts",
+    "onWebviewPanel:RadonIDETabPanel"
   ],
   "version": "1.6.0",
   "engines": {
@@ -169,10 +170,9 @@
           "default": "tab",
           "enum": [
             "tab",
-            "side-panel",
-            "secondary-side-panel"
+            "side-panel"
           ],
-          "description": "Controls location of the IDE panel. Due to vscode API limitations, when secondary side panel is selected, you need to manually move the IDE panel to the secondary side panel. Changing this option closes and reopens the IDE."
+          "description": "Controls the location of the Radon IDE panel. When side-panel is selected, you can use right-click menu on the panel to move it to the secondary side panel if you wish."
         },
         "RadonIDE.themeType": {
           "type": "string",

--- a/packages/vscode-extension/src/common/WorkspaceConfig.ts
+++ b/packages/vscode-extension/src/common/WorkspaceConfig.ts
@@ -1,4 +1,4 @@
-export type PanelLocation = "tab" | "side-panel" | "secondary-side-panel";
+export type PanelLocation = "tab" | "side-panel";
 export type ThemeType = "vscode" | "built-in";
 
 export type WorkspaceConfigProps = {

--- a/packages/vscode-extension/src/common/utils.ts
+++ b/packages/vscode-extension/src/common/utils.ts
@@ -9,6 +9,8 @@ export interface UtilsEventMap {
   telemetryEnabledChanged: boolean;
 }
 
+export type IDEPanelMoveTarget = "new-window" | "editor-tab" | "side-panel";
+
 export interface UtilsInterface {
   getCommandsCurrentKeyBinding(commandName: string): Promise<string | undefined>;
 
@@ -18,7 +20,7 @@ export interface UtilsInterface {
 
   saveMultimedia(multimediaData: MultimediaData): Promise<boolean>;
 
-  movePanelTo(location: "new-window" | "editor-tab" | "side-panel"): Promise<void>;
+  movePanelTo(location: IDEPanelMoveTarget): Promise<void>;
 
   showDismissableError(errorMessage: string): Promise<void>;
 

--- a/packages/vscode-extension/src/common/utils.ts
+++ b/packages/vscode-extension/src/common/utils.ts
@@ -18,7 +18,7 @@ export interface UtilsInterface {
 
   saveMultimedia(multimediaData: MultimediaData): Promise<boolean>;
 
-  movePanelToNewWindow(): Promise<void>;
+  movePanelTo(location: "new-window" | "editor-tab" | "side-panel"): Promise<void>;
 
   showDismissableError(errorMessage: string): Promise<void>;
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -33,6 +33,7 @@ import { registerChat } from "./chat";
 import { ProxyDebugSessionAdapterDescriptorFactory } from "./debugging/ProxyDebugAdapter";
 import { Connector } from "./connect/Connector";
 import { ReactDevtoolsEditorProvider } from "./react-devtools-profiler/ReactDevtoolsEditorProvider";
+import { IDEPanelMoveTarget } from "./common/utils";
 
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
 
@@ -87,8 +88,12 @@ export async function activate(context: ExtensionContext) {
 
   commands.executeCommand("setContext", "RNIDE.sidePanelIsClosed", false);
 
+  // this flag is used to prevent re-entry for showIDEPanel method, inside this method
+  // we update the configuration, and this method is also called as a result of configuration
+  // change such that we can monitor the changes that users make directly from the VSCode settings
   let updatingConfigProgrammatically = false;
-  async function showIDEPanel(newLocation?: "editor-tab" | "new-window" | "side-panel") {
+
+  async function showIDEPanel(newLocation?: IDEPanelMoveTarget) {
     if (updatingConfigProgrammatically) {
       return;
     }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -9,7 +9,6 @@ import {
   ConfigurationChangeEvent,
   DebugConfigurationProviderTriggerKind,
   DebugAdapterExecutable,
-  Disposable,
 } from "vscode";
 import vscode from "vscode";
 import { activate as activateJsDebug } from "vscode-js-debug/dist/src/extension";
@@ -210,35 +209,6 @@ export async function activate(context: ExtensionContext) {
     commands.registerCommand("RNIDE.captureScreenshot", captureScreenshot)
   );
   context.subscriptions.push(commands.registerCommand("RNIDE.openChat", openChat));
-
-  async function closeAuxiliaryBar(registeredCommandDisposable: Disposable) {
-    registeredCommandDisposable.dispose(); // must dispose to avoid endless loops
-
-    const wasIDEPanelVisible = SidePanelViewProvider.currentProvider?.view?.visible;
-
-    // run the built-in closeAuxiliaryBar command
-    await commands.executeCommand("workbench.action.closeAuxiliaryBar");
-
-    const isIDEPanelVisible = SidePanelViewProvider.currentProvider?.view?.visible;
-
-    // if closing of Auxiliary bar affected the visibility of SidePanelView, we assume that it means that it was pinned to the secondary sidebar.
-    if (wasIDEPanelVisible && !isIDEPanelVisible) {
-      commands.executeCommand("RNIDE.closePanel");
-    }
-
-    // re-register to continue intercepting closeAuxiliaryBar commands
-    registeredCommandDisposable = commands.registerCommand(
-      "workbench.action.closeAuxiliaryBar",
-      async (arg) => closeAuxiliaryBar(registeredCommandDisposable)
-    );
-    context.subscriptions.push(registeredCommandDisposable);
-  }
-
-  let closeAuxiliaryBarDisposable = commands.registerCommand(
-    "workbench.action.closeAuxiliaryBar",
-    async (arg) => closeAuxiliaryBar(closeAuxiliaryBarDisposable)
-  );
-  context.subscriptions.push(closeAuxiliaryBarDisposable);
 
   // Debug adapter used by custom launch configuration, we register it in case someone tries to run the IDE configuration
   // The current workflow is that people shouldn't run it, but since it is listed under launch options it might happen

--- a/packages/vscode-extension/src/panels/SidepanelViewProvider.ts
+++ b/packages/vscode-extension/src/panels/SidepanelViewProvider.ts
@@ -5,7 +5,6 @@ import {
   WebviewView,
   WebviewViewProvider,
   commands,
-  workspace,
 } from "vscode";
 import { generateWebviewContent } from "./webviewContentGenerator";
 import { WebviewController } from "./WebviewController";
@@ -42,9 +41,6 @@ export class SidePanelViewProvider implements WebviewViewProvider, Disposable {
   public static showView() {
     if (SidePanelViewProvider.currentProvider) {
       commands.executeCommand(`${SidePanelViewProvider.viewType}.focus`);
-      if (workspace.getConfiguration("RadonIDE").get("panelLocation") === "secondary-side-panel") {
-        commands.executeCommand("workbench.action.focusAuxiliaryBar");
-      }
     } else {
       Logger.error("SidepanelViewProvider does not exist.");
       return;

--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -8,6 +8,7 @@ import {
   workspace,
   ConfigurationChangeEvent,
   Disposable,
+  WebviewPanelSerializer,
 } from "vscode";
 
 import { extensionContext } from "../utilities/extensionContext";
@@ -16,9 +17,8 @@ import { WebviewController } from "./WebviewController";
 import { disposeAll } from "../utilities/disposables";
 import { PREVIEW_WEBVIEW_NAME, PREVIEW_WEBVIEW_PATH } from "../webview/utilities/constants";
 
-const OPEN_PANEL_ON_ACTIVATION = "open_panel_on_activation";
-
 export class TabPanel implements Disposable {
+  public static readonly viewType = "RadonIDETabPanel";
   public static currentPanel: TabPanel | undefined;
   private readonly _panel: WebviewPanel;
   private disposables: Disposable[] = [];
@@ -68,46 +68,74 @@ export class TabPanel implements Disposable {
     );
   }
 
-  public static render(context: ExtensionContext) {
-    if (TabPanel.currentPanel) {
-      // If the webview panel already exists reveal it
-      TabPanel.currentPanel._panel.reveal();
+  public static restore(panel: WebviewPanel) {
+    TabPanel.currentPanel?.dispose();
+    TabPanel.currentPanel = new TabPanel(panel, extensionContext);
+  }
+
+  private static showInternal(viewColumn: ViewColumn, preserveFocus: boolean) {
+    const panel = TabPanel.currentPanel;
+    if (panel) {
+      panel._panel.reveal(viewColumn, preserveFocus);
     } else {
-      // If a webview panel does not already exist create and show a new one
-
-      // If there is an empty group in the editor, we will open the panel there:
-      const emptyGroup = window.tabGroups.all.find((group) => group.tabs.length === 0);
-
-      const panel = window.createWebviewPanel(
-        "radon-ide-panel",
+      const webviewPanel = window.createWebviewPanel(
+        TabPanel.viewType,
         "Radon IDE",
-        { viewColumn: emptyGroup?.viewColumn || ViewColumn.Beside },
+        { viewColumn, preserveFocus },
         {
           enableScripts: true,
           localResourceRoots: [
-            Uri.joinPath(context.extensionUri, "dist"),
-            Uri.joinPath(context.extensionUri, "node_modules"),
+            Uri.joinPath(extensionContext.extensionUri, "dist"),
+            Uri.joinPath(extensionContext.extensionUri, "node_modules"),
           ],
           retainContextWhenHidden: true,
         }
       );
-      TabPanel.currentPanel = new TabPanel(panel, context);
-      context.workspaceState.update(OPEN_PANEL_ON_ACTIVATION, true);
+      TabPanel.restore(webviewPanel);
+    }
+  }
 
-      commands.executeCommand("workbench.action.lockEditorGroup");
+  public static async show(
+    newLocation: "editor-tab" | "new-window" | undefined,
+    preserveFocus = false
+  ) {
+    if (newLocation === "new-window") {
+      await commands.executeCommand("workbench.action.newEmptyEditorWindow");
+      // we ignore errors for the enabelCompactAuxiliaryWindow command as it only's been added
+      // in VSCode 1.100 and won't be available in older versions or VSCode forks
+      await commands
+        .executeCommand("workbench.action.enableCompactAuxiliaryWindow")
+        .then(null, () => {});
+      // we find the last empty editor group and assume it belongs to the newly opened window
+      const emptyEditorGroups = window.tabGroups.all.filter((group) => group.tabs.length === 0);
+      if (emptyEditorGroups.length > 0) {
+        const lastEmptyGroup = emptyEditorGroups[emptyEditorGroups.length - 1];
+        this.showInternal(lastEmptyGroup.viewColumn, preserveFocus);
+      }
+    } else {
+      // We can't tell whether the panel is in new window or in some horizonal/vertical group
+      // we use the following logic to handle different cases:
+      // 1. If the current panel viewColumn is > 1, this means it could be in a new window,
+      // in this case we move it to the first group
+      // 2. Alternatively, if panel doesn't exist, or it is in the first group, we
+      // use "Beside" mode to open it beside the current editor.
+      const currentViewColumn = TabPanel.currentPanel?._panel.viewColumn || 0;
+      this.showInternal(currentViewColumn > 1 ? ViewColumn.One : ViewColumn.Beside, preserveFocus);
     }
   }
 
   public dispose() {
     commands.executeCommand("setContext", "RNIDE.panelIsOpen", false);
-    // this is triggered when the user closes the webview panel by hand, we want to reset open_panel_on_activation
-    // key in this case to prevent extension from automatically opening the panel next time they open the editor
-    extensionContext.workspaceState.update(OPEN_PANEL_ON_ACTIVATION, undefined);
-
     commands.executeCommand("setContext", "RNIDE.isTabPanelFocused", false);
 
     TabPanel.currentPanel = undefined;
 
     disposeAll(this.disposables);
+  }
+}
+
+export class TabPanelSerializer implements WebviewPanelSerializer {
+  public async deserializeWebviewPanel(webviewPanel: WebviewPanel, state: any): Promise<void> {
+    TabPanel.restore(webviewPanel);
   }
 }

--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -73,7 +73,7 @@ export class TabPanel implements Disposable {
     TabPanel.currentPanel = new TabPanel(panel, extensionContext);
   }
 
-  private static showInternal(viewColumn: ViewColumn, preserveFocus: boolean) {
+  private static showInternal(viewColumn: ViewColumn | undefined, preserveFocus: boolean) {
     const panel = TabPanel.currentPanel;
     if (panel) {
       panel._panel.reveal(viewColumn, preserveFocus);
@@ -81,7 +81,7 @@ export class TabPanel implements Disposable {
       const webviewPanel = window.createWebviewPanel(
         TabPanel.viewType,
         "Radon IDE",
-        { viewColumn, preserveFocus },
+        { viewColumn: viewColumn || ViewColumn.Beside, preserveFocus },
         {
           enableScripts: true,
           localResourceRoots: [
@@ -112,15 +112,20 @@ export class TabPanel implements Disposable {
         const lastEmptyGroup = emptyEditorGroups[emptyEditorGroups.length - 1];
         this.showInternal(lastEmptyGroup.viewColumn, preserveFocus);
       }
-    } else {
+    } else if (newLocation === "editor-tab") {
       // We can't tell whether the panel is in new window or in some horizonal/vertical group
       // we use the following logic to handle different cases:
       // 1. If the current panel viewColumn is > 1, this means it could be in a new window,
       // in this case we move it to the first group
-      // 2. Alternatively, if panel doesn't exist, or it is in the first group, we
+      // 2. Alternatively, if panel doesn't exist, or it is in the first group
       // use "Beside" mode to open it beside the current editor.
       const currentViewColumn = TabPanel.currentPanel?._panel.viewColumn || 0;
       this.showInternal(currentViewColumn > 1 ? ViewColumn.One : ViewColumn.Beside, preserveFocus);
+    } else {
+      // This is called when the user doens't request a specific lcoation for the panel
+      // for example, when they trigger "show IDE panel" command from the command palette
+      // or when they switch the location from the settings.
+      this.showInternal(undefined, preserveFocus);
     }
   }
 

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { EventEmitter } from "stream";
 import fs from "fs";
 import path from "path";
-import { commands, env, ProgressLocation, Uri, window } from "vscode";
+import { commands, env, ProgressLocation, Uri, window, workspace } from "vscode";
 import JSON5 from "json5";
 import vscode from "vscode";
 import { TelemetryEventProperties } from "@vscode/extension-telemetry";
@@ -123,8 +123,8 @@ export class Utils implements UtilsInterface {
     return true;
   }
 
-  public async movePanelToNewWindow() {
-    commands.executeCommand("workbench.action.moveEditorToNewWindow");
+  public async movePanelTo(location: "new-window" | "editor-tab" | "side-panel") {
+    commands.executeCommand("RNIDE.showPanel", location);
   }
 
   public async showDismissableError(errorMessage: string) {

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -9,7 +9,12 @@ import { TelemetryEventProperties } from "@vscode/extension-telemetry";
 import { Logger } from "../Logger";
 import { extensionContext } from "./extensionContext";
 import { openFileAtPosition } from "./openFileAtPosition";
-import { UtilsEventListener, UtilsEventMap, UtilsInterface } from "../common/utils";
+import {
+  IDEPanelMoveTarget,
+  UtilsEventListener,
+  UtilsEventMap,
+  UtilsInterface,
+} from "../common/utils";
 import { Platform } from "./platform";
 import { MultimediaData } from "../common/Project";
 import { getTelemetryReporter } from "./telemetry";
@@ -123,7 +128,7 @@ export class Utils implements UtilsInterface {
     return true;
   }
 
-  public async movePanelTo(location: "new-window" | "editor-tab" | "side-panel") {
+  public async movePanelTo(location: IDEPanelMoveTarget) {
     commands.executeCommand("RNIDE.showPanel", location);
   }
 

--- a/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/SettingsDropdown.tsx
@@ -25,7 +25,7 @@ interface SettingsDropdownProps {
 function SettingsDropdown({ project, isDeviceRunning, children, disabled }: SettingsDropdownProps) {
   const { panelLocation, themeType, update } = useWorkspaceConfig();
   const { openModal } = useModal();
-  const { movePanelToNewWindow, reportIssue } = useUtils();
+  const { movePanelTo, reportIssue } = useUtils();
   const { telemetryEnabled } = useTelemetry();
 
   const extensionVersion = document.querySelector<HTMLMetaElement>(
@@ -75,7 +75,7 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-layout" />
-              Change IDE panel location
+              Change IDE location
               <span className="codicon codicon-chevron-right right-slot" />
             </DropdownMenu.SubTrigger>
             <DropdownMenu.Portal>
@@ -83,53 +83,26 @@ function SettingsDropdown({ project, isDeviceRunning, children, disabled }: Sett
                 className="dropdown-menu-subcontent"
                 sideOffset={2}
                 alignOffset={-5}>
-                <DropdownMenu.Item
-                  className="dropdown-menu-item"
-                  onSelect={() => update("panelLocation", "tab")}>
-                  <span className="codicon codicon-layout-centered" />
-                  Editor tab
-                  {panelLocation === "tab" && <span className="codicon codicon-check right-slot" />}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className="dropdown-menu-item"
-                  onSelect={() => update("panelLocation", "side-panel")}>
-                  <span className="codicon codicon-layout-sidebar-right" />
-                  Side panel
-                  {panelLocation === "side-panel" && (
-                    <span className="codicon codicon-check right-slot" />
-                  )}
-                </DropdownMenu.Item>
-                <DropdownMenu.Item
-                  className="dropdown-menu-item"
-                  onSelect={() => {
-                    update("panelLocation", "secondary-side-panel");
-                    openModal(
-                      "Drag and drop to secondary side panel",
-                      <div>
-                        Drag and drop the IDE Panel by its icon from the side bar to move it to the
-                        secondary panel.
-                      </div>
-                    );
-                  }}>
-                  <span className="codicon codicon-layout-sidebar-left" />
-                  Secondary side panel
-                  {panelLocation === "secondary-side-panel" && (
-                    <span className="codicon codicon-check right-slot" />
-                  )}
-                </DropdownMenu.Item>
-                {panelLocation === "tab" && (
-                  <>
-                    <DropdownMenu.Separator className="dropdown-menu-separator" />
-                    <DropdownMenu.Item
-                      className="dropdown-menu-item"
-                      onSelect={() => {
-                        movePanelToNewWindow();
-                      }}>
-                      <span className="codicon codicon-multiple-windows" />
-                      New Window
-                    </DropdownMenu.Item>
-                  </>
+                {panelLocation !== "side-panel" && (
+                  <DropdownMenu.Item
+                    className="dropdown-menu-item"
+                    onSelect={() => movePanelTo("side-panel")}>
+                    <span className="codicon codicon-layout-sidebar-right" />
+                    Move to Side Panel
+                  </DropdownMenu.Item>
                 )}
+                <DropdownMenu.Item
+                  className="dropdown-menu-item"
+                  onSelect={() => movePanelTo("editor-tab")}>
+                  <span className="codicon codicon-layout-centered" />
+                  Move to Editor Tab
+                </DropdownMenu.Item>
+                <DropdownMenu.Item
+                  className="dropdown-menu-item"
+                  onSelect={() => movePanelTo("new-window")}>
+                  <span className="codicon codicon-multiple-windows" />
+                  Move to New Window
+                </DropdownMenu.Item>
               </DropdownMenu.SubContent>
             </DropdownMenu.Portal>
           </DropdownMenu.Sub>


### PR DESCRIPTION
This PR improves window/panel position management. Before, when using IDE in editor panel, we'd always get the editor position structure messed up when restarting the editor. Thanks to the made changes, we can also take adventage of the new "compact" mode for new windows.

Here's what we're changing:
1. We're deleting code for handling secondary side bar. This includes the setting option etc. Due to limitation of vscode extension API, we cannot control this way and the value gets out of sync between the UI and our configuration. Going forward we have to rely on the user moving it correctly (will be updating the docs to reflect that as well).
2. The panel location now only tell whether we should use "side-bar" or "tab" mode for the IDE panel. This is the only combination that we can reliably implement. 
3. We're updating the menu option for changing the position to only list "Move to Side Bar", "Move to New Window" and "Move to Editor Tab". We hide the side bar option when we know the panel is in the side bar. The other options stay on at all time as we can still shuffle the view between tabs and windows even when the panel is already in new window or in editor tab.
4. We're removing `OPEN_PANEL_ON_ACTIVATION` in favor of using WebviewSerializer API. The Serializer API allows us to rely on VSCode to restore the window in the right place after the editor is restarted. This is much more reliable than what we had before.
5. We're changing the "showIDEPanel" logic, such that it takes the new location as parameter. Sometimes the parameter will be left out, for example when the panel location changes as a result of the settings change. The parameter can also include a hint whether the "tab" mode is requested with "move to new window" or "move to editor tab".
6. When opening panel in new window, we use the new "compact" mode added to VSCode 1.100

### How Has This Been Tested: 
1. Run any project and play with the panel position
2. Test the following conversions:
  a) side-panel -> editor-tab (should open in "beside" mode)
  b) side-panel -> new-window
  c) editor-tab -> new-window
  d) new->window -> editor-tab (will open in the first editor group)
  e) new-> window -> new-window (will open a "newer" window)
  d) editor-tab -> editor-tab (when the IDE is in the first group, it will move to "beside" group, otherwise it will move to the first group)
3. Make sure changing panelLocation in settings is reflected
4. Restart VSCode with the panel open in all three states. Make sure the window is in the same location after restart
5. Test new-window mode on Cursor where no compact mode command fails
6. Make sure "Show IDE Panel" command focuses the panel (i.e. when it is placed in a hidden side panel)

https://github.com/user-attachments/assets/6c759f8d-c6dd-40f3-a764-afd6cdbc819c



