### PR TITLE
Fix UrlSelect behavior when Expo Router is not used

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -40,7 +40,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const [urlList, setUrlList] = useState<UrlItem[]>([]);
   const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
   const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(urlList[0]?.id);
+  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(urlList[0]?.id || "/");
 
   useEffect(() => {
     function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {
@@ -111,7 +111,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         onClick={() => {
           project.goHome("/{}");
           if (!isExpoRouterProject) {
-            setUrlSelectValue(""); // sets UrlSelect trigger to a placeholder
+            setUrlSelectValue("/"); // sets UrlSelect trigger to a placeholder
           }
         }}
         tooltip={{
@@ -128,7 +128,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         recentItems={recentUrlList}
         items={sortedUrlList}
         value={urlSelectValue}
-        disabled={disabledAlsoWhenStarting}
+        disabled={disabledAlsoWhenStarting || (!isExpoRouterProject && urlHistory.length < 1)}
+        dropdownOnly={!isExpoRouterProject}
       />
     </>
   );

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -1,6 +1,7 @@
 .url-select-wrapper {
   position: relative;
   flex: 1;
+  margin-left: 2px;
 }
 
 .url-select-input {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -174,16 +174,17 @@ function UrlSelect({
             disabled={disabled}
             readonly={dropdownOnly}
             onInput={() => setInputValue(textfieldRef.current?.value ?? "")}
+            onFocus={() => setIsDropdownOpen(true)}
             onMouseDown={() => {
-              if (!dropdownOnly || !isDropdownOpen) {
-                setIsDropdownOpen(true);
+              if (!isDropdownOpen && !dropdownOnly) {
+                setTimeout(() => textfieldRef.current?.focus(), 0);
               } else if (dropdownOnly) {
-                setIsDropdownOpen(false);
+                setIsDropdownOpen(!isDropdownOpen);
+                textfieldRef.current?.blur();
               }
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
-                e.preventDefault();
                 closeDropdownWithValue(textfieldRef.current?.value ?? "");
                 textfieldRef.current?.blur();
               }
@@ -198,8 +199,6 @@ function UrlSelect({
                     undefined,
                     document.querySelector(".url-select-item") as HTMLDivElement
                   );
-                } else {
-                  setIsDropdownOpen(true);
                 }
               }
             }}


### PR DESCRIPTION
This PR fixes bugs caused mainly by the application path bar being always enabled, even if Expo Router was not present:
- the input field was active, so the user could input a route and send it to a nonexistent handler, resulting in a hidden error and the app not navigating anywhere, but changing the displayed path;
- the bar did not have any routes to present, but the dropdown could be opened, resulting in broken layout;
- there was no `/` route on the list, so users couldn't intuitively navigate to the homepage with the bar;
- paths not starting with `"/"` were displayed with id instead of name, resulting in unreadable preview paths.

### Fixes:
If Expo Router is not used:
- disable the UrlSelect if the path history doesn't exist;
- make the bar's field read-only;
- create a simpler route list without the search result section;
- hard-code a `/` route that uses `project.goHome()` on selection into the dropdown;
- make the input field lose focus after clicking outside the dropdown;
- set a fail-safe `"/"` path bar placeholder instead of `""`

### How Has This Been Tested: 
- open a React Native project without Expo Router - the path bar will stay disabled until the first navigation change
- after navigating, i.e. to a preview, click the UrlSelect -  the input field is not editable, but text can be highlighted, copied, etc.
- in the dropdown, there is only one section with `/` route first, and then the other visited ones sorted from newest
- open a component preview - now both on bare RN and on ER projects the component name is displayed instead of the file path