### PR TITLE
Fix occasional webview crash in UrlSelect

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -40,7 +40,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const [urlList, setUrlList] = useState<UrlItem[]>([]);
   const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
   const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id);
+  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(urlList[0]?.id);
 
   useEffect(() => {
     function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -53,7 +53,7 @@ const PopoverItem = React.forwardRef<HTMLDivElement, PropsWithChildren<PopoverIt
 );
 
 interface UrlSelectProps {
-  value: string;
+  value?: string;
   onValueChange: (newValue: string) => void;
   recentItems: UrlItem[];
   items: UrlItem[];
@@ -121,7 +121,9 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
   };
 
   useEffect(() => {
-    setInputValue(getNameFromId(value));
+    if (value !== undefined) {
+      setInputValue(getNameFromId(value));
+    }
   }, [value]);
 
   useEffect(() => {


### PR DESCRIPTION
Due to mistyped parameters, sometimes `value` passed to the `UrlSelect` component is `undefined`, causing an error due to `.toLowerCase` being called on it.
This PR fixes the tyle of `urlSelectValue` state and checks for `undefined` where necessary

### How Has This Been Tested: 
- the issue was hard to reproduce reliably, but sometimes the IDE webview would crash due to method call on undefined that is impossible now



