### PR TITLE
Kmagiera/unify skip files

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -413,6 +413,10 @@
                   }
                 }
               },
+              "skipFiles": {
+                "type": "array",
+                "description": "Files matching this pattern will be filtered out or hidden from debugger stack traces / exception breakpoints in debugger or when using inspector. The patterns support negation (when '!' is place at the start of the pattern) Radon IDE has a default set of patterns and this option will add to that list. If you want to force the default patterns to be ignored, add '!**/*' as the first pattern to your list."
+              },
               "eas": {
                 "type": "object",
                 "description": "Configuration for EAS build service",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -194,6 +194,7 @@
           "type": "string",
           "scope": "window",
           "default": null,
+          "markdownDeprecationMessage": "This setting is now replaced by `skipFiles` option in the launch configuration, check [this link](https://ide.swmansion.com/docs/guides/configuration#customizing-launch-configuration-for-radon-ide) for more information.",
           "description": "Files matching this pattern fill be excluded for the inspector jump to file functionality. This can be used if your codebase has some design system primitives that are used everywhere in your codebase and that you don't want to always get opened when using inspect functionality."
         }
       }

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -14,6 +14,7 @@ export type LaunchConfigurationOptions = {
     ios?: CustomBuild;
     android?: CustomBuild;
   };
+  skipFiles?: string[];
   eas?: {
     ios?: EasConfig;
     android?: EasConfig;

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -5,6 +5,7 @@ import { disposeAll } from "../utilities/disposables";
 import { sleep } from "../utilities/retry";
 import { startDebugging } from "./startDebugging";
 import { extensionContext } from "../utilities/extensionContext";
+import { getSkipFiles } from "../utilities/launchConfiguration";
 
 const PING_TIMEOUT = 1000;
 
@@ -139,8 +140,6 @@ export class DebugSession implements Disposable {
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
     const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
-    const extensionPath = extensionContext.extensionUri.path;
-
     this.jsDebugSession = await startDebugging(
       undefined,
       {
@@ -152,12 +151,7 @@ export class DebugSession implements Disposable {
         websocketAddress: configuration.websocketAddress,
         expoPreludeLineCount: configuration.expoPreludeLineCount,
         displayDebuggerOverlay: configuration.displayDebuggerOverlay,
-        skipFiles: [
-          "__source__",
-          `${extensionPath}/**/*`,
-          "**/node_modules/**/*",
-          "!**/node_modules/expo-router/**/*",
-        ],
+        skipFiles: getSkipFiles(),
       },
       {
         parentSession: this.parentDebugSession,

--- a/packages/vscode-extension/src/utilities/launchConfiguration.ts
+++ b/packages/vscode-extension/src/utilities/launchConfiguration.ts
@@ -1,5 +1,24 @@
 import { workspace } from "vscode";
 import { LaunchConfigurationOptions } from "../common/LaunchConfig";
+import { extensionContext } from "./extensionContext";
+
+export function getSkipFiles() {
+  const extensionPath = extensionContext.extensionUri.path;
+
+  const baseSkipFiles = [
+    "__source__",
+    `${extensionPath}/**/*`,
+    "**/node_modules/**/*",
+    "!**/node_modules/expo-router/**/*",
+  ];
+
+  const customSkipFiles = getLaunchConfiguration().skipFiles;
+  if (customSkipFiles) {
+    return [...baseSkipFiles, ...customSkipFiles];
+  } else {
+    return baseSkipFiles;
+  }
+}
 
 export function getLaunchConfiguration() {
   const ideConfig: LaunchConfigurationOptions =

--- a/packages/vscode-extension/src/utilities/skipFiles.ts
+++ b/packages/vscode-extension/src/utilities/skipFiles.ts
@@ -1,0 +1,25 @@
+import { Minimatch } from "minimatch";
+
+export class SkipFilesProcessor {
+  private skipFiles: Minimatch[];
+
+  constructor(skipFiles: string[]) {
+    this.skipFiles = skipFiles.map(
+      (pattern) => new Minimatch(pattern, { flipNegate: true, dot: true })
+    );
+  }
+
+  public shouldAcceptFile(fileName: string) {
+    let accept = true;
+    for (const pattern of this.skipFiles) {
+      if (pattern.match(fileName)) {
+        accept = pattern.negate;
+      }
+    }
+    return accept;
+  }
+
+  public shouldSkipFile(fileName: string) {
+    return !this.shouldAcceptFile(fileName);
+  }
+}


### PR DESCRIPTION
This PR unifies the skip files logic we had in two places. It also adapts the skip files concept to the element inspector that was previously using a custom setting `RadonIDE.inspectorExcludePattern`.

1. We extract the skip files logic to separate class and use it in the two places where we had it before
2. We deprecte `RadonIDE.inspectorExcludePattern` option 
3. We add a new launch configuration option `skipFiles` that will append to the set of default skip files (node modules, etc)

### How Has This Been Tested: 
1. Run project, make sure the debugger works
2. Use right-click inspector to see that the built-in RN items doesn't show up by default.


