### PR TITLE
Make lint properly run and fix accumulated errors

### DIFF
--- a/packages/vscode-extension/eslint.config.mjs
+++ b/packages/vscode-extension/eslint.config.mjs
@@ -1,57 +1,23 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import typescriptEslint from "@typescript-eslint/eslint-plugin";
-import _import from "eslint-plugin-import";
-import { fixupPluginRules } from "@eslint/compat";
-import tsParser from "@typescript-eslint/parser";
+import eslint from "@eslint/js";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
 
-export default defineConfig([
-  globalIgnores(["webview-ui/**/*"]),
+export default [
+  eslint.configs.recommended,
   {
-    plugins: {
-      "@typescript-eslint": typescriptEslint,
-      "import": fixupPluginRules(_import),
-    },
-
+    files: ["**/*.{ts,tsx,js,jsx}"],
     languageOptions: {
-      parser: tsParser,
-      ecmaVersion: 6,
-      sourceType: "module",
-    },
-
-    settings: {
-      "import/parsers": {
-        "@typescript-eslint/parser": [".ts", ".tsx"],
-      },
-
-      "import/resolver": {
-        typescript: {
-          alwaysTryTypes: true,
-        },
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
       },
     },
-
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
     rules: {
-      "curly": "warn",
-      "eqeqeq": "warn",
-      "no-throw-literal": "warn",
-      "semi": "off",
-      "@typescript-eslint/naming-convention": "off",
-      "@typescript-eslint/no-shadow": "error",
-
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        {
-          varsIgnorePattern: "^_",
-          args: "none",
-        },
-      ],
-
-      "import/order": [
-        "warn",
-        {
-          groups: ["builtin", "external"],
-        },
-      ],
+      ...tseslint.configs.recommended.rules,
     },
   },
-]);
+];

--- a/packages/vscode-extension/eslint.config.mjs
+++ b/packages/vscode-extension/eslint.config.mjs
@@ -1,8 +1,13 @@
 import eslint from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsparser from "@typescript-eslint/parser";
+import importPlugin from "eslint-plugin-import";
+import globals from "globals";
 
 export default [
+  {
+    ignores: ["webview-ui/**/*"],
+  },
   eslint.configs.recommended,
   {
     files: ["**/*.{ts,tsx,js,jsx}"],
@@ -12,12 +17,59 @@ export default [
         ecmaVersion: "latest",
         sourceType: "module",
       },
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+        NodeJS: "readonly",
+        React: "readonly",
+        // VSCode API globals
+        acquireVsCodeApi: "readonly",
+        Thenable: "readonly",
+      },
     },
     plugins: {
       "@typescript-eslint": tseslint,
+      "import": importPlugin,
+    },
+    settings: {
+      "import/parsers": {
+        "@typescript-eslint/parser": [".ts", ".tsx"],
+      },
+      "import/resolver": {
+        typescript: {
+          alwaysTryTypes: true,
+        },
+      },
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+      "curly": "warn",
+      "eqeqeq": "warn",
+      "no-throw-literal": "warn",
+      "semi": "off",
+      "no-empty": "off",
+      "no-useless-escape": "off",
+      "no-case-declarations": "off",
+      "no-irregular-whitespace": "off",
+      "@typescript-eslint/naming-convention": "off",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-require-imports": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          varsIgnorePattern: "^_",
+          args: "none",
+          caughtErrors: "none",
+        },
+      ],
+      "import/order": [
+        "warn",
+        {
+          groups: ["builtin", "external"],
+        },
+      ],
     },
   },
 ];

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -66,6 +66,7 @@
         "execa": "^5.1.1",
         "fantasticon": "^3.0.0",
         "file-loader": "^6.2.0",
+        "globals": "^16.1.0",
         "lodash": "^4.17.21",
         "minimatch": "^10.0.1",
         "mocha": "^10.2.0",
@@ -14817,6 +14818,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -22677,9 +22690,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
+      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -783,6 +783,7 @@
     "execa": "^5.1.1",
     "fantasticon": "^3.0.0",
     "file-loader": "^6.2.0",
+    "globals": "^16.1.0",
     "lodash": "^4.17.21",
     "minimatch": "^10.0.1",
     "mocha": "^10.2.0",

--- a/packages/vscode-extension/src/builders/BuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.test.ts
@@ -1,12 +1,13 @@
+import assert from "assert";
 import Sinon from "sinon";
+import { describe, afterEach, beforeEach, it } from "mocha";
+
 import { BuildType } from "../common/BuildConfig";
 import { DevicePlatform } from "../common/DeviceManager";
 import { CustomBuild, EasConfig, LaunchConfigurationOptions } from "../common/LaunchConfig";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { BuildManager } from "./BuildManager";
 import { BuildCache } from "./BuildCache";
-import assert from "assert";
-import { describe, afterEach, beforeEach, it } from "mocha";
 import * as ExpoGo from "./expoGo";
 
 const APP_ROOT = "appRoot";

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -171,7 +171,7 @@ export async function buildIos(
 
 async function buildLocal(
   buildConfig: IOSLocalBuildConfig,
-  installPodsIfNeeded: Function,
+  installPodsIfNeeded: () => Promise<void>,
   cancelToken: CancelToken,
   outputChannel: OutputChannel,
   progressListener: (newProgress: number) => void

--- a/packages/vscode-extension/src/builders/cancelToken.ts
+++ b/packages/vscode-extension/src/builders/cancelToken.ts
@@ -32,7 +32,7 @@ export class CancelToken {
       const wrappedInput = new Proxy(input, {
         get(target, prop, receiver) {
           if (prop === "then") {
-            return (resolve: any, reject: any) => promise.then(resolve, reject);
+            return (res: any, rej: any) => promise.then(res, rej);
           }
           return Reflect.get(target, prop, receiver);
         },

--- a/packages/vscode-extension/src/debugging/CDPProxy.ts
+++ b/packages/vscode-extension/src/debugging/CDPProxy.ts
@@ -88,8 +88,6 @@ export class CDPProxy {
     Connection,
     IncomingMessage,
   ]): Promise<void> {
-    debuggerTarget = debuggerTarget;
-
     debuggerTarget.pause(); // don't listen for events until the target is ready
 
     const applicationTarget = new Connection(

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -1,4 +1,5 @@
 import WebSocket from "ws";
+import { Disposable, EventEmitter } from "vscode";
 import { OutputEvent, Source, StackFrame } from "@vscode/debugadapter";
 import { DebugProtocol } from "@vscode/debugprotocol";
 import { Minimatch } from "minimatch";
@@ -18,7 +19,6 @@ import { CDPCallFrame, CDPDebuggerScope, CDPRemoteObject } from "./cdp";
 import { typeToCategory } from "./DebugAdapter";
 import { annotateLocations } from "./cpuProfiler";
 import { CDPConfiguration } from "./CDPDebugAdapter";
-import { Disposable, EventEmitter } from "vscode";
 
 type ResolveType<T = unknown> = (result: T) => void;
 type RejectType = (error: unknown) => void;
@@ -446,7 +446,9 @@ export class CDPSession {
 
       this.cdpMessagePromises.set(message.id, {
         resolve: (e: any) => {
-          timeout && clearTimeout(timeout);
+          if (timeout) {
+            clearTimeout(timeout);
+          }
           resolve(e);
         },
         reject,

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,10 +1,10 @@
 import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
 import { EventEmitter } from "vscode";
+import { Minimatch } from "minimatch";
 import _ from "lodash";
 import { CDPProxyDelegate, ProxyTunnel } from "./CDPProxy";
 import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { Logger } from "../Logger";
-import { Minimatch } from "minimatch";
 
 export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   private debuggerPausedEmitter = new EventEmitter<{ reason: "breakpoint" | "exception" }>();
@@ -258,9 +258,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       this.sourceMapRegistry.registerSourceMap(sourceMapData, url, scriptId, isMainBundle);
     } catch (e) {
       Logger.error("Could not process the source map", e);
-    } finally {
-      return command;
     }
+    return command;
   }
 
   private handleConsoleAPICalled(

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -301,7 +301,9 @@ export async function activate(context: ExtensionContext) {
 
   const shouldExtensionActivate = findAppRootFolder() !== undefined;
 
-  shouldExtensionActivate && extensionActivated(context);
+  if (shouldExtensionActivate) {
+    extensionActivated(context);
+  }
 }
 
 class LaunchConfigDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -79,10 +79,7 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
 
     const newCustomApplicationRoots = [...oldCustomApplicationRoots, appRoot];
 
-    extensionContext.workspaceState.update(
-      CUSTOM_APPLICATION_ROOTS_KEY,
-      newCustomApplicationRoots
-    ) ?? [];
+    extensionContext.workspaceState.update(CUSTOM_APPLICATION_ROOTS_KEY, newCustomApplicationRoots);
 
     this.eventEmitter.emit("applicationRootsChanged");
   }

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/redux-devtools-plugin.ts
@@ -59,7 +59,7 @@ export class ReduxDevtoolsPlugin implements ToolPlugin {
     this.devtoolsListeners.push(
       this.devtools.onEvent("RNIDE_pluginMessage", (payload) => {
         if (payload.scope === REDUX_PLUGIN_ID) {
-          const { scope, ...data } = payload;
+          const { scope: _scope, ...data } = payload;
           this.connectedWebview?.postMessage({ scope: "RNIDE-redux-devtools", data });
         }
       })

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -1,18 +1,17 @@
 import http from "http";
-import { commands, Disposable, Uri } from "vscode";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { Disposable, Uri } from "vscode";
 import { WebSocketServer, WebSocket } from "ws";
 import { Logger } from "../Logger";
 import {
   createBridge,
   createStore,
-  FrontendBridge,
   prepareProfilingDataExport,
   Store,
   Wall,
 } from "../../third-party/react-devtools/headless";
-import path from "path";
-import fs from "fs";
-import os from "os";
 
 // Define event names as a const array to avoid duplication
 export const DEVTOOLS_EVENTS = [
@@ -205,11 +204,11 @@ export class Devtools implements Disposable {
     }
     return {
       dispose: () => {
-        const listeners = this.listeners.get(eventName);
-        if (listeners) {
-          const index = listeners.indexOf(listener as (...payload: any) => void);
+        const listenersToClean = this.listeners.get(eventName);
+        if (listenersToClean) {
+          const index = listenersToClean.indexOf(listener as (...payload: any) => void);
           if (index !== -1) {
-            listeners.splice(index, 1);
+            listenersToClean.splice(index, 1);
           }
         }
       },

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -86,7 +86,9 @@ export class ToolsManager implements Disposable {
           }
         });
         // notify tools manager that the state of requested plugins has changed
-        changed && this.handleStateChange();
+        if (changed) {
+          this.handleStateChange();
+        }
       })
     );
     this.handleStateChange();

--- a/packages/vscode-extension/src/utilities/common.test.ts
+++ b/packages/vscode-extension/src/utilities/common.test.ts
@@ -1,7 +1,7 @@
 import process from "process";
 import assert from "assert";
 import sinon from "sinon";
-import { after } from "mocha";
+import { after, test } from "mocha";
 import { ABI, getNativeABI } from "./common";
 
 after(() => {

--- a/packages/vscode-extension/src/utilities/platform.ts
+++ b/packages/vscode-extension/src/utilities/platform.ts
@@ -13,6 +13,7 @@ const OS: "macos" | "windows" | "linux" | "unsupported" = (() => {
       return "unsupported";
   }
 })();
+
 export const Platform = {
   OS,
   select: <R, T>(obj: { macos: R; windows: T; linux: T }) => {
@@ -20,5 +21,3 @@ export const Platform = {
     return Platform.OS !== "unsupported" ? obj[Platform.OS] : obj["macos"];
   },
 };
-
-export type Platform = typeof Platform;

--- a/packages/vscode-extension/src/utilities/sdkmanager.ts
+++ b/packages/vscode-extension/src/utilities/sdkmanager.ts
@@ -42,7 +42,7 @@ function mapApiLevelToAndroidVersion(apiLevel: number): number | undefined {
     case 28:
       return 9;
     default:
-      undefined;
+      return undefined;
   }
 }
 

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { EventEmitter } from "stream";
 import fs from "fs";
 import path from "path";
-import { commands, env, ProgressLocation, Uri, window, workspace } from "vscode";
+import { commands, env, ProgressLocation, Uri, window } from "vscode";
 import JSON5 from "json5";
 import vscode from "vscode";
 import { TelemetryEventProperties } from "@vscode/extension-telemetry";

--- a/packages/vscode-extension/src/webview/components/Feedback.tsx
+++ b/packages/vscode-extension/src/webview/components/Feedback.tsx
@@ -20,7 +20,7 @@ export function Feedback({ sentiment, setSentiment }: FeedbackProps) {
 
   return (
     <div className="feedback">
-      {Boolean(sentiment) ? (
+      {sentiment ? (
         <p className="feedback-prompt">
           {sentiment === "positive" ? "What went well?" : "Tell us more"}
         </p>

--- a/packages/vscode-extension/src/webview/components/IconButtonWithOptions.tsx
+++ b/packages/vscode-extension/src/webview/components/IconButtonWithOptions.tsx
@@ -5,12 +5,12 @@ import IconButton, { IconButtonProps } from "./shared/IconButton";
 import "./IconButtonWithOptions.css";
 import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
-interface IconButtonWithOptions extends IconButtonProps {
+interface IconButtonWithOptionsProps extends IconButtonProps {
   options: Record<string, () => void>;
   disabled?: boolean;
 }
 
-export const IconButtonWithOptions = forwardRef<HTMLButtonElement, IconButtonWithOptions>(
+export const IconButtonWithOptions = forwardRef<HTMLButtonElement, IconButtonWithOptionsProps>(
   (props, ref) => {
     const { options, disabled, children, ...iconButtonProps } = props;
 

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -213,8 +213,12 @@ function Preview({
       sendInspect(e, "Move", false);
     } else if (isMultiTouching) {
       setTouchPoint(getTouchPosition(e));
-      isPanning && moveAnchorPoint(e);
-      isPressing && sendMultiTouchForEvent(e, "Move");
+      if (isPanning) {
+        moveAnchorPoint(e);
+      }
+      if (isPressing) {
+        sendMultiTouchForEvent(e, "Move");
+      }
     } else if (isPressing) {
       sendTouch(e, "Move");
     }

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -74,14 +74,14 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
   const textfieldRef = useRef<HTMLInputElement>(null);
 
   const getNameFromId = (id: string) => {
-    const item = items.find((item) => item.id === id);
-    if (!item) {
+    const itemForID = items.find((item) => item.id === id);
+    if (!itemForID) {
       return id;
     }
-    if (item.name.startsWith("/")) {
-      return item.name;
+    if (itemForID.name.startsWith("/")) {
+      return itemForID.name;
     }
-    return item.id;
+    return itemForID.id;
   };
 
   const closeDropdownWithValue = (id: string) => {

--- a/packages/vscode-extension/src/webview/components/shared/SearchSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/SearchSelect.tsx
@@ -112,7 +112,9 @@ export const SearchSelect = ({
 
   const updateValue = (newValue: string, updateQuery: boolean) => {
     setValue(newValue);
-    updateQuery && setQuery(newValue);
+    if (updateQuery) {
+      setQuery(newValue);
+    }
   };
 
   const getOptionWithHighlight = (element: string): ReactNode => {

--- a/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/DependenciesProvider.tsx
@@ -16,24 +16,21 @@ import {
 
 const dependencyManager = makeProxy<DependencyManagerInterface>("DependencyManager");
 
-const dependenciesDomain = [
-  "nodejs",
-  "packageManager",
-  "androidEmulator",
-  "xcode",
-  "cocoaPods",
-  "nodeModules",
-  "ios",
-  "android",
-  "pods",
-  "reactNative",
-  "expo",
-  "expoRouter",
-  "storybook",
-  "easCli",
-] as const;
-
-type Dependency = (typeof dependenciesDomain)[number];
+type Dependency =
+  | "nodejs"
+  | "packageManager"
+  | "androidEmulator"
+  | "xcode"
+  | "cocoaPods"
+  | "nodeModules"
+  | "ios"
+  | "android"
+  | "pods"
+  | "reactNative"
+  | "expo"
+  | "expoRouter"
+  | "storybook"
+  | "easCli";
 
 type ErrorType = "ios" | "simulator" | "emulator" | "android" | "common";
 type Errors = Partial<Record<ErrorType, { message: string }>>;
@@ -135,8 +132,10 @@ function getErrors(statuses: DependencyRecord) {
           break;
         case "ios":
           setFirstError(dependency, "ios");
+          break;
         case "android":
           setFirstError(dependency, "android");
+          break;
         default:
           break;
       }


### PR DESCRIPTION
After updating dependencies in #1107 we changed eslint config to adapt it to a new version in a way that made lint skip all of the files we had in the codebase and effectively we stopped running lint altogether.

This PR restores the lint to run. Since the defaults changed, we are now changing the behaviors of some rules that are specifically annoying but also updating code to reflect rules that are important.

### How Has This Been Tested: 
1. Run lint, see it passes
2. Test critical changes, specifically in `waitForEmulatorOnline`


