### PR TITLE
Refactor project and device state to fix issues with device switch and simplify our logic

### DIFF
--- a/packages/docs/docs/guides/keyboard-shortcuts.md
+++ b/packages/docs/docs/guides/keyboard-shortcuts.md
@@ -13,7 +13,7 @@ Radon IDE lets you perform some repetitive actions through keyboard shortcuts.
 | Toggle recording                       | Command + Shift + E   | Control + Shift + E |
 | Capture screenshot                     | Command + Shift + A   | Control + Shift + A |
 | Perform biometric authorization        | Command + Shift + M   | Control + Shift + M |
-| Perform failed biometric authorization | Command + Shift + N   | Control + Shift + N |
+| Perform failed biometric authorization | Option + Command + Shift + M   | Control + Alt + Shift + M |
 | Close IDE Panel with confirmation      | Command + W           | Control + W         |
 
 ## Customize shortcuts

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-context-menu": "^2.2.7",
         "@radix-ui/react-dialog": "^1.1.7",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
+        "@radix-ui/react-popover": "^1.1.13",
         "@radix-ui/react-progress": "^1.1.3",
         "@radix-ui/react-radio-group": "^1.2.4",
         "@radix-ui/react-scroll-area": "^1.2.4",
@@ -15890,6 +15891,268 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.13.tgz",
+      "integrity": "sha512-84uqQV3omKDR076izYgcha6gdpN8m3z6w/AeJ83MSBJYVG/AbOHdLjAgsPZkeC/kt+k64moXFCnio8BbqXszlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.9",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.6",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.6",
+        "@radix-ui/react-portal": "1.1.8",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-slot": "1.2.2",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.6.tgz",
+      "integrity": "sha512-2JMfHJf/eVnwq+2dewT3C0acmCWD3XiVA1Da+jTDqo342UlU13WvXtqHhG+yJw5JeQmu4ue2eMy6gcEArLBlcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.9.tgz",
+      "integrity": "sha512-way197PiTvNp+WBP7svMJasHl+vibhWGQDb6Mgf5mhEWJkgb85z7Lfl9TUdkqpWsf8GRNmoopx9ZxCyDzmgRMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.6.tgz",
+      "integrity": "sha512-r9zpYNUQY+2jWHWZGyddQLL9YHkM/XvSFHVcWs7bdVuxMAnCwTAuy6Pf47Z4nw7dYcUou1vg/VgjjrrH03VeBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.6.tgz",
+      "integrity": "sha512-7iqXaOWIjDBfIG7aq8CUEeCSsQMLFdn7VEE8TaFz704DtEzpPHR7w/uuzRflvKgltqSAImgcmxQ7fFX3X7wasg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.8.tgz",
+      "integrity": "sha512-hQsTUIn7p7fxCPvao/q6wpbxmCwgLrlz+nOrJgC+RwfZqWY/WN+UMqkXzrtKbPrF82P43eCTl3ekeKuyAQbFeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.2.tgz",
+      "integrity": "sha512-uHa+l/lKfxuDD2zjN/0peM/RhhSmRjr5YWdk/37EnSv1nJ88uvG85DPexSm8HdFQROd2VdERJ6ynXbkCFi+APw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
+      "integrity": "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.3.tgz",
@@ -16290,6 +16553,25 @@
       "dev": true,
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -19,7 +19,8 @@
     "workspaceContains:**/metro.config.js",
     "workspaceContains:**/metro.config.ts",
     "workspaceContains:**/app.config.js",
-    "workspaceContains:**/app.config.ts"
+    "workspaceContains:**/app.config.ts",
+    "onWebviewPanel:RadonIDETabPanel"
   ],
   "version": "1.6.0",
   "engines": {
@@ -169,10 +170,9 @@
           "default": "tab",
           "enum": [
             "tab",
-            "side-panel",
-            "secondary-side-panel"
+            "side-panel"
           ],
-          "description": "Controls location of the IDE panel. Due to vscode API limitations, when secondary side panel is selected, you need to manually move the IDE panel to the secondary side panel. Changing this option closes and reopens the IDE."
+          "description": "Controls the location of the Radon IDE panel. When side-panel is selected, you can use right-click menu on the panel to move it to the secondary side panel if you wish."
         },
         "RadonIDE.themeType": {
           "type": "string",
@@ -736,6 +736,7 @@
     "@radix-ui/react-context-menu": "^2.2.7",
     "@radix-ui/react-dialog": "^1.1.7",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.13",
     "@radix-ui/react-progress": "^1.1.3",
     "@radix-ui/react-radio-group": "^1.2.4",
     "@radix-ui/react-scroll-area": "^1.2.4",

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -90,14 +90,6 @@ export class BuildManager implements Disposable {
     return this.isCachedBuildStale;
   }
 
-  public activate() {
-    this.workspaceChangeListener.startWatching();
-  }
-
-  public deactivate() {
-    this.workspaceChangeListener.stopWatching();
-  }
-
   private buildOutputChannel: OutputChannel | undefined;
 
   public focusBuildOutput() {

--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -1,9 +1,8 @@
-import { DeviceSessionDelegate } from "../project/deviceSession";
 import { DeviceInfo } from "./DeviceManager";
+import { DeviceSessionState } from "./Project";
 
-export type DeviceSessionsManagerDelegate = DeviceSessionDelegate & {
-  onDeviceSelected: (deviceInfo: DeviceInfo, previewURL?: string) => void;
-  onReloadRequested: (type: ReloadAction) => void;
+export type DeviceSessionsManagerDelegate = {
+  onActiveSessionStateChanged(state: DeviceSessionState): void;
 };
 
 export type SelectDeviceOptions = {
@@ -20,7 +19,9 @@ export type ReloadAction =
   | "reloadJs"; // refetch JS scripts from metro
 
 export interface DeviceSessionsManagerInterface {
-  reload(type: ReloadAction): Promise<boolean>;
-  stopDevice(deviceId: string): Promise<boolean>;
-  selectDevice(deviceInfo: DeviceInfo, selectDeviceOptions?: SelectDeviceOptions): Promise<boolean>;
+  reloadCurrentSession(type: ReloadAction): Promise<boolean>;
+  startOrActivateSessionForDevice(
+    deviceInfo: DeviceInfo,
+    selectDeviceOptions?: SelectDeviceOptions
+  ): Promise<boolean>;
 }

--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -23,5 +23,5 @@ export interface DeviceSessionsManagerInterface {
   startOrActivateSessionForDevice(
     deviceInfo: DeviceInfo,
     selectDeviceOptions?: SelectDeviceOptions
-  ): Promise<boolean>;
+  ): Promise<void>;
 }

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -33,7 +33,12 @@ export type BuildErrorDescriptor = {
   buildType: BuildType | null;
 };
 
-export type ProfilingState = "stopped" | "running" | "saving";
+export type ProfilingState = "stopped" | "profiling" | "saving";
+
+export type NavigationHistoryItem = {
+  displayName: string;
+  id: string;
+};
 
 export type DeviceSessionState = {
   status:
@@ -52,10 +57,10 @@ export type DeviceSessionState = {
   fastRefreshOngoing: boolean;
   profilingReactState: ProfilingState;
   profilingCPUState: ProfilingState;
-  navigationHistory: { displayName: string; id: string }[];
-  toolsState: ToolsState | undefined;
+  navigationHistory: NavigationHistoryItem[];
+  toolsState: ToolsState;
   isDebuggerPaused: boolean;
-  logCount: number;
+  logCounter: number;
   hasStaleBuildCache: boolean;
 };
 
@@ -70,9 +75,9 @@ export const DeviceSessionInitialState: DeviceSessionState = {
   profilingReactState: "stopped",
   profilingCPUState: "stopped",
   navigationHistory: [],
-  toolsState: undefined,
+  toolsState: {},
   isDebuggerPaused: false,
-  logCount: 0,
+  logCounter: 0,
   hasStaleBuildCache: false,
 };
 
@@ -153,13 +158,9 @@ export enum ActivateDeviceResult {
 }
 
 export interface ProjectEventMap {
-  log: { type: string };
   projectStateChanged: ProjectState;
   deviceSettingsChanged: DeviceSettings;
-  toolsStateChanged: ToolsState;
   licenseActivationChanged: boolean;
-  navigationChanged: { displayName: string; id: string };
-  needsNativeRebuild: void;
   replayDataCreated: MultimediaData;
   isRecording: boolean;
 }
@@ -193,6 +194,7 @@ export interface ProjectInterface {
   focusExtensionLogsOutput(): Promise<void>;
   focusDebugConsole(): Promise<void>;
   openNavigation(navigationItemID: string): Promise<void>;
+  navigateBack(): Promise<void>;
   openDevMenu(): Promise<void>;
 
   activateLicense(activationKey: string): Promise<ActivateDeviceResult>;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -56,7 +56,6 @@ export type DeviceSessionState = {
   buildError: BuildErrorDescriptor | undefined;
   selectedDevice: DeviceInfo | undefined;
   previewURL: string | undefined;
-  fastRefreshOngoing: boolean;
   profilingReactState: ProfilingState;
   profilingCPUState: ProfilingState;
   navigationHistory: NavigationHistoryItem[];
@@ -73,7 +72,6 @@ export const DeviceSessionInitialState: DeviceSessionState = {
   buildError: undefined,
   selectedDevice: undefined,
   previewURL: undefined,
-  fastRefreshOngoing: false,
   profilingReactState: "stopped",
   profilingCPUState: "stopped",
   navigationHistory: [],
@@ -179,7 +177,6 @@ export type MultimediaData = {
 
 export interface ProjectInterface {
   getProjectState(): Promise<ProjectState>;
-  goHome(homeUrl: string): Promise<void>;
   renameDevice(deviceInfo: DeviceInfo, newDisplayName: string): Promise<void>;
   updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void>;
 
@@ -197,6 +194,7 @@ export interface ProjectInterface {
   focusDebugConsole(): Promise<void>;
   openNavigation(navigationItemID: string): Promise<void>;
   navigateBack(): Promise<void>;
+  navigateHome(): Promise<void>;
   openDevMenu(): Promise<void>;
 
   activateLicense(activationKey: string): Promise<ActivateDeviceResult>;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -36,6 +36,17 @@ export type BuildErrorDescriptor = {
 export type ProfilingState = "stopped" | "running" | "saving";
 
 export type DeviceSessionState = {
+  status:
+    | "starting"
+    | "running"
+    | "bootError"
+    | "bundlingError"
+    | "debuggerPaused"
+    | "refreshing"
+    | "buildError";
+  startupMessage: StartupMessage | undefined;
+  stageProgress: number | undefined;
+  buildError: BuildErrorDescriptor | undefined;
   selectedDevice: DeviceInfo | undefined;
   previewURL: string | undefined;
   fastRefreshOngoing: boolean;
@@ -46,24 +57,24 @@ export type DeviceSessionState = {
   isDebuggerPaused: boolean;
   logCount: number;
   hasStaleBuildCache: boolean;
-} & (
-  | {
-      status:
-        | "starting"
-        | "running"
-        | "bootError"
-        | "bundlingError"
-        | "debuggerPaused"
-        | "refreshing";
-      startupMessage: StartupMessage | undefined;
-      stageProgress: number | undefined;
-    }
-  | {
-      status: "buildError";
-      selectedDevice: DeviceInfo | undefined;
-      buildError: BuildErrorDescriptor;
-    }
-);
+};
+
+export const DeviceSessionInitialState: DeviceSessionState = {
+  status: "starting",
+  startupMessage: undefined,
+  stageProgress: undefined,
+  buildError: undefined,
+  selectedDevice: undefined,
+  previewURL: undefined,
+  fastRefreshOngoing: false,
+  profilingReactState: "stopped",
+  profilingCPUState: "stopped",
+  navigationHistory: [],
+  toolsState: undefined,
+  isDebuggerPaused: false,
+  logCount: 0,
+  hasStaleBuildCache: false,
+};
 
 export type ProjectState = {
   initialized: boolean;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -40,15 +40,17 @@ export type NavigationHistoryItem = {
   id: string;
 };
 
+export type DeviceSessionStatus =
+  | "starting"
+  | "running"
+  | "bootError"
+  | "bundlingError"
+  | "debuggerPaused"
+  | "refreshing"
+  | "buildError";
+
 export type DeviceSessionState = {
-  status:
-    | "starting"
-    | "running"
-    | "bootError"
-    | "bundlingError"
-    | "debuggerPaused"
-    | "refreshing"
-    | "buildError";
+  status: DeviceSessionStatus;
   startupMessage: StartupMessage | undefined;
   stageProgress: number | undefined;
   buildError: BuildErrorDescriptor | undefined;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -27,8 +27,27 @@ export type ToolsState = {
   [key: string]: ToolState;
 };
 
-export type ProjectState =
-  | ({
+export type BuildErrorDescriptor = {
+  message: string;
+  platform: DevicePlatform;
+  buildType: BuildType | null;
+};
+
+export type ProfilingState = "stopped" | "running" | "saving";
+
+export type DeviceSessionState = {
+  selectedDevice: DeviceInfo | undefined;
+  previewURL: string | undefined;
+  fastRefreshOngoing: boolean;
+  profilingReactState: ProfilingState;
+  profilingCPUState: ProfilingState;
+  navigationHistory: { displayName: string; id: string }[];
+  toolsState: ToolsState | undefined;
+  isDebuggerPaused: boolean;
+  logCount: number;
+  hasStaleBuildCache: boolean;
+} & (
+  | {
       status:
         | "starting"
         | "running"
@@ -36,26 +55,20 @@ export type ProjectState =
         | "bundlingError"
         | "debuggerPaused"
         | "refreshing";
-    } & ProjectStateCommon)
-  | ProjectStateBuildError;
+      startupMessage: StartupMessage | undefined;
+      stageProgress: number | undefined;
+    }
+  | {
+      status: "buildError";
+      selectedDevice: DeviceInfo | undefined;
+      buildError: BuildErrorDescriptor;
+    }
+);
 
-type ProjectStateCommon = {
-  previewURL: string | undefined;
-  selectedDevice: DeviceInfo | undefined;
+export type ProjectState = {
   initialized: boolean;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
-  startupMessage: StartupMessage | undefined;
-  stageProgress: number | undefined;
-};
-
-type ProjectStateBuildError = {
-  status: "buildError";
-  buildError: {
-    message: string;
-    platform: DevicePlatform;
-    buildType: BuildType | null;
-  };
-} & ProjectStateCommon;
+} & DeviceSessionState;
 
 export type ZoomLevelType = number | "Fit";
 
@@ -138,9 +151,6 @@ export interface ProjectEventMap {
   needsNativeRebuild: void;
   replayDataCreated: MultimediaData;
   isRecording: boolean;
-  isProfilingCPU: boolean;
-  isProfilingReact: boolean;
-  isSavingReactProfile: boolean;
 }
 
 export interface ProjectEventListener<T> {
@@ -163,7 +173,6 @@ export interface ProjectInterface {
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
   runCommand(command: string): Promise<void>;
 
-  getToolsState(): Promise<ToolsState>;
   updateToolEnabledState(toolName: keyof ToolsState, enabled: boolean): Promise<void>;
   openTool(toolName: keyof ToolsState): Promise<void>;
 

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -123,17 +123,17 @@ export class DebugSession implements Disposable {
   }
 
   public async stop() {
-    if (this.parentDebugSession) {
-      const parentDebugSession = this.parentDebugSession;
-      this.parentDebugSession = undefined;
-      await debug.stopDebugging(parentDebugSession);
-    }
     if (this.jsDebugSession) {
       const jsDebugSession = this.jsDebugSession;
       this.jsDebugSession = undefined;
       await debug.stopDebugging(jsDebugSession);
     }
     this.currentWsTarget = undefined;
+    if (this.parentDebugSession) {
+      const parentDebugSession = this.parentDebugSession;
+      this.parentDebugSession = undefined;
+      await debug.stopDebugging(parentDebugSession);
+    }
   }
 
   public async dispose() {
@@ -146,7 +146,7 @@ export class DebugSession implements Disposable {
     if (this.jsDebugSession) {
       await this.restart();
     }
-    if (this.options.useParentDebugSession) {
+    if (this.options.useParentDebugSession && !this.parentDebugSession) {
       await this.startParentDebugSession();
     }
 
@@ -188,7 +188,6 @@ export class DebugSession implements Disposable {
       debug.stopDebugging(this.jsDebugSession);
     }
     this.jsDebugSession = newDebugSession;
-    console.log("START DEBUGGER [JS]", this.jsDebugSession.id);
     this.currentWsTarget = configuration.websocketAddress;
 
     return true;

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -5,6 +5,7 @@ import { disposeAll } from "../utilities/disposables";
 import { sleep } from "../utilities/retry";
 import { startDebugging } from "./startDebugging";
 import { extensionContext } from "../utilities/extensionContext";
+import { Logger } from "../Logger";
 
 const PING_TIMEOUT = 1000;
 
@@ -35,16 +36,22 @@ export interface JSDebugConfiguration {
 
 export type DebugSource = { filename?: string; line1based?: number; column0based?: number };
 
+type DebugSessionOptions = {
+  useParentDebugSession?: boolean;
+};
+
 export class DebugSession implements Disposable {
   private parentDebugSession: vscode.DebugSession | undefined;
   private jsDebugSession: vscode.DebugSession | undefined;
 
-  private useParentDebugSession = false;
   private disposables: Disposable[] = [];
 
   private currentWsTarget: string | undefined;
 
-  constructor(private delegate: DebugSessionDelegate) {
+  constructor(
+    private delegate: DebugSessionDelegate,
+    private options: DebugSessionOptions = {}
+  ) {
     this.disposables.push(
       debug.onDidTerminateDebugSession((session) => {
         if (session.id === this.jsDebugSession?.id) {
@@ -87,8 +94,7 @@ export class DebugSession implements Disposable {
       !this.jsDebugSession,
       "Cannot start parent debug session when js debug session is already running"
     );
-    this.useParentDebugSession = true;
-    this.parentDebugSession = await startDebugging(
+    const newParentDebugSession = await startDebugging(
       undefined,
       {
         type: MASTER_DEBUGGER_TYPE,
@@ -102,11 +108,16 @@ export class DebugSession implements Disposable {
         suppressSaveBeforeStart: true,
       }
     );
+    if (this.parentDebugSession) {
+      Logger.warn("Parent debugger session has spawned concurrently, dropping the earlier session");
+      debug.stopDebugging(this.parentDebugSession);
+    }
+    this.parentDebugSession = newParentDebugSession;
   }
 
   public async restart() {
     await this.stop();
-    if (this.useParentDebugSession) {
+    if (this.options.useParentDebugSession) {
       await this.startParentDebugSession();
     }
   }
@@ -135,13 +146,16 @@ export class DebugSession implements Disposable {
     if (this.jsDebugSession) {
       await this.restart();
     }
+    if (this.options.useParentDebugSession) {
+      await this.startParentDebugSession();
+    }
 
     const isUsingNewDebugger = configuration.isUsingNewDebugger;
     const debuggerType = isUsingNewDebugger ? PROXY_JS_DEBUGGER_TYPE : OLD_JS_DEBUGGER_TYPE;
 
     const extensionPath = extensionContext.extensionUri.path;
 
-    this.jsDebugSession = await startDebugging(
+    const newDebugSession = await startDebugging(
       undefined,
       {
         type: debuggerType,
@@ -169,7 +183,12 @@ export class DebugSession implements Disposable {
         compact: true,
       }
     );
-
+    if (this.jsDebugSession) {
+      Logger.warn("JS debugger session has spawned concurrently, dropping the earlier session");
+      debug.stopDebugging(this.jsDebugSession);
+    }
+    this.jsDebugSession = newDebugSession;
+    console.log("START DEBUGGER [JS]", this.jsDebugSession.id);
     this.currentWsTarget = configuration.websocketAddress;
 
     return true;

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -244,10 +244,10 @@ export class AndroidEmulatorDevice extends DeviceBase {
     return promise;
   }
 
-  async bootDevice(deviceSettings: DeviceSettings): Promise<void> {
+  async bootDevice(): Promise<void> {
     await this.internalBootDevice();
 
-    let shouldRestart = await this.changeSettings(deviceSettings);
+    let shouldRestart = await this.changeSettings(this.deviceSettings);
     if (shouldRestart) {
       await this.forcefullyResetDevice();
     }

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -5,6 +5,9 @@ import { BuildResult } from "../builders/BuildManager";
 import { AppPermissionType, DeviceSettings, TouchPoint, DeviceButtonType } from "../common/Project";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
+import { extensionContext } from "../utilities/extensionContext";
+import { getTelemetryReporter } from "../utilities/telemetry";
+import { getChanges } from "../utilities/diffing";
 
 const LEFT_META_HID_CODE = 0xe3;
 const RIGHT_META_HID_CODE = 0xe7;
@@ -13,12 +16,31 @@ const C_KEY_HID_CODE = 0x06;
 
 export const REBOOT_TIMEOUT = 3000;
 
+export const DEVICE_SETTINGS_KEY = "device_settings_v4";
+export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
+  appearance: "dark",
+  contentSize: "normal",
+  location: {
+    latitude: 50.048653,
+    longitude: 19.965474,
+    isDisabled: false,
+  },
+  hasEnrolledBiometrics: false,
+  locale: "en_US",
+  replaysEnabled: false,
+  showTouches: false,
+};
+
 export abstract class DeviceBase implements Disposable {
   protected preview: Preview | undefined;
   private previewStartPromise: Promise<string> | undefined;
   private acquired = false;
   private pressingLeftMetaKey = false;
   private pressingRightMetaKey = false;
+  protected deviceSettings: DeviceSettings = extensionContext.workspaceState.get(
+    DEVICE_SETTINGS_KEY,
+    DEVICE_SETTINGS_DEFAULT
+  );
 
   abstract get lockFilePath(): string;
 
@@ -26,13 +48,47 @@ export abstract class DeviceBase implements Disposable {
     return this.preview?.streamURL;
   }
 
+  public get previewReady() {
+    return this.preview?.streamURL !== undefined;
+  }
+
   async reboot(): Promise<void> {
     this.preview?.dispose();
     this.preview = undefined;
     this.previewStartPromise = undefined;
   }
-  abstract bootDevice(deviceSettings: DeviceSettings): Promise<void>;
-  abstract changeSettings(settings: DeviceSettings): Promise<boolean>;
+
+  async updateDeviceSettings(settings: DeviceSettings) {
+    const changes = getChanges(this.deviceSettings, settings);
+
+    getTelemetryReporter().sendTelemetryEvent("device-settings:update-device-settings", {
+      platform: this.platform,
+      changedSetting: JSON.stringify(changes),
+    });
+
+    extensionContext.workspaceState.update(DEVICE_SETTINGS_KEY, settings);
+    if (this.previewReady) {
+      if (changes.replaysEnabled !== undefined) {
+        if (changes.replaysEnabled) {
+          this.enableReplay();
+        } else {
+          this.disableReplays();
+        }
+      }
+      if (changes.showTouches !== undefined) {
+        if (changes.showTouches) {
+          this.showTouches();
+        } else {
+          this.hideTouches();
+        }
+      }
+    }
+
+    return this.changeSettings(settings);
+  }
+
+  abstract bootDevice(): Promise<void>;
+  protected abstract changeSettings(settings: DeviceSettings): Promise<boolean>;
   abstract sendBiometricAuthorization(isMatch: boolean): Promise<void>;
   abstract getClipboard(): Promise<string | void>;
   abstract installApp(build: BuildResult, forceReinstall: boolean): Promise<void>;
@@ -165,6 +221,14 @@ export abstract class DeviceBase implements Disposable {
     if (!this.previewStartPromise) {
       this.preview = this.makePreview();
       this.previewStartPromise = this.preview.start();
+      this.previewStartPromise.then(() => {
+        if (this.deviceSettings.replaysEnabled) {
+          this.enableReplay();
+        }
+        if (this.deviceSettings.showTouches) {
+          this.showTouches();
+        }
+      });
     }
     return this.previewStartPromise;
   }

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -117,14 +117,14 @@ export class IosSimulatorDevice extends DeviceBase {
     }
   }
 
-  async bootDevice(settings: DeviceSettings) {
-    if (await this.shouldUpdateLocale(settings.locale)) {
-      await this.changeLocale(settings.locale);
+  async bootDevice() {
+    if (await this.shouldUpdateLocale(this.deviceSettings.locale)) {
+      await this.changeLocale(this.deviceSettings.locale);
     }
 
     await this.internalBootDevice();
 
-    await this.changeSettings(settings);
+    await this.changeSettings(this.deviceSettings);
   }
 
   private async shouldUpdateLocale(locale: Locale): Promise<boolean> {

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -47,10 +47,7 @@ export class WebviewController implements Disposable {
       ["Utils", () => this.ide.utils as object],
       [
         "RenderOutlines",
-        () =>
-          this.ide.project.deviceSession!.toolsManager.getPlugin(
-            RENDER_OUTLINES_PLUGIN_ID
-          ) as object,
+        () => this.ide.project.deviceSession!.getPlugin(RENDER_OUTLINES_PLUGIN_ID) as object,
       ],
     ]);
 

--- a/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/expo-dev-plugins/ExpoDevPluginWebviewProvider.ts
@@ -44,7 +44,7 @@ export class ExpoDevPluginWebviewProvider implements WebviewViewProvider {
       reportToolVisibilityChanged(this.pluginName, webviewView.visible)
     );
 
-    const metroPort = IDE.getInstanceIfExists()?.project?.deviceSession?.metro.port;
+    const metroPort = IDE.getInstanceIfExists()?.project?.deviceSession?.getMetroPort();
     if (!metroPort) {
       Logger.error(
         "Metro port is unknown while expected to be set, the devtools panel cannot be opened."

--- a/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/network/NetworkDevtoolsWebviewProvider.ts
@@ -30,8 +30,7 @@ export class NetworkDevtoolsWebviewProvider implements WebviewViewProvider {
     };
 
     const project = IDE.getInstanceIfExists()?.project;
-    const wsPort = (project?.deviceSession?.toolsManager.getPlugin("network") as NetworkPlugin)
-      ?.websocketPort;
+    const wsPort = (project?.deviceSession?.getPlugin("network") as NetworkPlugin)?.websocketPort;
     if (!wsPort) {
       throw new Error("Couldn't retrieve websocket port from network plugin");
     }

--- a/packages/vscode-extension/src/plugins/react-query-devtools-plugin/ReactQueryDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/react-query-devtools-plugin/ReactQueryDevToolsPluginWebviewProvider.ts
@@ -87,7 +87,7 @@ export class ReactQueryDevToolsPluginWebviewProvider implements WebviewViewProvi
 
     webview.html = generateWebviewContent(extensionContext, webview, extensionContext.extensionUri);
 
-    const devTools = IDE.getInstanceIfExists()?.project?.deviceSession?.toolsManager.devtools;
+    const devTools = IDE.getInstanceIfExists()?.project?.deviceSession?.devtools;
 
     const listener = devTools?.onEvent("RNIDE_pluginMessage", (payload) => {
       if (payload.scope === REACT_QUERY_PLUGIN_ID) {

--- a/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/redux-devtools-plugin/ReduxDevToolsPluginWebviewProvider.ts
@@ -120,7 +120,7 @@ export class ReduxDevToolsPluginWebviewProvider implements WebviewViewProvider {
     };
 
     const project = IDE.getInstanceIfExists()?.project;
-    const reduxDevtoolsPlugin = project?.deviceSession?.toolsManager.getPlugin(
+    const reduxDevtoolsPlugin = project?.deviceSession?.getPlugin(
       REDUX_PLUGIN_ID
     ) as ReduxDevtoolsPlugin;
     if (!reduxDevtoolsPlugin) {

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -62,13 +62,13 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
         .values()
         .filter((session) => session !== existingDeviceSession);
       await Promise.all(otherSessions.map((session) => this.terminateSession(session)));
-      return true;
+      return;
     }
 
     // otherwise, we need to acquire the device and start a new session
     const device = await this.acquireDeviceByDeviceInfo(deviceInfo);
     if (!device) {
-      return false;
+      return;
     }
     Logger.debug("Selected device is ready");
 
@@ -90,15 +90,10 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     }
 
     try {
-      await newDeviceSession.start({
-        resetMetroCache: false,
-        cleanBuild: false,
-      });
+      await newDeviceSession.start();
     } catch (e) {
       Logger.error("Couldn't start device session", e instanceof Error ? e.message : e);
-      return false;
     }
-    return true;
   }
 
   private findInitialDeviceAndStartSession = async () => {

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -51,39 +51,34 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
   ) {
     const killPreviousDeviceSession = !selectDeviceOptions?.preservePreviousDevice;
 
-    const existingSession = this.deviceSessions
+    // if there's an existing session for the device, we use it instead of starting a new one
+    const existingDeviceSession = this.deviceSessions
       .values()
       .find((session) => session.deviceInfo.id === deviceInfo.id);
-    if (existingSession) {
-      this.updateSelectedSession(existingSession);
+    if (existingDeviceSession) {
+      this.updateSelectedSession(existingDeviceSession);
       const otherSessions = this.deviceSessions
         .values()
-        .filter((session) => session !== existingSession);
+        .filter((session) => session !== existingDeviceSession);
       await Promise.all(otherSessions.map((session) => this.terminateSession(session)));
       return true;
     }
 
+    // otherwise, we need to acquire the device and start a new session
     const device = await this.acquireDeviceByDeviceInfo(deviceInfo);
     if (!device) {
       return false;
     }
     Logger.debug("Selected device is ready");
 
-    const newDeviceSession = new DeviceSession(
-      this.applicationContext.appRootFolder,
-      deviceInfo,
-      device,
-      this.applicationContext.dependencyManager,
-      this.applicationContext.buildCache,
-      {
-        onStateChange: (state) => {
-          if (this.activeSession === newDeviceSession) {
-            this.deviceSessionManagerDelegate.onActiveSessionStateChanged(state);
-          }
-        },
-        ensureDependenciesAndNodeVersion: async () => {},
-      }
-    );
+    const newDeviceSession = new DeviceSession(this.applicationContext, deviceInfo, device, {
+      onStateChange: (state) => {
+        if (this.activeSession === newDeviceSession) {
+          this.deviceSessionManagerDelegate.onActiveSessionStateChanged(state);
+        }
+      },
+      ensureDependenciesAndNodeVersion: async () => {},
+    });
 
     const previousSessions = this.deviceSessions.values();
     this.deviceSessions.add(newDeviceSession);
@@ -111,18 +106,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
    * If the device list is empty, we wait until we can select a device.
    */
   private async findDeviceAndStartSession() {
-    // if (this.deviceSessions.size > 0) {
-    // if there is some session already running, we switch to that session
-
-    // const selectedActiveSession = await this.trySelectingActiveDeviceSession(
-    //   anyActiveDeviceSessionId,
-    //   true
-    // );
-    // if (selectedActiveSession) {
-    //   return true;
-    // }
-    // }
-
     const findAndStartInternal = async (devices: DeviceInfo[]) => {
       // we try to pick the last selected device that we saved in the persistent state, otherwise
       // we take the first device from the list

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -16,12 +16,14 @@ import {
 } from "../common/DeviceSessionsManager";
 import { disposeAll } from "../utilities/disposables";
 import { DeviceSessionInitialState } from "../common/Project";
+import { CancelError } from "../builders/cancelToken";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 
 export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerInterface {
   private deviceSessions: Set<DeviceSession> = new Set();
   private activeSession: DeviceSession | undefined;
+  private findingDevice: boolean = false;
 
   public get selectedDeviceSession() {
     return this.activeSession;
@@ -32,8 +34,9 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     private readonly deviceManager: DeviceManager,
     private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate
   ) {
-    this.findDeviceAndStartSession();
+    this.findInitialDeviceAndStartSession();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
+    this.deviceManager.addListener("devicesChanged", this.findInitialDeviceAndStartSession);
   }
 
   public async reloadCurrentSession(type: ReloadAction) {
@@ -80,7 +83,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
       ensureDependenciesAndNodeVersion: async () => {},
     });
 
-    const previousSessions = this.deviceSessions.values();
+    const previousSessions = Array.from(this.deviceSessions.values());
     this.deviceSessions.add(newDeviceSession);
     this.updateSelectedSession(newDeviceSession);
 
@@ -100,60 +103,36 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     return true;
   }
 
-  /**
-   * This method tries to select any running device, if there isn't any
-   * it tries to select the last selected device from devices list.
-   * If the device list is empty, we wait until we can select a device.
-   */
-  private async findDeviceAndStartSession() {
-    const findAndStartInternal = async (devices: DeviceInfo[]) => {
+  private findInitialDeviceAndStartSession = async () => {
+    if (this.selectedDeviceSession && !this.findingDevice) {
+      // this method can be triggered when new devices are added, we don't want to
+      // run the device selection process, if an existing session is already running
+      // or if we're already in the process of finding a device.
+      return;
+    }
+
+    try {
+      this.findingDevice = true;
+
+      const devices = await this.deviceManager.listAllDevices();
+
       // we try to pick the last selected device that we saved in the persistent state, otherwise
-      // we take the first device from the list
+      // we take the first iOS device from the list, or any first device if there's no iOS device
       const lastDeviceId = extensionContext.workspaceState.get<string | undefined>(
         LAST_SELECTED_DEVICE_KEY
       );
-      // we select first iOS device if the user didn't use any device before
       const defaultDevice =
         devices.find((device) => device.platform === DevicePlatform.IOS) ?? devices.at(0);
       const device = devices.find((device) => device.id === lastDeviceId) ?? defaultDevice;
 
       if (device) {
         // if we found a device on the devices list, we try to select it
-        const isDeviceSelected = await this.startOrActivateSessionForDevice(device);
-        if (isDeviceSelected) {
-          return true;
-        }
+        await this.startOrActivateSessionForDevice(device);
       }
-
-      // if device selection wasn't successful we will retry it later on when devicesChange
-      // event is emitted (i.e. when user create a new device). We also make sure that the
-      // device selection is cleared in the project state:
-      this.updateSelectedSession(undefined);
-
-      // when we reach this place, it means there's no device that we can select, we
-      // wait for the new device to be added to the list:
-      const listener = async (newDevices: DeviceInfo[]) => {
-        this.deviceManager.removeListener("devicesChanged", listener);
-        if (this.activeSession) {
-          // device was selected in the meantime, we don't need to do anything
-          return;
-        } else if (isEqual(newDevices, devices)) {
-          // list is the same, we register listener to wait for the next change
-          this.deviceManager.addListener("devicesChanged", listener);
-        } else {
-          findAndStartInternal(newDevices);
-        }
-      };
-
-      // we trigger initial listener call with the most up to date list of devices
-      listener(await this.deviceManager.listAllDevices());
-
-      return false;
-    };
-
-    const devices = await this.deviceManager.listAllDevices();
-    await findAndStartInternal(devices);
-  }
+    } finally {
+      this.findingDevice = false;
+    }
+  };
 
   // used in callbacks, needs to be an arrow function
   private removeDeviceListener = async (device: DeviceInfo) => {
@@ -171,11 +150,9 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     if (previousSession !== session) {
       previousSession?.deactivate();
       session?.activate();
-    }
-    if (session) {
-      this.deviceSessionManagerDelegate.onActiveSessionStateChanged(session.getState());
-    } else {
-      this.deviceSessionManagerDelegate.onActiveSessionStateChanged(DeviceSessionInitialState);
+      this.deviceSessionManagerDelegate.onActiveSessionStateChanged(
+        session?.getState() ?? DeviceSessionInitialState
+      );
     }
   }
 
@@ -220,5 +197,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
   dispose() {
     disposeAll(this.deviceSessions.values().toArray());
     this.deviceManager.removeListener("deviceRemoved", this.removeDeviceListener);
+    this.deviceManager.removeListener("devicesChanged", this.findInitialDeviceAndStartSession);
   }
 }

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -1,16 +1,13 @@
 import { isEqual } from "lodash";
 import { Disposable, window } from "vscode";
-import { BuildError } from "../builders/BuildManager";
-import { DeviceInfo } from "../common/DeviceManager";
-import { ProjectState, StartupMessage } from "../common/Project";
+import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { ApplicationContext } from "./ApplicationContext";
-import { DeviceBootError, DeviceSession } from "./deviceSession";
+import { DeviceSession, DeviceSessionDelegate } from "./deviceSession";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
-import { CancelError } from "../builders/cancelToken";
 import {
   DeviceSessionsManagerInterface,
   DeviceSessionsManagerDelegate,
@@ -18,203 +15,117 @@ import {
   SelectDeviceOptions,
 } from "../common/DeviceSessionsManager";
 import { disposeAll } from "../utilities/disposables";
+import { DeviceSessionState } from "../common/Project";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 
-export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Disposable {
-  // selected device id
-  private selectedDevice: string | undefined;
-  private deviceSessions: Map<string, DeviceSession> = new Map();
+export class DeviceSessionsManager
+  implements Disposable, DeviceSessionsManagerInterface, DeviceSessionDelegate
+{
+  private deviceSessions: Set<DeviceSession> = new Set();
+  private activeSession: DeviceSession | undefined;
 
   public get selectedDeviceSession() {
-    if (!this.selectedDevice) {
-      return undefined;
-    }
-    return this.deviceSessions.get(this.selectedDevice);
+    return this.activeSession;
   }
 
   constructor(
     private readonly applicationContext: ApplicationContext,
     private readonly deviceManager: DeviceManager,
-    private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate,
-    private readonly updateProjectState: (newState: Partial<ProjectState>) => void
+    private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate
   ) {
-    this.trySelectingDevice();
+    this.findDeviceAndStartSession();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
   }
 
-  private updateStateForSession(deviceSession: DeviceSession, newState: Partial<ProjectState>) {
-    if (deviceSession === this.selectedDeviceSession) {
-      this.updateProjectState(newState);
-    }
-  }
+  // private async trySelectingActiveDeviceSession(id: string, killPreviousDeviceSession?: boolean) {
+  //   if (!this.activeSessions.has(id)) {
+  //     return false;
+  //   }
+  //   if (this.selectedDevice) {
+  //     if (killPreviousDeviceSession) {
+  //       this.killAndRemoveDevice(this.selectedDevice);
+  //     } else {
+  //       await this.selectedDeviceSession?.deactivate();
+  //     }
+  //   }
+  //   this.selectedDevice = id;
+  //   this.selectedDeviceSession?.activate();
+  //   return true;
+  // }
 
-  private async trySelectingActiveDeviceSession(id: string, killPreviousDeviceSession?: boolean) {
-    if (!this.deviceSessions.has(id)) {
-      return false;
-    }
-    if (this.selectedDevice) {
-      if (killPreviousDeviceSession) {
-        this.killAndRemoveDevice(this.selectedDevice);
-      } else {
-        await this.selectedDeviceSession?.deactivate();
-      }
-    }
-    this.selectedDevice = id;
-    this.selectedDeviceSession?.activate();
-    return true;
-  }
-
-  public async reload(type: ReloadAction) {
-    this.deviceSessionManagerDelegate.onReloadRequested(type);
-
+  public async reloadCurrentSession(type: ReloadAction) {
     const deviceSession = this.selectedDeviceSession;
     if (!deviceSession) {
       window.showErrorMessage("Failed to reload, no active device found.", "Dismiss");
       return false;
     }
-    try {
-      const success = await deviceSession.perform(type);
-      if (success) {
-        this.updateStateForSession(deviceSession, { status: "running" });
-        return true;
-      } else if (!success) {
-        window.showErrorMessage("Failed to reload, you may try another reload option.", "Dismiss");
-      }
-    } catch (e) {
-      if (e instanceof CancelError) {
-        return false;
-      } else if (e instanceof BuildError) {
-        this.updateStateForSession(deviceSession, {
-          status: "buildError",
-          buildError: {
-            message: e.message,
-            buildType: e.buildType,
-            platform: this.selectedDeviceSession.platform,
-          },
-        });
-      }
-      Logger.error("Failed to reload device", e);
-      throw e;
-    }
-    return false;
+    return await deviceSession.performReloadAction(type);
   }
 
-  public async stopDevice(deviceId: string) {
-    if (deviceId === this.selectedDevice) {
-      window.showWarningMessage(
-        "You cannot stop the selected device. Please select another device first.",
-        "Dismiss"
-      );
-      return false;
-    }
-    const deviceSession = this.deviceSessions.get(deviceId);
-    if (!deviceSession) {
-      Logger.warn("Failed to stop device, device wasn't running.", "Dismiss");
-      return true;
-    }
-    await this.killAndRemoveDevice(deviceId);
-    return true;
-  }
+  // private onSessionStateChanged(session: DeviceSession) {
+  //   if (session === this.activeSession) {
+  //     this.deviceSessionManagerDelegate.onActiveSessionStateChanged(session.getState());
+  //   }
+  // }
 
-  public async selectDevice(deviceInfo: DeviceInfo, selectDeviceOptions?: SelectDeviceOptions) {
+  public async startOrActivateSessionForDevice(
+    deviceInfo: DeviceInfo,
+    selectDeviceOptions?: SelectDeviceOptions
+  ) {
     const killPreviousDeviceSession = !selectDeviceOptions?.preservePreviousDevice;
-    const { id: newDeviceId } = deviceInfo;
 
-    const selectedActiveSession = await this.trySelectingActiveDeviceSession(
-      newDeviceId,
-      killPreviousDeviceSession
-    );
-
-    if (selectedActiveSession) {
-      this.deviceSessionManagerDelegate.onDeviceSelected(
-        deviceInfo,
-        this.selectedDeviceSession?.previewURL
-      );
+    const existingSession = this.deviceSessions
+      .values()
+      .find((session) => session.deviceInfo.id === deviceInfo.id);
+    if (existingSession) {
+      this.updateSelectedSession(existingSession);
+      const otherSessions = this.deviceSessions
+        .values()
+        .filter((session) => session !== existingSession);
+      await Promise.all(otherSessions.map((session) => this.terminateSession(session)));
       return true;
     }
 
-    const device = await this.selectDeviceOnly(deviceInfo);
+    const device = await this.acquireDeviceByDeviceInfo(deviceInfo);
     if (!device) {
       return false;
     }
     Logger.debug("Selected device is ready");
 
-    if (this.selectedDevice) {
-      if (killPreviousDeviceSession) {
-        await this.killAndRemoveDevice(this.selectedDevice);
-      } else {
-        await this.selectedDeviceSession?.deactivate();
+    const newDeviceSession = new DeviceSession(
+      this.applicationContext.appRootFolder,
+      deviceInfo,
+      device,
+      this.applicationContext.dependencyManager,
+      this.applicationContext.buildCache,
+      {
+        onStateChange: (state) => {
+          if (this.activeSession === newDeviceSession) {
+            this.deviceSessionManagerDelegate.onActiveSessionStateChanged(state);
+          }
+        },
+        ensureDependenciesAndNodeVersion: async () => {},
       }
+    );
+
+    const previousSessions = this.deviceSessions.values();
+    this.deviceSessions.add(newDeviceSession);
+    this.updateSelectedSession(newDeviceSession);
+
+    if (killPreviousDeviceSession) {
+      await Promise.all(previousSessions.map((session) => this.terminateSession(session)));
     }
 
-    // we explicitely update the project state w/o using updateStateForSession
-    // as the new session is just being created
-    this.updateProjectState({
-      selectedDevice: deviceInfo,
-      initialized: true,
-      status: "starting",
-      startupMessage: StartupMessage.InitializingDevice,
-      previewURL: undefined,
-    });
-
-    let newDeviceSession: DeviceSession | undefined;
     try {
-      const deviceSession = new DeviceSession(
-        this.applicationContext.appRootFolder,
-        device,
-        this.applicationContext.dependencyManager,
-        this.applicationContext.buildCache,
-        this.deviceSessionManagerDelegate,
-        this.deviceSessionManagerDelegate,
-        this.deviceSessionManagerDelegate,
-        this.deviceSessionManagerDelegate
-      );
-      newDeviceSession = deviceSession;
-      this.deviceSessions.set(newDeviceId, deviceSession);
-      this.selectedDevice = newDeviceId;
-
-      const previewURL = await newDeviceSession.start({
+      await newDeviceSession.start({
         resetMetroCache: false,
         cleanBuild: false,
-        previewReadyCallback: (url) => {
-          this.updateStateForSession(deviceSession, { previewURL: url });
-        },
-      });
-      this.updateStateForSession(deviceSession, {
-        previewURL,
-        status: "running",
       });
     } catch (e) {
       Logger.error("Couldn't start device session", e instanceof Error ? e.message : e);
-
-      if (newDeviceSession) {
-        if (e instanceof CancelError) {
-          Logger.debug("[SelectDevice] Device selection was canceled", e);
-        } else if (e instanceof DeviceBootError) {
-          this.updateStateForSession(newDeviceSession, { status: "bootError" });
-        } else if (e instanceof BuildError) {
-          this.updateStateForSession(newDeviceSession, {
-            status: "buildError",
-            buildError: {
-              message: e.message,
-              buildType: e.buildType,
-              platform: deviceInfo.platform,
-            },
-          });
-        } else {
-          this.updateStateForSession(newDeviceSession, {
-            status: "buildError",
-            buildError: {
-              message: (e as Error).message,
-              buildType: null,
-              platform: deviceInfo.platform,
-            },
-          });
-        }
-      }
+      return false;
     }
-    this.deviceSessionManagerDelegate.onDeviceSelected(deviceInfo);
     return true;
   }
 
@@ -223,30 +134,33 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
    * it tries to select the last selected device from devices list.
    * If the device list is empty, we wait until we can select a device.
    */
-  private async trySelectingDevice() {
-    const anyActiveDeviceSessionId = this.deviceSessions.keys().next().value;
+  private async findDeviceAndStartSession() {
+    // if (this.deviceSessions.size > 0) {
+    // if there is some session already running, we switch to that session
 
-    if (anyActiveDeviceSessionId) {
-      const selectedActiveSession = await this.trySelectingActiveDeviceSession(
-        anyActiveDeviceSessionId,
-        true
-      );
-      if (selectedActiveSession) {
-        return true;
-      }
-    }
+    // const selectedActiveSession = await this.trySelectingActiveDeviceSession(
+    //   anyActiveDeviceSessionId,
+    //   true
+    // );
+    // if (selectedActiveSession) {
+    //   return true;
+    // }
+    // }
 
-    const selectInitialDevice = async (devices: DeviceInfo[]) => {
+    const findAndStartInternal = async (devices: DeviceInfo[]) => {
       // we try to pick the last selected device that we saved in the persistent state, otherwise
       // we take the first device from the list
       const lastDeviceId = extensionContext.workspaceState.get<string | undefined>(
         LAST_SELECTED_DEVICE_KEY
       );
-      const device = devices.find(({ id }) => id === lastDeviceId) ?? devices.at(0);
+      // we select first iOS device if the user didn't use any device before
+      const defaultDevice =
+        devices.find((device) => device.platform === DevicePlatform.IOS) ?? devices.at(0);
+      const device = devices.find((device) => device.id === lastDeviceId) ?? defaultDevice;
 
       if (device) {
         // if we found a device on the devices list, we try to select it
-        const isDeviceSelected = await this.selectDevice(device);
+        const isDeviceSelected = await this.startOrActivateSessionForDevice(device);
         if (isDeviceSelected) {
           return true;
         }
@@ -255,22 +169,20 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
       // if device selection wasn't successful we will retry it later on when devicesChange
       // event is emitted (i.e. when user create a new device). We also make sure that the
       // device selection is cleared in the project state:
-      this.updateProjectState({
-        selectedDevice: undefined,
-        initialized: true, // when no device can be selected, we consider the project initialized
-      });
+      this.updateSelectedSession(undefined);
+
       // when we reach this place, it means there's no device that we can select, we
       // wait for the new device to be added to the list:
       const listener = async (newDevices: DeviceInfo[]) => {
         this.deviceManager.removeListener("devicesChanged", listener);
-        if (this.selectedDevice) {
+        if (this.activeSession) {
           // device was selected in the meantime, we don't need to do anything
           return;
         } else if (isEqual(newDevices, devices)) {
           // list is the same, we register listener to wait for the next change
           this.deviceManager.addListener("devicesChanged", listener);
         } else {
-          selectInitialDevice(newDevices);
+          findAndStartInternal(newDevices);
         }
       };
 
@@ -281,26 +193,48 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
     };
 
     const devices = await this.deviceManager.listAllDevices();
-    await selectInitialDevice(devices);
+    await findAndStartInternal(devices);
   }
 
   // used in callbacks, needs to be an arrow function
   private removeDeviceListener = async (device: DeviceInfo) => {
-    const deviceSession = this.selectedDeviceSession;
-    if (this.selectedDevice === device.id) {
-      this.updateStateForSession(this.selectedDeviceSession, { status: "starting" });
-      await this.killAndRemoveDevice(device.id);
-      await this.trySelectingDevice();
-    }
+    // if the deleted device was running an active session, we need to terminate that session
+    this.deviceSessions.forEach((session) => {
+      if (session.deviceInfo.id === device.id) {
+        this.terminateSession(session);
+      }
+    });
   };
 
-  private async killAndRemoveDevice(deviceId: string) {
-    const deviceSession = this.deviceSessions.get(deviceId);
-    await deviceSession?.dispose();
-    this.deviceSessions.delete(deviceId);
+  private updateSelectedSession(session: DeviceSession | undefined) {
+    const previousSession = this.activeSession;
+    this.activeSession = session;
+    if (previousSession !== session) {
+      previousSession?.deactivate();
+      session?.activate();
+    }
+    if (session) {
+      this.deviceSessionManagerDelegate.onStateChange(session.getState());
+    } else {
+      this.deviceSessionManagerDelegate.onStateChange({
+        status: "starting",
+        previewURL: undefined,
+        selectedDevice: undefined,
+        startupMessage: undefined,
+        stageProgress: undefined,
+      });
+    }
   }
 
-  private async selectDeviceOnly(deviceInfo: DeviceInfo) {
+  private async terminateSession(session: DeviceSession) {
+    this.deviceSessions.delete(session);
+    if (session === this.activeSession) {
+      this.updateSelectedSession(undefined);
+    }
+    await session.dispose();
+  }
+
+  private async acquireDeviceByDeviceInfo(deviceInfo: DeviceInfo) {
     if (!deviceInfo.available) {
       window.showErrorMessage(
         "Selected device is not available. Perhaps the system image it uses is not installed. Please select another device.",

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -1,11 +1,10 @@
-import { isEqual } from "lodash";
 import { Disposable, window } from "vscode";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { ApplicationContext } from "./ApplicationContext";
-import { DeviceSession, DeviceSessionDelegate } from "./deviceSession";
+import { DeviceSession } from "./deviceSession";
 import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import {
@@ -16,7 +15,6 @@ import {
 } from "../common/DeviceSessionsManager";
 import { disposeAll } from "../utilities/disposables";
 import { DeviceSessionInitialState } from "../common/Project";
-import { CancelError } from "../builders/cancelToken";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 
@@ -123,11 +121,11 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
       );
       const defaultDevice =
         devices.find((device) => device.platform === DevicePlatform.IOS) ?? devices.at(0);
-      const device = devices.find((device) => device.id === lastDeviceId) ?? defaultDevice;
+      const initialDevice = devices.find((device) => device.id === lastDeviceId) ?? defaultDevice;
 
-      if (device) {
+      if (initialDevice) {
         // if we found a device on the devices list, we try to select it
-        await this.startOrActivateSessionForDevice(device);
+        await this.startOrActivateSessionForDevice(initialDevice);
       }
     } finally {
       this.findingDevice = false;

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -43,6 +43,12 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
   }
 
+  private updateStateForSession(deviceSession: DeviceSession, newState: Partial<ProjectState>) {
+    if (deviceSession === this.selectedDeviceSession) {
+      this.updateProjectState(newState);
+    }
+  }
+
   private async trySelectingActiveDeviceSession(id: string, killPreviousDeviceSession?: boolean) {
     if (!this.deviceSessions.has(id)) {
       return false;
@@ -70,7 +76,7 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
     try {
       const success = await deviceSession.perform(type);
       if (success) {
-        this.updateProjectState({ status: "running" });
+        this.updateStateForSession(deviceSession, { status: "running" });
         return true;
       } else if (!success) {
         window.showErrorMessage("Failed to reload, you may try another reload option.", "Dismiss");
@@ -79,7 +85,7 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
       if (e instanceof CancelError) {
         return false;
       } else if (e instanceof BuildError) {
-        this.updateProjectState({
+        this.updateStateForSession(deviceSession, {
           status: "buildError",
           buildError: {
             message: e.message,
@@ -142,6 +148,8 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
       }
     }
 
+    // we explicitely update the project state w/o using updateStateForSession
+    // as the new session is just being created
     this.updateProjectState({
       selectedDevice: deviceInfo,
       initialized: true,
@@ -150,9 +158,9 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
       previewURL: undefined,
     });
 
-    let newDeviceSession;
+    let newDeviceSession: DeviceSession | undefined;
     try {
-      newDeviceSession = new DeviceSession(
+      const deviceSession = new DeviceSession(
         this.applicationContext.appRootFolder,
         device,
         this.applicationContext.dependencyManager,
@@ -162,32 +170,31 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
         this.deviceSessionManagerDelegate,
         this.deviceSessionManagerDelegate
       );
-      this.deviceSessions.set(newDeviceId, newDeviceSession);
+      newDeviceSession = deviceSession;
+      this.deviceSessions.set(newDeviceId, deviceSession);
       this.selectedDevice = newDeviceId;
 
       const previewURL = await newDeviceSession.start({
         resetMetroCache: false,
         cleanBuild: false,
         previewReadyCallback: (url) => {
-          this.updateProjectState({ previewURL: url });
+          this.updateStateForSession(deviceSession, { previewURL: url });
         },
       });
-      this.updateProjectState({
+      this.updateStateForSession(deviceSession, {
         previewURL,
         status: "running",
       });
     } catch (e) {
       Logger.error("Couldn't start device session", e instanceof Error ? e.message : e);
 
-      const isSelected = this.selectedDevice === deviceInfo.id;
-      const isNewSession = this.selectedDeviceSession === newDeviceSession;
-      if (isSelected && isNewSession) {
+      if (newDeviceSession) {
         if (e instanceof CancelError) {
           Logger.debug("[SelectDevice] Device selection was canceled", e);
         } else if (e instanceof DeviceBootError) {
-          this.updateProjectState({ status: "bootError" });
+          this.updateStateForSession(newDeviceSession, { status: "bootError" });
         } else if (e instanceof BuildError) {
-          this.updateProjectState({
+          this.updateStateForSession(newDeviceSession, {
             status: "buildError",
             buildError: {
               message: e.message,
@@ -196,7 +203,7 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
             },
           });
         } else {
-          this.updateProjectState({
+          this.updateStateForSession(newDeviceSession, {
             status: "buildError",
             buildError: {
               message: (e as Error).message,
@@ -279,8 +286,9 @@ export class DeviceSessionsManager implements DeviceSessionsManagerInterface, Di
 
   // used in callbacks, needs to be an arrow function
   private removeDeviceListener = async (device: DeviceInfo) => {
+    const deviceSession = this.selectedDeviceSession;
     if (this.selectedDevice === device.id) {
-      this.updateProjectState({ status: "starting" });
+      this.updateStateForSession(this.selectedDeviceSession, { status: "starting" });
       await this.killAndRemoveDevice(device.id);
       await this.trySelectingDevice();
     }

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -15,13 +15,11 @@ import {
   SelectDeviceOptions,
 } from "../common/DeviceSessionsManager";
 import { disposeAll } from "../utilities/disposables";
-import { DeviceSessionState } from "../common/Project";
+import { DeviceSessionInitialState } from "../common/Project";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 
-export class DeviceSessionsManager
-  implements Disposable, DeviceSessionsManagerInterface, DeviceSessionDelegate
-{
+export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerInterface {
   private deviceSessions: Set<DeviceSession> = new Set();
   private activeSession: DeviceSession | undefined;
 
@@ -38,22 +36,6 @@ export class DeviceSessionsManager
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
   }
 
-  // private async trySelectingActiveDeviceSession(id: string, killPreviousDeviceSession?: boolean) {
-  //   if (!this.activeSessions.has(id)) {
-  //     return false;
-  //   }
-  //   if (this.selectedDevice) {
-  //     if (killPreviousDeviceSession) {
-  //       this.killAndRemoveDevice(this.selectedDevice);
-  //     } else {
-  //       await this.selectedDeviceSession?.deactivate();
-  //     }
-  //   }
-  //   this.selectedDevice = id;
-  //   this.selectedDeviceSession?.activate();
-  //   return true;
-  // }
-
   public async reloadCurrentSession(type: ReloadAction) {
     const deviceSession = this.selectedDeviceSession;
     if (!deviceSession) {
@@ -62,12 +44,6 @@ export class DeviceSessionsManager
     }
     return await deviceSession.performReloadAction(type);
   }
-
-  // private onSessionStateChanged(session: DeviceSession) {
-  //   if (session === this.activeSession) {
-  //     this.deviceSessionManagerDelegate.onActiveSessionStateChanged(session.getState());
-  //   }
-  // }
 
   public async startOrActivateSessionForDevice(
     deviceInfo: DeviceInfo,
@@ -214,15 +190,9 @@ export class DeviceSessionsManager
       session?.activate();
     }
     if (session) {
-      this.deviceSessionManagerDelegate.onStateChange(session.getState());
+      this.deviceSessionManagerDelegate.onActiveSessionStateChanged(session.getState());
     } else {
-      this.deviceSessionManagerDelegate.onStateChange({
-        status: "starting",
-        previewURL: undefined,
-        selectedDevice: undefined,
-        startupMessage: undefined,
-        stageProgress: undefined,
-      });
+      this.deviceSessionManagerDelegate.onActiveSessionStateChanged(DeviceSessionInitialState);
     }
   }
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import assert from "assert";
 import { commands, DebugSessionCustomEvent, Disposable, window } from "vscode";
 import { MetroLauncher, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -84,7 +84,7 @@ export class DeviceSession
   private toolsManager: ToolsManager;
   private inspectCallID = 7621;
   private maybeBuildResult: BuildResult | undefined;
-  private devtools;
+  public devtools; // TODO: make this private!
   private debugSession: DebugSession;
   private disposableBuild: DisposableBuild<BuildResult> | undefined;
   private buildManager: BuildManager;
@@ -142,9 +142,11 @@ export class DeviceSession
   }
 
   public getState(): DeviceSessionState {
-    const state = {
+    return {
+      status: this.status,
       startupMessage: this.startupMessage,
       stageProgress: this.stageProgress,
+      buildError: this.buildError,
       fastRefreshOngoing: this.fastRefreshOngoing,
       profilingCPUState: this.profilingCPUState,
       profilingReactState: this.profilingReactState,
@@ -156,19 +158,6 @@ export class DeviceSession
       logCount: this.logCount,
       hasStaleBuildCache: this.hasStaleBuildCache,
     };
-    if (this.status === "buildError") {
-      assert(this.buildError, "build error needs to be set");
-      return {
-        ...state,
-        status: "buildError",
-        buildError: this.buildError,
-      };
-    } else {
-      return {
-        ...state,
-        status: this.status,
-      };
-    }
   }
 
   //#region Metro delegate methods
@@ -963,5 +952,13 @@ export class DeviceSession
 
   public async openTool(toolName: ToolKey) {
     this.toolsManager.openTool(toolName);
+  }
+
+  public getPlugin(toolName: ToolKey) {
+    return this.toolsManager.getPlugin(toolName);
+  }
+
+  public getMetroPort() {
+    return this.metro.port;
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -276,7 +276,7 @@ export class DeviceSession
   build in vscode dispose system ignores async keyword and works synchronously.
   */
   public async dispose() {
-    this.deactivate();
+    await this.deactivate();
     await this.debugSession?.dispose();
     this.disposableBuild?.dispose();
     this.device?.dispose();

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -31,32 +31,11 @@ import { getTelemetryReporter } from "../utilities/telemetry";
 import { CancelError, CancelToken } from "../builders/cancelToken";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { ToolKey, ToolsDelegate, ToolsManager } from "./tools";
-import { extensionContext } from "../utilities/extensionContext";
 import { ReloadAction } from "../common/DeviceSessionsManager";
 import { focusSource } from "../utilities/focusSource";
 import { ApplicationContext } from "./ApplicationContext";
 
-const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const MAX_URL_HISTORY_SIZE = 20;
-
-export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
-  appearance: "dark",
-  contentSize: "normal",
-  location: {
-    latitude: 50.048653,
-    longitude: 19.965474,
-    isDisabled: false,
-  },
-  hasEnrolledBiometrics: false,
-  locale: "en_US",
-  replaysEnabled: false,
-  showTouches: false,
-};
-
-type StartOptions = {
-  cleanBuild: boolean;
-  resetMetroCache: boolean;
-};
 
 type RestartOptions = {
   forceClean: boolean;
@@ -89,8 +68,6 @@ export class DeviceSession
   private debugSession: DebugSession;
   private disposableBuild: DisposableBuild<BuildResult> | undefined;
   private buildManager: BuildManager;
-  public deviceSettings: DeviceSettings;
-  private isLaunching = true;
   private cancelToken: CancelToken | undefined;
 
   private status: DeviceSessionStatus = "starting";
@@ -113,10 +90,6 @@ export class DeviceSession
     return this.maybeBuildResult;
   }
 
-  public get isAppLaunched() {
-    return !this.isLaunching;
-  }
-
   public get previewURL() {
     return this.device.previewURL;
   }
@@ -131,9 +104,6 @@ export class DeviceSession
     private readonly device: DeviceBase,
     private readonly deviceSessionDelegate: DeviceSessionDelegate
   ) {
-    this.deviceSettings =
-      extensionContext.workspaceState.get(DEVICE_SETTINGS_KEY) ?? DEVICE_SETTINGS_DEFAULT;
-
     this.devtools = this.makeDevtools();
     this.metro = new MetroLauncher(this.devtools, this);
     this.toolsManager = new ToolsManager(this.devtools, this);
@@ -144,7 +114,7 @@ export class DeviceSession
       this,
       device.platform
     );
-    this.debugSession = new DebugSession(this);
+    this.debugSession = new DebugSession(this, { useParentDebugSession: true });
   }
 
   public getState(): DeviceSessionState {
@@ -315,19 +285,21 @@ export class DeviceSession
   }
 
   public async activate() {
-    this.isActive = true;
-    this.buildManager.activate();
-    this.toolsManager.activate();
-    this.debugSession = new DebugSession(this);
-    await this.debugSession.startParentDebugSession();
-    await this.connectJSDebugger();
+    if (!this.isActive) {
+      this.isActive = true;
+      this.toolsManager.activate();
+      if (this.startupMessage === StartupMessage.AttachingDebugger) {
+        await this.reconnectJSDebuggerIfNeeded();
+      }
+    }
   }
 
   public async deactivate() {
-    this.isActive = false;
-    await this.debugSession.dispose();
-    this.buildManager.deactivate();
-    this.toolsManager.deactivate();
+    if (this.isActive) {
+      this.isActive = false;
+      this.toolsManager.deactivate();
+      await this.debugSession.dispose();
+    }
   }
 
   public async performReloadAction(type: ReloadAction): Promise<boolean> {
@@ -437,7 +409,6 @@ export class DeviceSession
   private async restart({ forceClean, cleanCache }: RestartOptions) {
     if (this.cancelToken) {
       this.cancelToken.cancel();
-      this.cancelToken = undefined;
     }
 
     const cancelToken = new CancelToken();
@@ -521,8 +492,6 @@ export class DeviceSession
     await this.debugSession.restart();
   }
 
-  private launchAppCancelToken: CancelToken | undefined;
-
   private async reconnectJSDebuggerIfNeeded() {
     // after reloading JS, we sometimes need to reconnect the JS debugger. This is
     // needed specifically in Expo Go based environments where the reloaded runtime
@@ -574,7 +543,6 @@ export class DeviceSession
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
       platform: this.device.platform,
     });
-    this.isLaunching = true;
     this.device.disableReplays();
 
     // FIXME: Windows getting stuck waiting for the promise to resolve. This
@@ -621,14 +589,8 @@ export class DeviceSession
     Logger.debug("App and preview ready, moving on...");
     this.startupMessage = StartupMessage.AttachingDebugger;
     this.emitStateChange();
-    await cancelToken.adapt(this.connectJSDebugger());
-
-    this.isLaunching = false;
-    if (this.deviceSettings?.replaysEnabled) {
-      this.device.enableReplay();
-    }
-    if (this.deviceSettings?.showTouches) {
-      this.device.showTouches();
+    if (this.isActive) {
+      await cancelToken.adapt(this.connectJSDebugger());
     }
 
     const launchDurationSec = (Date.now() - launchRequestTime) / 1000;
@@ -642,11 +604,11 @@ export class DeviceSession
     return previewURL!;
   }
 
-  private async bootDevice(deviceSettings: DeviceSettings) {
+  private async bootDevice() {
     this.startupMessage = StartupMessage.BootingDevice;
     this.emitStateChange();
     try {
-      await this.device.bootDevice(deviceSettings);
+      await this.device.bootDevice();
     } catch (e) {
       Logger.error("Failed to boot device", e);
       throw new DeviceBootError("Failed to boot device", e);
@@ -702,10 +664,44 @@ export class DeviceSession
     Logger.debug("Metro & devtools ready");
   }
 
-  public async start({ cleanBuild, resetMetroCache }: StartOptions) {
+  public async start() {
     try {
-      await this.startInternal({ cleanBuild, resetMetroCache });
-      this.status = "running";
+      this.resetStartingState(StartupMessage.InitializingDevice);
+
+      if (this.cancelToken) {
+        this.cancelToken.cancel();
+      }
+
+      const cancelToken = new CancelToken();
+      this.cancelToken = cancelToken;
+
+      const waitForNodeModules = this.deviceSessionDelegate.ensureDependenciesAndNodeVersion();
+
+      Logger.debug(`Launching devtools`);
+      this.devtools.start();
+
+      Logger.debug(`Launching metro`);
+      this.metro.start({
+        resetCache: false,
+        appRoot: this.applicationContext.appRootFolder,
+        dependencies: [waitForNodeModules],
+      });
+
+      if (this.isActive) {
+        await cancelToken.adapt(this.debugSession.startParentDebugSession());
+      }
+
+      await cancelToken.adapt(this.waitForMetroReady());
+      // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
+      await cancelToken.adapt(this.bootDevice());
+      await this.buildApp({
+        appRoot: this.applicationContext.appRootFolder,
+        clean: false,
+        cancelToken,
+      });
+      await cancelToken.adapt(this.installApp({ reinstall: false }));
+      await this.launchApp(cancelToken);
+      Logger.debug("Device session started");
     } catch (e) {
       if (e instanceof CancelError) {
         Logger.info("Device selection was canceled", e);
@@ -736,48 +732,6 @@ export class DeviceSession
     this.deviceSessionDelegate.onStateChange(this.getState());
   }
 
-  private async startInternal({ cleanBuild, resetMetroCache }: StartOptions) {
-    this.resetStartingState(StartupMessage.InitializingDevice);
-
-    this.emitStateChange();
-
-    if (this.cancelToken) {
-      this.cancelToken.cancel();
-      this.cancelToken = undefined;
-    }
-
-    const cancelToken = new CancelToken();
-    this.cancelToken = cancelToken;
-
-    const waitForNodeModules = this.deviceSessionDelegate.ensureDependenciesAndNodeVersion();
-
-    Logger.debug(`Launching devtools`);
-    this.devtools.start();
-
-    Logger.debug(`Launching metro`);
-    this.metro.start({
-      resetCache: resetMetroCache,
-      appRoot: this.applicationContext.appRootFolder,
-      dependencies: [waitForNodeModules],
-    });
-    // We start the debug session early to be able to use it to surface bundle
-    // errors in the console. We only start the parent debug session and the JS
-    // debugger will be started at later time once the app is built and launched.
-    await cancelToken.adapt(this.debugSession.startParentDebugSession());
-
-    await cancelToken.adapt(this.waitForMetroReady());
-    // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
-    await cancelToken.adapt(this.bootDevice(this.deviceSettings));
-    await this.buildApp({
-      appRoot: this.applicationContext.appRootFolder,
-      clean: cleanBuild,
-      cancelToken,
-    });
-    await cancelToken.adapt(this.installApp({ reinstall: false }));
-    await this.launchApp(cancelToken);
-    Logger.debug("Device session started");
-  }
-
   private async connectJSDebugger() {
     const websocketAddress = await this.metro.getDebuggerURL();
     if (!websocketAddress) {
@@ -793,7 +747,8 @@ export class DeviceSession
     });
 
     if (connected) {
-      // TODO(jgonet): Right now, we ignore start failure
+      this.status = "running";
+      this.emitStateChange();
       Logger.debug("Connected to debugger, moving on...");
     } else {
       Logger.error("Couldn't connect to debugger");
@@ -960,36 +915,8 @@ export class DeviceSession
     return promise;
   }
 
-  public async changeDeviceSettings(settings: DeviceSettings): Promise<boolean> {
-    const changedSettings = (Object.keys(settings) as Array<keyof DeviceSettings>).filter(
-      (settingKey) => {
-        return !_.isEqual(settings[settingKey], this.deviceSettings[settingKey]);
-      }
-    );
-
-    getTelemetryReporter().sendTelemetryEvent("device-settings:update-device-settings", {
-      platform: this.device.platform,
-      changedSetting: JSON.stringify(changedSettings),
-    });
-
-    extensionContext.workspaceState.update(DEVICE_SETTINGS_KEY, settings);
-    if (this.deviceSettings?.replaysEnabled !== settings.replaysEnabled && !this.isLaunching) {
-      if (settings.replaysEnabled) {
-        this.device.enableReplay();
-      } else {
-        this.device.disableReplays();
-      }
-    }
-    if (this.deviceSettings?.showTouches !== settings.showTouches && !this.isLaunching) {
-      if (settings.showTouches) {
-        this.device.showTouches();
-      } else {
-        this.device.hideTouches();
-      }
-    }
-    this.deviceSettings = settings;
-
-    return this.device.changeSettings(settings);
+  public async updateDeviceSettings(settings: DeviceSettings): Promise<boolean> {
+    return this.device.updateDeviceSettings(settings);
   }
 
   public focusBuildOutput() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -23,6 +23,7 @@ import {
   ToolsState,
   ProfilingState,
   NavigationHistoryItem,
+  DeviceSessionStatus,
 } from "../common/Project";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
@@ -95,8 +96,8 @@ export class DeviceSession
   private isLaunching = true;
   private cancelToken: CancelToken | undefined;
 
-  private status: DeviceSessionState["status"] = "starting";
-  private startupMessage: StartupMessage | undefined;
+  private status: DeviceSessionStatus = "starting";
+  private startupMessage: StartupMessage = StartupMessage.InitializingDevice;
   private stageProgress: number | undefined;
   private buildError: BuildErrorDescriptor | undefined;
   private fastRefreshOngoing = false;
@@ -694,6 +695,7 @@ export class DeviceSession
   public async start({ cleanBuild, resetMetroCache }: StartOptions) {
     try {
       await this.startInternal({ cleanBuild, resetMetroCache });
+      this.status = "running";
     } catch (e) {
       if (e instanceof CancelError) {
         Logger.info("Device selection was canceled", e);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -39,6 +39,8 @@ import { ApplicationContext } from "./ApplicationContext";
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const MAX_URL_HISTORY_SIZE = 20;
 
+const something = 88;
+
 export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
   appearance: "dark",
   contentSize: "normal",

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -1,10 +1,12 @@
 import _ from "lodash";
-import { Disposable } from "vscode";
+import assert from "assert";
+import { commands, DebugSessionCustomEvent, Disposable, window } from "vscode";
 import { MetroLauncher, MetroDelegate } from "./metro";
 import { Devtools } from "./devtools";
 import { DeviceBase } from "../devices/DeviceBase";
 import { Logger } from "../Logger";
 import {
+  BuildError,
   BuildManager,
   BuildManagerDelegate,
   BuildResult,
@@ -16,6 +18,10 @@ import {
   StartupMessage,
   TouchPoint,
   DeviceButtonType,
+  DeviceSessionState,
+  BuildErrorDescriptor,
+  ToolsState,
+  ProfilingState,
 } from "../common/Project";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
@@ -24,10 +30,11 @@ import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildCache } from "../builders/BuildCache";
 import { CancelError, CancelToken } from "../builders/cancelToken";
-import { DevicePlatform } from "../common/DeviceManager";
-import { ToolsDelegate, ToolsManager } from "./tools";
+import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
+import { ToolKey, ToolsDelegate, ToolsManager } from "./tools";
 import { extensionContext } from "../utilities/extensionContext";
 import { ReloadAction } from "../common/DeviceSessionsManager";
+import { focusSource } from "../utilities/focusSource";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 
@@ -45,11 +52,9 @@ export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
   showTouches: false,
 };
 
-type PreviewReadyCallback = (previewURL: string) => void;
 type StartOptions = {
   cleanBuild: boolean;
   resetMetroCache: boolean;
-  previewReadyCallback: PreviewReadyCallback;
 };
 
 type RestartOptions = {
@@ -57,27 +62,10 @@ type RestartOptions = {
   cleanCache: boolean;
 };
 
-export type AppEvent = {
-  navigationChanged: { displayName: string; id: string };
-  fastRefreshStarted: undefined;
-  fastRefreshComplete: undefined;
-  isProfilingReact: boolean;
-  isSavingReactProfile: boolean;
-};
-
 export type DeviceSessionDelegate = {
-  onAppEvent<E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void;
-  onStateChange(state: StartupMessage): void;
-  onReloadStarted(id: string): void;
-  onReloadCompleted(id: string): void;
-  onPreviewReady(previewURL: string): void;
-  onBuildProgress(stageProgress: number): void;
-  onDeviceSettingChanged(settings: DeviceSettings): void;
+  onStateChange(state: DeviceSessionState): void;
   ensureDependenciesAndNodeVersion(): Promise<void>;
-} & MetroDelegate &
-  ToolsDelegate &
-  DebugSessionDelegate &
-  BuildManagerDelegate;
+};
 
 export class DeviceBootError extends Error {
   constructor(
@@ -88,13 +76,15 @@ export class DeviceBootError extends Error {
   }
 }
 
-export class DeviceSession implements Disposable {
-  public metro: MetroLauncher;
-  public toolsManager: ToolsManager;
-  private isActive: boolean = false;
+export class DeviceSession
+  implements Disposable, MetroDelegate, ToolsDelegate, DebugSessionDelegate, BuildManagerDelegate
+{
+  private isActive = false;
+  private metro: MetroLauncher;
+  private toolsManager: ToolsManager;
   private inspectCallID = 7621;
   private maybeBuildResult: BuildResult | undefined;
-  public devtools;
+  private devtools;
   private debugSession: DebugSession;
   private disposableBuild: DisposableBuild<BuildResult> | undefined;
   private buildManager: BuildManager;
@@ -102,6 +92,17 @@ export class DeviceSession implements Disposable {
   private isLaunching = true;
   private cancelToken: CancelToken | undefined;
 
+  private status: DeviceSessionState["status"] = "starting";
+  private startupMessage: StartupMessage | undefined;
+  private stageProgress: number | undefined;
+  private buildError: BuildErrorDescriptor | undefined;
+  private fastRefreshOngoing = false;
+  private profilingCPUState: ProfilingState = "stopped";
+  private profilingReactState: ProfilingState = "stopped";
+  private navigationHistory: { displayName: string; id: string }[] = [];
+  private logCount = 0;
+  private isDebuggerPaused = false;
+  private hasStaleBuildCache = false;
   private get buildResult() {
     if (!this.maybeBuildResult) {
       throw new Error("Expecting build to be ready");
@@ -123,29 +124,128 @@ export class DeviceSession implements Disposable {
 
   constructor(
     private readonly appRootFolder: string,
+    readonly deviceInfo: DeviceInfo,
     private readonly device: DeviceBase,
     readonly dependencyManager: DependencyManager,
     readonly buildCache: BuildCache,
-    debugEventDelegate: DebugSessionDelegate,
-    private readonly deviceSessionDelegate: DeviceSessionDelegate,
-    private readonly metroDelegate: MetroDelegate,
-    private readonly toolsDelegate: ToolsDelegate
+    private readonly deviceSessionDelegate: DeviceSessionDelegate
   ) {
     this.deviceSettings =
       extensionContext.workspaceState.get(DEVICE_SETTINGS_KEY) ?? DEVICE_SETTINGS_DEFAULT;
 
     this.devtools = this.makeDevtools();
-    this.metro = new MetroLauncher(this.devtools, metroDelegate);
-    this.toolsManager = new ToolsManager(this.devtools, toolsDelegate);
+    this.metro = new MetroLauncher(this.devtools, this);
+    this.toolsManager = new ToolsManager(this.devtools, this);
 
-    this.buildManager = new BuildManager(
-      dependencyManager,
-      buildCache,
-      deviceSessionDelegate,
-      device.platform
-    );
-    this.debugSession = new DebugSession(debugEventDelegate);
+    this.buildManager = new BuildManager(dependencyManager, buildCache, this, device.platform);
+    this.debugSession = new DebugSession(this);
   }
+
+  public getState(): DeviceSessionState {
+    const state = {
+      startupMessage: this.startupMessage,
+      stageProgress: this.stageProgress,
+      fastRefreshOngoing: this.fastRefreshOngoing,
+      profilingCPUState: this.profilingCPUState,
+      profilingReactState: this.profilingReactState,
+      navigationHistory: this.navigationHistory,
+      selectedDevice: this.deviceInfo,
+      previewURL: this.previewURL,
+      toolsState: this.toolsManager.getToolsState(),
+      isDebuggerPaused: this.isDebuggerPaused,
+      logCount: this.logCount,
+      hasStaleBuildCache: this.hasStaleBuildCache,
+    };
+    if (this.status === "buildError") {
+      assert(this.buildError, "build error needs to be set");
+      return {
+        ...state,
+        status: "buildError",
+        buildError: this.buildError,
+      };
+    } else {
+      return {
+        ...state,
+        status: this.status,
+      };
+    }
+  }
+
+  //#region Metro delegate methods
+
+  onBundleProgress = throttle((stageProgress: number) => {
+    if (this.startupMessage === StartupMessage.WaitingForAppToLoad) {
+      this.stageProgress = stageProgress;
+      this.emitStateChange();
+    }
+  }, 100);
+
+  onBundlingError = async (message: string, source: DebugSource, errorModulePath: string) => {
+    await this.appendDebugConsoleEntry(message, "error", source);
+
+    if (this.status === "starting") {
+      focusSource(source);
+    }
+
+    Logger.error("[Bundling Error]", message);
+
+    this.status = "bundlingError";
+    this.emitStateChange();
+  };
+
+  //#endregion
+
+  //#region Tools delegate methods
+
+  onToolsStateChange = (toolsState: ToolsState) => {
+    this.emitStateChange();
+  };
+
+  //#endregion
+
+  //#region Debug session delegate methods
+
+  onConsoleLog = (event: DebugSessionCustomEvent): void => {
+    this.logCount++;
+    this.emitStateChange();
+  };
+
+  onDebuggerPaused = (event: DebugSessionCustomEvent): void => {
+    this.isDebuggerPaused = true;
+    this.emitStateChange();
+
+    if (this.isActive) {
+      commands.executeCommand("workbench.view.debug");
+    }
+  };
+
+  onDebuggerResumed = (event: DebugSessionCustomEvent): void => {
+    this.isDebuggerPaused = false;
+    this.emitStateChange();
+  };
+
+  onProfilingCPUStarted = (event: DebugSessionCustomEvent): void => {
+    this.profilingCPUState = "running";
+    this.emitStateChange();
+  };
+
+  onProfilingCPUStopped = (event: DebugSessionCustomEvent): void => {
+    this.profilingCPUState = "stopped";
+    this.emitStateChange();
+  };
+
+  //#endregion
+
+  //#region Build manager delegate methods
+
+  onCacheStale = (platform: DevicePlatform) => {
+    if (platform === this.device.platform) {
+      this.hasStaleBuildCache = true;
+      this.emitStateChange();
+    }
+  };
+
+  //#endregion
 
   private makeDevtools() {
     const devtools = new Devtools();
@@ -155,17 +255,23 @@ export class DeviceSession implements Disposable {
     // We don't need to store event disposables here as they are tied to the lifecycle
     // of the devtools instance, which is disposed when we recreate the devtools or
     // when the device session is disposed
-    devtools.onEvent("RNIDE_navigationChanged", (payload) => {
-      this.deviceSessionDelegate.onAppEvent("navigationChanged", payload);
+    devtools.onEvent("RNIDE_navigationChanged", (payload: { displayName: string; id: string }) => {
+      this.navigationHistory.push(payload);
+      this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshStarted", () => {
-      this.deviceSessionDelegate.onAppEvent("fastRefreshStarted", undefined);
+      this.fastRefreshOngoing = true;
+      this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshComplete", () => {
-      this.deviceSessionDelegate.onAppEvent("fastRefreshComplete", undefined);
+      this.fastRefreshOngoing = false;
+      this.emitStateChange();
     });
     devtools.onEvent("RNIDE_isProfilingReact", (isProfiling) => {
-      this.deviceSessionDelegate.onAppEvent("isProfilingReact", isProfiling);
+      if (this.profilingReactState !== "saving") {
+        this.profilingReactState = isProfiling ? "running" : "stopped";
+        this.emitStateChange();
+      }
     });
     return devtools;
   }
@@ -187,7 +293,7 @@ export class DeviceSession implements Disposable {
     this.isActive = true;
     this.buildManager.activate();
     this.toolsManager.activate();
-    this.debugSession = new DebugSession(this.deviceSessionDelegate);
+    this.debugSession = new DebugSession(this);
     await this.debugSession.startParentDebugSession();
     await this.connectJSDebugger();
   }
@@ -199,7 +305,42 @@ export class DeviceSession implements Disposable {
     this.toolsManager.deactivate();
   }
 
-  public async perform(type: ReloadAction): Promise<boolean> {
+  public async performReloadAction(type: ReloadAction): Promise<boolean> {
+    try {
+      this.status = "starting";
+      this.emitStateChange();
+
+      getTelemetryReporter().sendTelemetryEvent("url-bar:reload-requested", {
+        platform: this.device.platform,
+        method: type,
+      });
+      const result = await this.performReloadActionInternal(type);
+      if (result) {
+        this.status = "running";
+        this.emitStateChange();
+      } else {
+        window.showErrorMessage("Failed to reload, you may try another reload option.", "Dismiss");
+      }
+      return result;
+    } catch (e) {
+      if (e instanceof CancelError) {
+        // reload got cancelled, we don't show any errors
+        return false;
+      } else if (e instanceof BuildError) {
+        this.status = "buildError";
+        this.buildError = {
+          message: e.message,
+          buildType: e.buildType,
+          platform: this.device.platform,
+        };
+        this.emitStateChange();
+      }
+      Logger.error("Failed to perform reload action", type, e);
+      throw e;
+    }
+  }
+
+  private async performReloadActionInternal(type: ReloadAction): Promise<boolean> {
     try {
       switch (type) {
         case "autoReload":
@@ -226,7 +367,6 @@ export class DeviceSession implements Disposable {
       Logger.debug("[Reload]", e);
       throw e;
     }
-    throw new Error("Not implemented " + type);
   }
 
   private async reloadJS() {
@@ -284,8 +424,8 @@ export class DeviceSession implements Disposable {
       const oldMetro = this.metro;
       const oldToolsManager = this.toolsManager;
       this.devtools = this.makeDevtools();
-      this.metro = new MetroLauncher(this.devtools, this.metroDelegate);
-      this.toolsManager = new ToolsManager(this.devtools, this.toolsDelegate);
+      this.metro = new MetroLauncher(this.devtools, this);
+      this.toolsManager = new ToolsManager(this.devtools, this);
       oldToolsManager.dispose();
       oldDevtools.dispose();
       oldMetro.dispose();
@@ -302,7 +442,8 @@ export class DeviceSession implements Disposable {
     }
 
     await cancelToken.adapt(this.restartDebugger());
-    this.deviceSessionDelegate.onStateChange(StartupMessage.BootingDevice);
+    this.startupMessage = StartupMessage.BootingDevice;
+    this.emitStateChange();
     await cancelToken.adapt(this.device.reboot());
     await this.buildApp({ appRoot: this.appRootFolder, clean: forceClean, cancelToken });
     await this.installApp({ reinstall: false });
@@ -315,7 +456,8 @@ export class DeviceSession implements Disposable {
       platform: this.device.platform,
     });
 
-    this.deviceSessionDelegate.onReloadStarted(this.device.deviceInfo.id);
+    this.status = "starting";
+    this.emitStateChange();
 
     try {
       if (this.buildManager.shouldRebuild()) {
@@ -331,7 +473,8 @@ export class DeviceSession implements Disposable {
 
       const restartSucceeded = await this.restartProcess();
       if (restartSucceeded) {
-        this.deviceSessionDelegate.onReloadCompleted(this.device.deviceInfo.id);
+        this.status = "running";
+        this.emitStateChange();
       }
     } catch (e) {
       if (e instanceof CancelError) {
@@ -381,7 +524,8 @@ export class DeviceSession implements Disposable {
   }
 
   private async reloadMetro() {
-    this.deviceSessionDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
+    this.startupMessage = StartupMessage.WaitingForAppToLoad;
+    this.emitStateChange();
     const { promise: bundleErrorPromise, reject } = Promise.withResolvers();
     const bundleErrorSubscription = this.metro.onBundleError(() => {
       reject(new Error("Bundle error occurred during reload"));
@@ -392,7 +536,8 @@ export class DeviceSession implements Disposable {
     } finally {
       bundleErrorSubscription.dispose();
     }
-    this.deviceSessionDelegate.onStateChange(StartupMessage.AttachingDebugger);
+    this.startupMessage = StartupMessage.AttachingDebugger;
+    this.emitStateChange();
     await this.reconnectJSDebuggerIfNeeded();
   }
 
@@ -412,13 +557,15 @@ export class DeviceSession implements Disposable {
     const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
     const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
-    this.deviceSessionDelegate.onStateChange(StartupMessage.Launching);
+    this.startupMessage = StartupMessage.Launching;
+    this.emitStateChange();
     await cancelToken.adapt(
       this.device.launchApp(this.buildResult, this.metro.port, this.devtools.port)
     );
 
     Logger.debug("Will wait for app ready and for preview");
-    this.deviceSessionDelegate.onStateChange(StartupMessage.WaitingForAppToLoad);
+    this.startupMessage = StartupMessage.WaitingForAppToLoad;
+    this.emitStateChange();
 
     let previewURL: string | undefined;
     if (shouldWaitForAppLaunch) {
@@ -439,14 +586,15 @@ export class DeviceSession implements Disposable {
         this.metro.ready(),
         this.device.startPreview().then((url) => {
           previewURL = url;
-          this.deviceSessionDelegate.onPreviewReady(url);
+          this.emitStateChange();
         }),
         waitForAppReady,
       ])
     );
 
     Logger.debug("App and preview ready, moving on...");
-    this.deviceSessionDelegate.onStateChange(StartupMessage.AttachingDebugger);
+    this.startupMessage = StartupMessage.AttachingDebugger;
+    this.emitStateChange();
     await cancelToken.adapt(this.connectJSDebugger());
 
     this.isLaunching = false;
@@ -469,7 +617,8 @@ export class DeviceSession implements Disposable {
   }
 
   private async bootDevice(deviceSettings: DeviceSettings) {
-    this.deviceSessionDelegate.onStateChange(StartupMessage.BootingDevice);
+    this.startupMessage = StartupMessage.BootingDevice;
+    this.emitStateChange();
     try {
       await this.device.bootDevice(deviceSettings);
     } catch (e) {
@@ -488,12 +637,16 @@ export class DeviceSession implements Disposable {
     cancelToken: CancelToken;
   }) {
     const buildStartTime = Date.now();
-    this.deviceSessionDelegate.onStateChange(StartupMessage.Building);
+    this.startupMessage = StartupMessage.Building;
+    this.emitStateChange();
     this.disposableBuild = this.buildManager.startBuild(this.device.deviceInfo, {
       appRoot,
       clean,
       progressListener: throttle((stageProgress: number) => {
-        this.deviceSessionDelegate.onBuildProgress(stageProgress);
+        if (this.startupMessage === StartupMessage.Building) {
+          this.stageProgress = stageProgress;
+          this.emitStateChange();
+        }
       }, 100),
       cancelToken,
     });
@@ -510,18 +663,58 @@ export class DeviceSession implements Disposable {
   }
 
   private async installApp({ reinstall }: { reinstall: boolean }) {
-    this.deviceSessionDelegate.onStateChange(StartupMessage.Installing);
+    this.startupMessage = StartupMessage.Installing;
+    this.emitStateChange();
     return this.device.installApp(this.buildResult, reinstall);
   }
 
   private async waitForMetroReady() {
-    this.deviceSessionDelegate.onStateChange(StartupMessage.StartingPackager);
+    this.startupMessage = StartupMessage.StartingPackager;
+    this.emitStateChange();
     // wait for metro/devtools to start before we continue
     await Promise.all([this.metro.ready(), this.devtools.ready()]);
     Logger.debug("Metro & devtools ready");
   }
 
-  public async start({ cleanBuild, resetMetroCache, previewReadyCallback }: StartOptions) {
+  public async start({ cleanBuild, resetMetroCache }: StartOptions) {
+    try {
+      await this.startInternal({ cleanBuild, resetMetroCache });
+    } catch (e) {
+      if (e instanceof CancelError) {
+        Logger.info("Device selection was canceled", e);
+      } else if (e instanceof DeviceBootError) {
+        this.status = "bootError";
+      } else if (e instanceof BuildError) {
+        this.status = "buildError";
+        this.buildError = {
+          message: e.message,
+          buildType: e.buildType,
+          platform: this.device.platform,
+        };
+      } else {
+        this.status = "buildError";
+        this.buildError = {
+          message: (e as Error).message,
+          buildType: null,
+          platform: this.device.platform,
+        };
+      }
+      throw e;
+    } finally {
+      this.emitStateChange();
+    }
+  }
+
+  private emitStateChange() {
+    this.deviceSessionDelegate.onStateChange(this.getState());
+  }
+
+  private async startInternal({ cleanBuild, resetMetroCache }: StartOptions) {
+    this.status = "starting";
+    this.stageProgress = undefined;
+    this.startupMessage = StartupMessage.InitializingDevice;
+    this.emitStateChange();
+
     if (this.cancelToken) {
       this.cancelToken.cancel();
       this.cancelToken = undefined;
@@ -551,9 +744,8 @@ export class DeviceSession implements Disposable {
     await cancelToken.adapt(this.bootDevice(this.deviceSettings));
     await this.buildApp({ appRoot: this.appRootFolder, clean: cleanBuild, cancelToken });
     await cancelToken.adapt(this.installApp({ reinstall: false }));
-    const previewUrl = await this.launchApp(cancelToken);
+    await this.launchApp(cancelToken);
     Logger.debug("Device session started");
-    return previewUrl;
   }
 
   private async connectJSDebugger() {
@@ -630,6 +822,19 @@ export class DeviceSession implements Disposable {
 
   public async captureScreenshot() {
     return this.device.captureScreenshot();
+  }
+
+  public async startProfilingReact() {
+    return await this.devtools.startProfilingReact();
+  }
+
+  public async stopProfilingReact() {
+    try {
+      return await this.devtools.stopProfilingReact();
+    } finally {
+      this.profilingReactState = "stopped";
+      this.emitStateChange();
+    }
   }
 
   public async startProfilingCPU() {
@@ -741,7 +946,6 @@ export class DeviceSession implements Disposable {
     }
     this.deviceSettings = settings;
 
-    this.deviceSessionDelegate.onDeviceSettingChanged(settings);
     return this.device.changeSettings(settings);
   }
 
@@ -751,5 +955,13 @@ export class DeviceSession implements Disposable {
 
   public async sendBiometricAuthorization(isMatch: boolean) {
     await this.device.sendBiometricAuthorization(isMatch);
+  }
+
+  public async updateToolEnabledState(toolName: ToolKey, enabled: boolean) {
+    this.toolsManager.updateToolEnabledState(toolName, enabled);
+  }
+
+  public async openTool(toolName: ToolKey) {
+    this.toolsManager.openTool(toolName);
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -97,14 +97,15 @@ export class DeviceSession
   private startupMessage: StartupMessage = StartupMessage.InitializingDevice;
   private stageProgress: number | undefined;
   private buildError: BuildErrorDescriptor | undefined;
-  private fastRefreshOngoing = false;
   private profilingCPUState: ProfilingState = "stopped";
   private profilingReactState: ProfilingState = "stopped";
   private navigationHistory: NavigationHistoryItem[] = [];
   private navigationBackTarget: NavigationHistoryItem | undefined;
+  private navigationHomeTarget: NavigationHistoryItem | undefined;
   private logCounter = 0;
   private isDebuggerPaused = false;
   private hasStaleBuildCache = false;
+
   private get buildResult() {
     if (!this.maybeBuildResult) {
       throw new Error("Expecting build to be ready");
@@ -152,7 +153,6 @@ export class DeviceSession
       startupMessage: this.startupMessage,
       stageProgress: this.stageProgress,
       buildError: this.buildError,
-      fastRefreshOngoing: this.fastRefreshOngoing,
       profilingCPUState: this.profilingCPUState,
       profilingReactState: this.profilingReactState,
       navigationHistory: this.navigationHistory,
@@ -163,6 +163,18 @@ export class DeviceSession
       logCounter: this.logCounter,
       hasStaleBuildCache: this.hasStaleBuildCache,
     };
+  }
+
+  private resetStartingState(startupMessage: StartupMessage = StartupMessage.Restarting) {
+    this.status = "starting";
+    this.startupMessage = startupMessage;
+    this.stageProgress = undefined;
+    this.buildError = undefined;
+    this.profilingCPUState = "stopped";
+    this.profilingReactState = "stopped";
+    this.navigationBackTarget = undefined;
+    this.navigationHomeTarget = undefined;
+    this.emitStateChange();
   }
 
   //#region Metro delegate methods
@@ -261,6 +273,10 @@ export class DeviceSession
         }
       }
 
+      if (!this.navigationHomeTarget) {
+        this.navigationHomeTarget = payload;
+      }
+
       this.navigationBackTarget = undefined;
       this.navigationHistory = [
         payload,
@@ -269,11 +285,11 @@ export class DeviceSession
       this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshStarted", () => {
-      this.fastRefreshOngoing = true;
+      this.status = "refreshing";
       this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshComplete", () => {
-      this.fastRefreshOngoing = false;
+      this.status = "running";
       this.emitStateChange();
     });
     devtools.onEvent("RNIDE_isProfilingReact", (isProfiling) => {
@@ -316,8 +332,7 @@ export class DeviceSession
 
   public async performReloadAction(type: ReloadAction): Promise<boolean> {
     try {
-      this.status = "starting";
-      this.emitStateChange();
+      this.resetStartingState();
 
       getTelemetryReporter().sendTelemetryEvent("url-bar:reload-requested", {
         platform: this.device.platform,
@@ -469,9 +484,7 @@ export class DeviceSession
       platform: this.device.platform,
     });
 
-    this.status = "starting";
-    this.emitStateChange();
-
+    this.resetStartingState();
     try {
       if (this.buildManager.shouldRebuild()) {
         await this.restart({ forceClean: false, cleanCache: false });
@@ -724,9 +737,8 @@ export class DeviceSession
   }
 
   private async startInternal({ cleanBuild, resetMetroCache }: StartOptions) {
-    this.status = "starting";
-    this.stageProgress = undefined;
-    this.startupMessage = StartupMessage.InitializingDevice;
+    this.resetStartingState(StartupMessage.InitializingDevice);
+
     this.emitStateChange();
 
     if (this.cancelToken) {
@@ -913,6 +925,12 @@ export class DeviceSession
 
   public openNavigation(id: string) {
     this.devtools.send("RNIDE_openNavigation", { id });
+  }
+
+  public navigateHome() {
+    if (this.navigationHomeTarget) {
+      this.devtools.send("RNIDE_openNavigation", { id: this.navigationHomeTarget.id });
+    }
   }
 
   public navigateBack() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -22,21 +22,22 @@ import {
   BuildErrorDescriptor,
   ToolsState,
   ProfilingState,
+  NavigationHistoryItem,
 } from "../common/Project";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DebugSession, DebugSessionDelegate, DebugSource } from "../debugging/DebugSession";
 import { throttle } from "../utilities/throttle";
-import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
-import { BuildCache } from "../builders/BuildCache";
 import { CancelError, CancelToken } from "../builders/cancelToken";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { ToolKey, ToolsDelegate, ToolsManager } from "./tools";
 import { extensionContext } from "../utilities/extensionContext";
 import { ReloadAction } from "../common/DeviceSessionsManager";
 import { focusSource } from "../utilities/focusSource";
+import { ApplicationContext } from "./ApplicationContext";
 
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
+const MAX_URL_HISTORY_SIZE = 20;
 
 export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
   appearance: "dark",
@@ -99,8 +100,9 @@ export class DeviceSession
   private fastRefreshOngoing = false;
   private profilingCPUState: ProfilingState = "stopped";
   private profilingReactState: ProfilingState = "stopped";
-  private navigationHistory: { displayName: string; id: string }[] = [];
-  private logCount = 0;
+  private navigationHistory: NavigationHistoryItem[] = [];
+  private navigationBackTarget: NavigationHistoryItem | undefined;
+  private logCounter = 0;
   private isDebuggerPaused = false;
   private hasStaleBuildCache = false;
   private get buildResult() {
@@ -123,11 +125,9 @@ export class DeviceSession
   }
 
   constructor(
-    private readonly appRootFolder: string,
+    private readonly applicationContext: ApplicationContext,
     readonly deviceInfo: DeviceInfo,
     private readonly device: DeviceBase,
-    readonly dependencyManager: DependencyManager,
-    readonly buildCache: BuildCache,
     private readonly deviceSessionDelegate: DeviceSessionDelegate
   ) {
     this.deviceSettings =
@@ -137,7 +137,12 @@ export class DeviceSession
     this.metro = new MetroLauncher(this.devtools, this);
     this.toolsManager = new ToolsManager(this.devtools, this);
 
-    this.buildManager = new BuildManager(dependencyManager, buildCache, this, device.platform);
+    this.buildManager = new BuildManager(
+      applicationContext.dependencyManager,
+      applicationContext.buildCache,
+      this,
+      device.platform
+    );
     this.debugSession = new DebugSession(this);
   }
 
@@ -155,7 +160,7 @@ export class DeviceSession
       previewURL: this.previewURL,
       toolsState: this.toolsManager.getToolsState(),
       isDebuggerPaused: this.isDebuggerPaused,
-      logCount: this.logCount,
+      logCounter: this.logCounter,
       hasStaleBuildCache: this.hasStaleBuildCache,
     };
   }
@@ -195,7 +200,7 @@ export class DeviceSession
   //#region Debug session delegate methods
 
   onConsoleLog = (event: DebugSessionCustomEvent): void => {
-    this.logCount++;
+    this.logCounter += 1;
     this.emitStateChange();
   };
 
@@ -214,7 +219,7 @@ export class DeviceSession
   };
 
   onProfilingCPUStarted = (event: DebugSessionCustomEvent): void => {
-    this.profilingCPUState = "running";
+    this.profilingCPUState = "profiling";
     this.emitStateChange();
   };
 
@@ -244,8 +249,23 @@ export class DeviceSession
     // We don't need to store event disposables here as they are tied to the lifecycle
     // of the devtools instance, which is disposed when we recreate the devtools or
     // when the device session is disposed
-    devtools.onEvent("RNIDE_navigationChanged", (payload: { displayName: string; id: string }) => {
-      this.navigationHistory.push(payload);
+    devtools.onEvent("RNIDE_navigationChanged", (payload: NavigationHistoryItem) => {
+      const backTargetId = this.navigationBackTarget?.id;
+      if (backTargetId === payload.id) {
+        // we are navigating back, remove all items from history that are before the back target
+        const backTargetIndex = this.navigationHistory.findIndex(
+          (record) => record.id === backTargetId
+        );
+        if (backTargetIndex !== -1) {
+          this.navigationHistory = this.navigationHistory.slice(backTargetIndex + 1);
+        }
+      }
+
+      this.navigationBackTarget = undefined;
+      this.navigationHistory = [
+        payload,
+        ...this.navigationHistory.filter((record) => record.id !== payload.id),
+      ].slice(0, MAX_URL_HISTORY_SIZE);
       this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshStarted", () => {
@@ -258,7 +278,7 @@ export class DeviceSession
     });
     devtools.onEvent("RNIDE_isProfilingReact", (isProfiling) => {
       if (this.profilingReactState !== "saving") {
-        this.profilingReactState = isProfiling ? "running" : "stopped";
+        this.profilingReactState = isProfiling ? "profiling" : "stopped";
         this.emitStateChange();
       }
     });
@@ -425,7 +445,7 @@ export class DeviceSession
       Logger.debug(`Launching metro`);
       this.metro.start({
         resetCache: true,
-        appRoot: this.appRootFolder,
+        appRoot: this.applicationContext.appRootFolder,
         dependencies: [],
       });
     }
@@ -434,7 +454,11 @@ export class DeviceSession
     this.startupMessage = StartupMessage.BootingDevice;
     this.emitStateChange();
     await cancelToken.adapt(this.device.reboot());
-    await this.buildApp({ appRoot: this.appRootFolder, clean: forceClean, cancelToken });
+    await this.buildApp({
+      appRoot: this.applicationContext.appRootFolder,
+      clean: forceClean,
+      cancelToken,
+    });
     await this.installApp({ reinstall: false });
     await this.launchApp(cancelToken);
     Logger.debug("Device session started");
@@ -720,7 +744,7 @@ export class DeviceSession
     Logger.debug(`Launching metro`);
     this.metro.start({
       resetCache: resetMetroCache,
-      appRoot: this.appRootFolder,
+      appRoot: this.applicationContext.appRootFolder,
       dependencies: [waitForNodeModules],
     });
     // We start the debug session early to be able to use it to surface bundle
@@ -731,7 +755,11 @@ export class DeviceSession
     await cancelToken.adapt(this.waitForMetroReady());
     // TODO(jgonet): Build and boot simultaneously, with predictable state change updates
     await cancelToken.adapt(this.bootDevice(this.deviceSettings));
-    await this.buildApp({ appRoot: this.appRootFolder, clean: cleanBuild, cancelToken });
+    await this.buildApp({
+      appRoot: this.applicationContext.appRootFolder,
+      clean: cleanBuild,
+      cancelToken,
+    });
     await cancelToken.adapt(this.installApp({ reinstall: false }));
     await this.launchApp(cancelToken);
     Logger.debug("Device session started");
@@ -886,6 +914,13 @@ export class DeviceSession
     this.devtools.send("RNIDE_openNavigation", { id });
   }
 
+  public navigateBack() {
+    if (this.navigationHistory.length > 1) {
+      this.navigationBackTarget = this.navigationHistory[1];
+      this.devtools.send("RNIDE_openNavigation", { id: this.navigationBackTarget.id });
+    }
+  }
+
   public async openDevMenu() {
     await this.metro.openDevMenu();
   }
@@ -960,5 +995,10 @@ export class DeviceSession
 
   public getMetroPort() {
     return this.metro.port;
+  }
+
+  public resetLogCounter() {
+    this.logCounter = 0;
+    this.emitStateChange();
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -39,8 +39,6 @@ import { ApplicationContext } from "./ApplicationContext";
 const DEVICE_SETTINGS_KEY = "device_settings_v4";
 const MAX_URL_HISTORY_SIZE = 20;
 
-const something = 88;
-
 export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
   appearance: "dark",
   contentSize: "normal",

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -1,11 +1,10 @@
 import http from "http";
-import { commands, Disposable, Uri } from "vscode";
+import { Disposable, Uri } from "vscode";
 import { WebSocketServer, WebSocket } from "ws";
 import { Logger } from "../Logger";
 import {
   createBridge,
   createStore,
-  FrontendBridge,
   prepareProfilingDataExport,
   Store,
   Wall,
@@ -183,7 +182,7 @@ export class Devtools implements Disposable {
   }
 
   public dispose() {
-    this.server.close();
+    this.server?.close();
   }
 
   public send(event: string, payload?: any) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -18,6 +18,7 @@ import { minimatch } from "minimatch";
 import {
   AppPermissionType,
   DeviceButtonType,
+  DeviceSessionInitialState,
   DeviceSessionState,
   DeviceSettings,
   InspectData,
@@ -65,21 +66,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   public deviceSessionsManager: DeviceSessionsManager;
 
   private projectState: ProjectState = {
-    status: "starting",
-    stageProgress: 0,
-    startupMessage: StartupMessage.InitializingDevice,
-    previewURL: undefined,
-    previewZoom: extensionContext.workspaceState.get(PREVIEW_ZOOM_KEY),
-    selectedDevice: undefined,
+    ...DeviceSessionInitialState,
     initialized: false,
-    fastRefreshOngoing: false,
-    profilingCPUState: "stopped",
-    profilingReactState: "stopped",
-    navigationHistory: [],
-    toolsState: undefined,
-    isDebuggerPaused: false,
-    logCount: 0,
-    hasStaleBuildCache: false,
+    previewZoom: undefined,
   };
 
   private disposables: Disposable[] = [];
@@ -165,34 +154,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   onActiveSessionStateChanged = (state: DeviceSessionState) => {
     this.updateProjectState(state);
   };
-
-  //#endregion
-
-  //#region App events
-  // onAppEvent = <E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void => {
-  //   switch (event) {
-  //     case "navigationChanged":
-  //       this.eventEmitter.emit("navigationChanged", payload);
-  //       break;
-  //     case "fastRefreshStarted":
-  //       this.updateProjectState({ status: "refreshing" });
-  //       break;
-  //     case "fastRefreshComplete":
-  //       const ignoredEvents = ["starting", "bundlingError"];
-  //       if (ignoredEvents.includes(this.projectState.status)) {
-  //         return;
-  //       }
-  //       this.updateProjectState({ status: "running" });
-  //       break;
-  //     case "isProfilingReact":
-  //       this.eventEmitter.emit("isProfilingReact", payload);
-  //       break;
-  //     case "isSavingReactProfile":
-  //       this.eventEmitter.emit("isSavingReactProfile", payload);
-  //       break;
-  //   }
-  // };
-  //#endregion
 
   private recordingTimeout: NodeJS.Timeout | undefined = undefined;
 
@@ -495,11 +456,16 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   public async focusDebugConsole() {
+    this.deviceSession?.resetLogCounter();
     commands.executeCommand("workbench.panel.repl.view.focus");
   }
 
   public async openNavigation(navigationItemID: string) {
     this.deviceSession?.openNavigation(navigationItemID);
+  }
+
+  public async navigateBack() {
+    this.deviceSession?.navigateBack();
   }
 
   public async openDevMenu() {
@@ -590,7 +556,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   private updateProjectState(newState: Partial<ProjectState>) {
     // NOTE: this is unsafe, but I'm not sure there's a way to enforce the type of `newState` correctly
-    const mergedState: any = { ...this.projectState, ...newState };
+    const mergedState: any = { ...this.projectState, ...newState, initialized: true };
     // // stageProgress is tied to a startup stage, so when there is a change of status or startupMessage,
     // // we always want to reset the progress.
     // if (

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -34,7 +34,6 @@ import { Logger } from "../Logger";
 import { DeviceInfo } from "../common/DeviceManager";
 import { DeviceManager } from "../devices/DeviceManager";
 import { extensionContext } from "../utilities/extensionContext";
-import { DEVICE_SETTINGS_DEFAULT } from "./deviceSession";
 import {
   activateDevice,
   watchLicenseTokenChange,
@@ -50,6 +49,7 @@ import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRoo
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DeviceSessionsManager } from "./DeviceSessionsManager";
 import { DeviceSessionsManagerDelegate } from "../common/DeviceSessionsManager";
+import { DEVICE_SETTINGS_DEFAULT, DEVICE_SETTINGS_KEY } from "../devices/DeviceBase";
 
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 const DEEP_LINKS_HISTORY_KEY = "deep_links_history";
@@ -484,7 +484,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   public async openComponentPreview(fileName: string, lineNumber1Based: number) {
     try {
       const deviceSession = this.deviceSession;
-      if (!deviceSession || !deviceSession.isAppLaunched) {
+      if (!deviceSession) {
         window.showWarningMessage("Wait for the app to load before launching preview.", "Dismiss");
         return;
       }
@@ -513,11 +513,11 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   public async getDeviceSettings() {
-    return this.deviceSession?.deviceSettings ?? DEVICE_SETTINGS_DEFAULT;
+    return extensionContext.workspaceState.get(DEVICE_SETTINGS_KEY, DEVICE_SETTINGS_DEFAULT);
   }
 
   public async updateDeviceSettings(settings: DeviceSettings) {
-    let needsRestart = await this.deviceSession?.changeDeviceSettings(settings);
+    let needsRestart = await this.deviceSession?.updateDeviceSettings(settings);
     this.eventEmitter.emit("deviceSettingsChanged", settings);
 
     if (needsRestart) {
@@ -554,16 +554,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   private updateProjectState(newState: Partial<ProjectState>) {
-    // NOTE: this is unsafe, but I'm not sure there's a way to enforce the type of `newState` correctly
-    const mergedState: any = { ...this.projectState, ...newState, initialized: true };
-    // // stageProgress is tied to a startup stage, so when there is a change of status or startupMessage,
-    // // we always want to reset the progress.
-    // if (
-    //   newState.status !== undefined ||
-    //   ("startupMessage" in newState && newState.startupMessage !== undefined)
-    // ) {
-    //   delete mergedState.stageProgress;
-    // }
+    const mergedState = { ...this.projectState, ...newState, initialized: true };
     this.projectState = mergedState;
     this.eventEmitter.emit("projectStateChanged", this.projectState);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -26,7 +26,6 @@ import {
   ProjectEventMap,
   ProjectInterface,
   ProjectState,
-  StartupMessage,
   ToolsState,
   TouchPoint,
   ZoomLevelType,

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -18,6 +18,7 @@ import { minimatch } from "minimatch";
 import {
   AppPermissionType,
   DeviceButtonType,
+  DeviceSessionState,
   DeviceSettings,
   InspectData,
   ProjectEventListener,
@@ -33,10 +34,7 @@ import { Logger } from "../Logger";
 import { DeviceInfo } from "../common/DeviceManager";
 import { DeviceManager } from "../devices/DeviceManager";
 import { extensionContext } from "../utilities/extensionContext";
-import { throttle } from "../utilities/throttle";
-import { DebugSource } from "../debugging/DebugSession";
-import { AppEvent, DEVICE_SETTINGS_DEFAULT } from "./deviceSession";
-import { PanelLocation } from "../common/WorkspaceConfig";
+import { DEVICE_SETTINGS_DEFAULT } from "./deviceSession";
 import {
   activateDevice,
   watchLicenseTokenChange,
@@ -49,10 +47,9 @@ import { UtilsInterface } from "../common/utils";
 import { ApplicationContext } from "./ApplicationContext";
 import { disposeAll } from "../utilities/disposables";
 import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRootFolder";
-import { focusSource } from "../utilities/focusSource";
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DeviceSessionsManager } from "./DeviceSessionsManager";
-import { DeviceSessionsManagerDelegate, ReloadAction } from "../common/DeviceSessionsManager";
+import { DeviceSessionsManagerDelegate } from "../common/DeviceSessionsManager";
 
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 const DEEP_LINKS_HISTORY_KEY = "deep_links_history";
@@ -75,6 +72,14 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     previewZoom: extensionContext.workspaceState.get(PREVIEW_ZOOM_KEY),
     selectedDevice: undefined,
     initialized: false,
+    fastRefreshOngoing: false,
+    profilingCPUState: "stopped",
+    profilingReactState: "stopped",
+    navigationHistory: [],
+    toolsState: undefined,
+    isDebuggerPaused: false,
+    logCount: 0,
+    hasStaleBuildCache: false,
   };
 
   private disposables: Disposable[] = [];
@@ -92,10 +97,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
       this.deviceManager,
-      this,
-      (newState) => {
-        this.updateProjectState(newState);
-      }
+      this
     );
 
     this.disposables.push(refreshTokenPeriodically());
@@ -155,101 +157,42 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
       this.deviceManager,
-      this,
-      (newState) => {
-        this.updateProjectState(newState);
-      }
+      this
     );
     oldDeviceSessionsManager.dispose();
   }
 
-  //#region Device Session Delegate
-  onBuildProgress = (stageProgress: number): void => {
-    this.reportStageProgress(stageProgress, StartupMessage.Building);
+  onActiveSessionStateChanged = (state: DeviceSessionState) => {
+    this.updateProjectState(state);
   };
-
-  onStateChange = (state: StartupMessage): void => {
-    this.updateProjectState({ startupMessage: state });
-  };
-
-  public onReloadStarted(id: string): void {
-    this.updateProjectStateForDevice(id, {
-      status: "starting",
-      startupMessage: StartupMessage.Restarting,
-    });
-  }
-
-  public onReloadCompleted(id: string): void {
-    this.updateProjectStateForDevice(id, {
-      status: "running",
-    });
-  }
-
-  public onCacheStale(): void {
-    this.eventEmitter.emit("needsNativeRebuild");
-  }
-
-  public onPreviewReady(previewURL: string): void {
-    this.updateProjectState({ previewURL });
-  }
 
   //#endregion
 
   //#region App events
-  onAppEvent = <E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void => {
-    switch (event) {
-      case "navigationChanged":
-        this.eventEmitter.emit("navigationChanged", payload);
-        break;
-      case "fastRefreshStarted":
-        this.updateProjectState({ status: "refreshing" });
-        break;
-      case "fastRefreshComplete":
-        const ignoredEvents = ["starting", "bundlingError"];
-        if (ignoredEvents.includes(this.projectState.status)) {
-          return;
-        }
-        this.updateProjectState({ status: "running" });
-        break;
-      case "isProfilingReact":
-        this.eventEmitter.emit("isProfilingReact", payload);
-        break;
-      case "isSavingReactProfile":
-        this.eventEmitter.emit("isSavingReactProfile", payload);
-        break;
-    }
-  };
+  // onAppEvent = <E extends keyof AppEvent, P = AppEvent[E]>(event: E, payload: P): void => {
+  //   switch (event) {
+  //     case "navigationChanged":
+  //       this.eventEmitter.emit("navigationChanged", payload);
+  //       break;
+  //     case "fastRefreshStarted":
+  //       this.updateProjectState({ status: "refreshing" });
+  //       break;
+  //     case "fastRefreshComplete":
+  //       const ignoredEvents = ["starting", "bundlingError"];
+  //       if (ignoredEvents.includes(this.projectState.status)) {
+  //         return;
+  //       }
+  //       this.updateProjectState({ status: "running" });
+  //       break;
+  //     case "isProfilingReact":
+  //       this.eventEmitter.emit("isProfilingReact", payload);
+  //       break;
+  //     case "isSavingReactProfile":
+  //       this.eventEmitter.emit("isSavingReactProfile", payload);
+  //       break;
+  //   }
+  // };
   //#endregion
-
-  //#region Debugger events
-  onConsoleLog(event: DebugSessionCustomEvent) {
-    this.eventEmitter.emit("log", event.body);
-  }
-
-  onDebuggerPaused(event: DebugSessionCustomEvent) {
-    this.updateProjectState({ status: "debuggerPaused" });
-
-    // we don't want to focus on debug side panel if it means hiding Radon IDE
-    const panelLocation = workspace
-      .getConfiguration("RadonIDE")
-      .get<PanelLocation>("panelLocation");
-
-    if (panelLocation === "tab") {
-      commands.executeCommand("workbench.view.debug");
-    }
-  }
-
-  onDebuggerResumed() {
-    const ignoredEvents = ["starting", "bundlingError"];
-    if (ignoredEvents.includes(this.projectState.status)) {
-      return;
-    }
-    this.updateProjectState({ status: "running" });
-  }
-
-  //#endregion
-
-  //#region Recordings and screenshots
 
   private recordingTimeout: NodeJS.Timeout | undefined = undefined;
 
@@ -298,19 +241,14 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   async startProfilingReact() {
-    await this.deviceSession?.devtools.startProfilingReact();
+    await this.deviceSession?.startProfilingReact();
   }
 
   async stopProfilingReact() {
-    try {
-      this.eventEmitter.emit("isSavingReactProfile", true);
-      const uri = await this.deviceSession?.devtools.stopProfilingReact();
-      if (uri) {
-        // open profile file in vscode using our custom editor
-        commands.executeCommand("vscode.open", uri);
-      }
-    } finally {
-      this.eventEmitter.emit("isSavingReactProfile", false);
+    const uri = await this.deviceSession?.stopProfilingReact();
+    if (uri) {
+      // open profile file in vscode using our custom editor
+      commands.executeCommand("vscode.open", uri);
     }
   }
 
@@ -421,26 +359,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     await this.utils.showToast("Copied from device clipboard", 2000);
   }
 
-  async onBundlingError(
-    message: string,
-    source: DebugSource,
-    _errorModulePath: string
-  ): Promise<void> {
-    await this.deviceSession?.appendDebugConsoleEntry(message, "error", source);
-
-    if (this.projectState.status === "starting") {
-      focusSource(source);
-    }
-
-    Logger.error("[Bundling Error]", message);
-
-    this.updateProjectState({ status: "bundlingError" });
-  }
-
-  onBundleProgress = throttle((stageProgress: number) => {
-    this.reportStageProgress(stageProgress, StartupMessage.WaitingForAppToLoad);
-  }, 100);
-
   async getProjectState(): Promise<ProjectState> {
     return this.projectState;
   }
@@ -465,7 +383,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   private async reloadMetro() {
-    if (await this.deviceSession?.perform("reloadJs")) {
+    if (await this.deviceSession?.performReloadAction("reloadJs")) {
       this.updateProjectState({ status: "running" });
       return true;
     }
@@ -491,23 +409,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     }
   }
 
-  //#region Session lifecycle
-
-  onReloadRequested(type: ReloadAction) {
-    this.updateProjectState({ status: "starting", startupMessage: StartupMessage.Restarting });
-
-    getTelemetryReporter().sendTelemetryEvent("url-bar:reload-requested", {
-      platform: this.projectState.selectedDevice?.platform,
-      method: type,
-    });
-  }
-
-  //#endregion
-
   async resetAppPermissions(permissionType: AppPermissionType) {
     const needsRestart = await this.deviceSession?.resetAppPermissions(permissionType);
     if (needsRestart) {
-      await this.deviceSessionsManager.reload("restartProcess");
+      await this.deviceSessionsManager.reloadCurrentSession("restartProcess");
     }
   }
 
@@ -646,15 +551,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     return this.deviceSession?.deviceSettings ?? DEVICE_SETTINGS_DEFAULT;
   }
 
-  public async onDeviceSettingChanged(deviceSettings: DeviceSettings) {
-    this.eventEmitter.emit("deviceSettingsChanged", deviceSettings);
-  }
-
   public async updateDeviceSettings(settings: DeviceSettings) {
     let needsRestart = await this.deviceSession?.changeDeviceSettings(settings);
+    this.eventEmitter.emit("deviceSettingsChanged", settings);
 
     if (needsRestart) {
-      await this.deviceSessionsManager.reload("reboot");
+      await this.deviceSessionsManager.reloadCurrentSession("reboot");
     }
   }
 
@@ -662,16 +564,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.eventEmitter.emit("toolsStateChanged", toolsState);
   };
 
-  public async getToolsState() {
-    return this.deviceSession?.toolsManager.getToolsState() ?? {};
-  }
-
   public async updateToolEnabledState(toolName: ToolKey, enabled: boolean) {
-    await this.deviceSession?.toolsManager.updateToolEnabledState(toolName, enabled);
+    await this.deviceSession?.updateToolEnabledState(toolName, enabled);
   }
 
   public async openTool(toolName: ToolKey) {
-    await this.deviceSession?.toolsManager.openTool(toolName);
+    await this.deviceSession?.openTool(toolName);
   }
 
   public async renameDevice(deviceInfo: DeviceInfo, newDisplayName: string) {
@@ -690,32 +588,19 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     await this.deviceSession?.sendBiometricAuthorization(isMatch);
   }
 
-  private reportStageProgress(stageProgress: number, stage: string) {
-    if (stage !== this.projectState.startupMessage) {
-      return;
-    }
-    this.updateProjectState({ stageProgress });
-  }
-
   private updateProjectState(newState: Partial<ProjectState>) {
     // NOTE: this is unsafe, but I'm not sure there's a way to enforce the type of `newState` correctly
     const mergedState: any = { ...this.projectState, ...newState };
-    // stageProgress is tied to a startup stage, so when there is a change of status or startupMessage,
-    // we always want to reset the progress.
-    if (
-      newState.status !== undefined ||
-      ("startupMessage" in newState && newState.startupMessage !== undefined)
-    ) {
-      delete mergedState.stageProgress;
-    }
+    // // stageProgress is tied to a startup stage, so when there is a change of status or startupMessage,
+    // // we always want to reset the progress.
+    // if (
+    //   newState.status !== undefined ||
+    //   ("startupMessage" in newState && newState.startupMessage !== undefined)
+    // ) {
+    //   delete mergedState.stageProgress;
+    // }
     this.projectState = mergedState;
     this.eventEmitter.emit("projectStateChanged", this.projectState);
-  }
-
-  private updateProjectStateForDevice(id: string, newState: Partial<ProjectState>) {
-    if (id === this.projectState.selectedDevice?.id) {
-      this.updateProjectState(newState);
-    }
   }
 
   public async updatePreviewZoomLevel(zoom: ZoomLevelType): Promise<void> {
@@ -749,17 +634,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       );
     }
   }
-
-  //#region Select device
-
-  public async onDeviceSelected(deviceInfo: DeviceInfo, previewURL?: string) {
-    const newState: Partial<ProjectState> = previewURL
-      ? { selectedDevice: deviceInfo, previewURL }
-      : { selectedDevice: deviceInfo };
-    this.updateProjectState(newState);
-  }
-
-  //#endregion
 }
 
 export function isAppSourceFile(filePath: string) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -350,7 +350,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     return false;
   }
 
-  public async goHome(homeUrl: string) {
+  public async navigateHome() {
     getTelemetryReporter().sendTelemetryEvent("url-bar:go-home", {
       platform: this.projectState.selectedDevice?.platform,
     });
@@ -363,7 +363,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     }
 
     if (await this.dependencyManager.checkProjectUsesExpoRouter()) {
-      await this.openNavigation(homeUrl);
+      await this.deviceSession?.navigateHome();
     } else {
       await this.reloadMetro();
     }

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -89,7 +89,6 @@ export class ToolsManager implements Disposable {
         changed && this.handleStateChange();
       })
     );
-    this.handleStateChange();
   }
 
   public getPlugin(toolName: ToolKey): ToolPlugin | undefined {

--- a/packages/vscode-extension/src/utilities/diffing.ts
+++ b/packages/vscode-extension/src/utilities/diffing.ts
@@ -1,0 +1,13 @@
+import { isEqual } from "lodash";
+
+export function getChanges<T extends Record<string, any>>(oldObj: T, newObj: T): Partial<T> {
+  const changes: Partial<T> = {};
+
+  for (const key in newObj) {
+    if (!isEqual(oldObj[key], newObj[key])) {
+      changes[key] = newObj[key];
+    }
+  }
+
+  return changes;
+}

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -118,7 +118,7 @@ function DeviceSelect() {
     if (selectedDevice?.id !== value) {
       const deviceInfo = devices.find((d) => d.id === value);
       if (deviceInfo) {
-        deviceSessionsManager.selectDevice(deviceInfo);
+        deviceSessionsManager.startOrActivateSessionForDevice(deviceInfo);
       }
     }
   };

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -440,13 +440,10 @@ function Preview({
   }, [project, shouldPreventInputEvents]);
 
   useEffect(() => {
-    if (projectStatus === "running") {
-      project.addListener("needsNativeRebuild", openRebuildAlert);
-      return () => {
-        project.removeListener("needsNativeRebuild", openRebuildAlert);
-      };
+    if (projectState.hasStaleBuildCache) {
+      openRebuildAlert();
     }
-  }, [project, openRebuildAlert, projectStatus]);
+  }, [projectState.hasStaleBuildCache]);
 
   const device = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
     return sd.modelId === projectState?.selectedDevice?.modelId;

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -120,7 +120,9 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
                   <span className="codicon codicon-browser" /> Visit troubleshoot guide
                 </Button>
               </a>
-              <Button type="secondary" onClick={() => deviceSessionsManager.reload("rebuild")}>
+              <Button
+                type="secondary"
+                onClick={() => deviceSessionsManager.reloadCurrentSession("rebuild")}>
                 <span className="codicon codicon-refresh" /> Clean rebuild project
               </Button>
             </div>

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -26,8 +26,8 @@ function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: numbe
 }
 
 function useIsEnabled() {
-  const { toolsState } = useProject();
-  return toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
+  const { projectState } = useProject();
+  return projectState.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
 }
 
 function RenderOutlinesOverlay() {

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -71,11 +71,14 @@ function ToolsList({
 }
 
 function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) {
-  const { project, toolsState, isProfilingCPU, isProfilingReact } = useProject();
+  const { project, projectState } = useProject();
 
-  const allTools = Object.entries(toolsState);
+  const allTools = Object.entries(projectState.toolsState);
   const panelTools = allTools.filter(([key, tool]) => tool.panelAvailable);
   const nonPanelTools = allTools.filter(([key, tool]) => !tool.panelAvailable);
+
+  const isProfilingCPU = projectState.profilingCPUState !== "stopped";
+  const isProfilingReact = projectState.profilingReactState !== "stopped";
 
   return (
     <DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -10,19 +10,19 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
   const { deviceSessionsManager } = useDevices();
   return (
     <IconButtonWithOptions
-      onClick={() => deviceSessionsManager.reload("autoReload")}
+      onClick={() => deviceSessionsManager.reloadCurrentSession("autoReload")}
       tooltip={{
         label: "Reload the app",
         side: "bottom",
       }}
       disabled={disabled}
       options={{
-        "Reload JS": () => deviceSessionsManager.reload("reloadJs"),
-        "Restart app process": () => deviceSessionsManager.reload("restartProcess"),
-        "Reinstall app": () => deviceSessionsManager.reload("reinstall"),
-        "Clear Metro cache": () => deviceSessionsManager.reload("clearMetro"),
-        "Reboot IDE": () => deviceSessionsManager.reload("reboot"),
-        "Clean rebuild": () => deviceSessionsManager.reload("rebuild"),
+        "Reload JS": () => deviceSessionsManager.reloadCurrentSession("reloadJs"),
+        "Restart app process": () => deviceSessionsManager.reloadCurrentSession("restartProcess"),
+        "Reinstall app": () => deviceSessionsManager.reloadCurrentSession("reinstall"),
+        "Clear Metro cache": () => deviceSessionsManager.reloadCurrentSession("clearMetro"),
+        "Reboot IDE": () => deviceSessionsManager.reloadCurrentSession("reboot"),
+        "Clean rebuild": () => deviceSessionsManager.reloadCurrentSession("rebuild"),
       }}>
       <span className="codicon codicon-refresh" />
     </IconButtonWithOptions>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useMemo } from "react";
+import { useState } from "react";
 import { useProject } from "../providers/ProjectProvider";
-import UrlSelect, { UrlItem } from "./UrlSelect";
+import UrlSelect from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";
 import IconButton from "./shared/IconButton";
 import { useDependencies } from "../providers/DependenciesProvider";
@@ -33,57 +33,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const { project, projectState } = useProject();
   const { dependencies } = useDependencies();
 
-  const MAX_URL_HISTORY_SIZE = 20;
-  const MAX_RECENT_URL_SIZE = 5;
-
-  const [backNavigationPath, setBackNavigationPath] = useState<string>("");
-  const [urlList, setUrlList] = useState<UrlItem[]>([]);
-  const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
-  const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectValue, setUrlSelectValue] = useState<string>(urlList[0]?.id);
-
-  useEffect(() => {
-    function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {
-      return [newUrl, ...urls.filter((record) => record.id !== newUrl.id)];
-    }
-
-    function handleNavigationChanged(navigationData: { displayName: string; id: string }) {
-      if (backNavigationPath && backNavigationPath !== navigationData.id) {
-        return;
-      }
-
-      const newRecord: UrlItem = {
-        name: navigationData.displayName,
-        id: navigationData.id,
-      };
-      const isNotInHistory = urlHistory.length === 0 || urlHistory[0] !== newRecord.id;
-
-      setUrlList((currentUrlList) => moveAsMostRecent(currentUrlList, newRecord));
-      setRecentUrlList((currentRecentUrlList) => {
-        const updatedRecentUrls = moveAsMostRecent(currentRecentUrlList, newRecord);
-        return updatedRecentUrls.slice(0, MAX_RECENT_URL_SIZE);
-      });
-
-      if (isNotInHistory) {
-        setUrlHistory((currentUrlHistoryList) => {
-          const updatedUrlHistory = [newRecord.id, ...currentUrlHistoryList];
-          return updatedUrlHistory.slice(0, MAX_URL_HISTORY_SIZE);
-        });
-      }
-      setBackNavigationPath("");
-    }
-
-    project.addListener("navigationChanged", handleNavigationChanged);
-    return () => {
-      project.removeListener("navigationChanged", handleNavigationChanged);
-    };
-  }, [recentUrlList, urlHistory, backNavigationPath]);
-
-  const sortedUrlList = useMemo(() => {
-    const sorted = [...urlList].sort((a, b) => a.name.localeCompare(b.name));
-    setUrlSelectValue(urlList[0]?.id);
-    return sorted;
-  }, [urlList]);
+  const navHistory = projectState.navigationHistory;
+  const [urlSelectValue, setUrlSelectValue] = useState<string>(navHistory[0]?.id);
 
   const disabledAlsoWhenStarting = disabled || projectState.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
@@ -95,15 +46,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={disabledAlsoWhenStarting || !isExpoRouterProject || urlHistory.length < 2}
-        onClick={() => {
-          setUrlHistory((prevUrlHistory) => {
-            const newUrlHistory = prevUrlHistory.slice(1);
-            setBackNavigationPath(newUrlHistory[0]);
-            project.openNavigation(newUrlHistory[0]);
-            return newUrlHistory;
-          });
-        }}>
+        disabled={disabledAlsoWhenStarting || !isExpoRouterProject || navHistory.length < 2}
+        onClick={() => project.navigateBack()}>
         <span className="codicon codicon-arrow-left" />
       </IconButton>
       <ReloadButton disabled={disabled ?? false} />
@@ -125,10 +69,9 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         onValueChange={(value: string) => {
           project.openNavigation(value);
         }}
-        recentItems={recentUrlList}
-        items={sortedUrlList}
+        navigationHistory={navHistory}
         value={urlSelectValue}
-        disabled={disabledAlsoWhenStarting || urlList.length < (isExpoRouterProject ? 2 : 1)}
+        disabled={disabledAlsoWhenStarting || navHistory.length < (isExpoRouterProject ? 2 : 1)}
       />
     </>
   );

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useMemo } from "react";
+import { useState } from "react";
 import { useProject } from "../providers/ProjectProvider";
-import UrlSelect, { UrlItem } from "./UrlSelect";
+import UrlSelect from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";
 import IconButton from "./shared/IconButton";
 import { useDependencies } from "../providers/DependenciesProvider";
@@ -10,19 +10,19 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
   const { deviceSessionsManager } = useDevices();
   return (
     <IconButtonWithOptions
-      onClick={() => deviceSessionsManager.reload("autoReload")}
+      onClick={() => deviceSessionsManager.reloadCurrentSession("autoReload")}
       tooltip={{
         label: "Reload the app",
         side: "bottom",
       }}
       disabled={disabled}
       options={{
-        "Reload JS": () => deviceSessionsManager.reload("reloadJs"),
-        "Restart app process": () => deviceSessionsManager.reload("restartProcess"),
-        "Reinstall app": () => deviceSessionsManager.reload("reinstall"),
-        "Clear Metro cache": () => deviceSessionsManager.reload("clearMetro"),
-        "Reboot IDE": () => deviceSessionsManager.reload("reboot"),
-        "Clean rebuild": () => deviceSessionsManager.reload("rebuild"),
+        "Reload JS": () => deviceSessionsManager.reloadCurrentSession("reloadJs"),
+        "Restart app process": () => deviceSessionsManager.reloadCurrentSession("restartProcess"),
+        "Reinstall app": () => deviceSessionsManager.reloadCurrentSession("reinstall"),
+        "Clear Metro cache": () => deviceSessionsManager.reloadCurrentSession("clearMetro"),
+        "Reboot IDE": () => deviceSessionsManager.reloadCurrentSession("reboot"),
+        "Clean rebuild": () => deviceSessionsManager.reloadCurrentSession("rebuild"),
       }}>
       <span className="codicon codicon-refresh" />
     </IconButtonWithOptions>
@@ -33,57 +33,10 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const { project, projectState } = useProject();
   const { dependencies } = useDependencies();
 
-  const MAX_URL_HISTORY_SIZE = 20;
-  const MAX_RECENT_URL_SIZE = 5;
-
-  const [backNavigationPath, setBackNavigationPath] = useState<string>("");
-  const [urlList, setUrlList] = useState<UrlItem[]>([]);
-  const [recentUrlList, setRecentUrlList] = useState<UrlItem[]>([]);
-  const [urlHistory, setUrlHistory] = useState<string[]>([]);
-  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(urlList[0]?.id);
-
-  useEffect(() => {
-    function moveAsMostRecent(urls: UrlItem[], newUrl: UrlItem) {
-      return [newUrl, ...urls.filter((record) => record.id !== newUrl.id)];
-    }
-
-    function handleNavigationChanged(navigationData: { displayName: string; id: string }) {
-      if (backNavigationPath && backNavigationPath !== navigationData.id) {
-        return;
-      }
-
-      const newRecord: UrlItem = {
-        name: navigationData.displayName,
-        id: navigationData.id,
-      };
-      const isNotInHistory = urlHistory.length === 0 || urlHistory[0] !== newRecord.id;
-
-      setUrlList((currentUrlList) => moveAsMostRecent(currentUrlList, newRecord));
-      setRecentUrlList((currentRecentUrlList) => {
-        const updatedRecentUrls = moveAsMostRecent(currentRecentUrlList, newRecord);
-        return updatedRecentUrls.slice(0, MAX_RECENT_URL_SIZE);
-      });
-
-      if (isNotInHistory) {
-        setUrlHistory((currentUrlHistoryList) => {
-          const updatedUrlHistory = [newRecord.id, ...currentUrlHistoryList];
-          return updatedUrlHistory.slice(0, MAX_URL_HISTORY_SIZE);
-        });
-      }
-      setBackNavigationPath("");
-    }
-
-    project.addListener("navigationChanged", handleNavigationChanged);
-    return () => {
-      project.removeListener("navigationChanged", handleNavigationChanged);
-    };
-  }, [recentUrlList, urlHistory, backNavigationPath]);
-
-  const sortedUrlList = useMemo(() => {
-    const sorted = [...urlList].sort((a, b) => a.name.localeCompare(b.name));
-    setUrlSelectValue(urlList[0]?.id);
-    return sorted;
-  }, [urlList]);
+  const navigationHistory = projectState.navigationHistory;
+  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(
+    navigationHistory[0]?.id
+  );
 
   const disabledAlsoWhenStarting = disabled || projectState.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
@@ -95,15 +48,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={disabledAlsoWhenStarting || !isExpoRouterProject || urlHistory.length < 2}
-        onClick={() => {
-          setUrlHistory((prevUrlHistory) => {
-            const newUrlHistory = prevUrlHistory.slice(1);
-            setBackNavigationPath(newUrlHistory[0]);
-            project.openNavigation(newUrlHistory[0]);
-            return newUrlHistory;
-          });
-        }}>
+        disabled={disabledAlsoWhenStarting || !isExpoRouterProject || navigationHistory.length < 2}
+        onClick={() => project.navigateBack()}>
         <span className="codicon codicon-arrow-left" />
       </IconButton>
       <ReloadButton disabled={disabled ?? false} />
@@ -125,8 +71,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         onValueChange={(value: string) => {
           project.openNavigation(value);
         }}
-        recentItems={recentUrlList}
-        items={sortedUrlList}
+        navigationHistory={navigationHistory}
         value={urlSelectValue}
         disabled={disabledAlsoWhenStarting}
       />

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -34,9 +34,6 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const { dependencies } = useDependencies();
 
   const navigationHistory = projectState.navigationHistory;
-  const [urlSelectValue, setUrlSelectValue] = useState<string | undefined>(
-    navigationHistory[0]?.id
-  );
 
   const disabledAlsoWhenStarting = disabled || projectState.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
@@ -55,10 +52,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
       <ReloadButton disabled={disabled ?? false} />
       <IconButton
         onClick={() => {
-          project.goHome("/{}");
-          if (!isExpoRouterProject) {
-            setUrlSelectValue(""); // sets UrlSelect trigger to a placeholder
-          }
+          project.navigateHome();
         }}
         tooltip={{
           label: "Go to main screen",
@@ -72,7 +66,6 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           project.openNavigation(value);
         }}
         navigationHistory={navigationHistory}
-        value={urlSelectValue}
         disabled={disabledAlsoWhenStarting}
       />
     </>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useProject } from "../providers/ProjectProvider";
 import UrlSelect from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -3,11 +3,10 @@ import * as Popover from "@radix-ui/react-popover";
 import { VscodeTextfield } from "@vscode-elements/react-elements";
 import { partition } from "lodash";
 import "./UrlSelect.css";
-
-export type UrlItem = { id: string; name: string };
+import { NavigationHistoryItem } from "../../common/Project";
 
 interface PopoverItemProps {
-  item: UrlItem;
+  item: NavigationHistoryItem;
   width: number;
   style?: React.CSSProperties;
   textfieldRef: React.RefObject<HTMLInputElement>;
@@ -55,8 +54,7 @@ const PopoverItem = React.forwardRef<HTMLDivElement, PropsWithChildren<PopoverIt
 interface UrlSelectProps {
   value?: string;
   onValueChange: (newValue: string) => void;
-  recentItems: UrlItem[];
-  items: UrlItem[];
+  navigationHistory: NavigationHistoryItem[];
   disabled?: boolean;
 }
 
@@ -64,22 +62,22 @@ type UrlSelectFocusable = HTMLDivElement | HTMLInputElement;
 
 // Currently, recentItems are not used, but they can be mapped to show the most recent
 // URLs in the dropdown. This can be implemented in the future if needed.
-function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSelectProps) {
+function UrlSelect({ onValueChange, navigationHistory, value, disabled }: UrlSelectProps) {
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const [inputValue, setInputValue] = React.useState("");
-  const [filteredItems, setFilteredItems] = React.useState<UrlItem[]>([]);
-  const [filteredOutItems, setFilteredOutItems] = React.useState<UrlItem[]>([]);
+  const [filteredItems, setFilteredItems] = React.useState<NavigationHistoryItem[]>([]);
+  const [filteredOutItems, setFilteredOutItems] = React.useState<NavigationHistoryItem[]>([]);
 
   const [textfieldWidth, setTextfieldWidth] = React.useState<number>(0);
   const textfieldRef = useRef<HTMLInputElement>(null);
 
   const getNameFromId = (id: string) => {
-    const itemForID = items.find((item) => item.id === id);
+    const itemForID = navigationHistory.find((item) => item.id === id);
     if (!itemForID) {
       return id;
     }
-    if (itemForID.name.startsWith("/")) {
-      return itemForID.name;
+    if (itemForID.displayName.startsWith("/")) {
+      return itemForID.displayName;
     }
     return itemForID.id;
   };
@@ -129,16 +127,16 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
   useEffect(() => {
     if (disabled) {
       setFilteredItems([]);
-      setFilteredOutItems(items);
+      setFilteredOutItems(navigationHistory);
       return;
     }
     const inputValueLowerCase = inputValue.toLowerCase();
-    const [filtered, filteredOut] = partition(items, (item) =>
+    const [filtered, filteredOut] = partition(navigationHistory, (item) =>
       getNameFromId(item.id).toLowerCase().includes(inputValueLowerCase)
     );
     setFilteredItems(filtered);
     setFilteredOutItems(filteredOut);
-  }, [inputValue, items]);
+  }, [inputValue, navigationHistory]);
 
   useEffect(() => {
     if (textfieldRef.current) {
@@ -222,7 +220,7 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
                 <div className="url-select-label">Suggested paths:</div>
                 {filteredItems.map(
                   (item) =>
-                    item.name && (
+                    item.displayName && (
                       <PopoverItem
                         item={item}
                         key={item.id}
@@ -246,7 +244,7 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
                 <div className="url-select-label">Other paths:</div>
                 {filteredOutItems.map(
                   (item) =>
-                    item.name && (
+                    item.displayName && (
                       <PopoverItem
                         item={item}
                         key={item.id}

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -1,8 +1,7 @@
 import React, { PropsWithChildren } from "react";
 import * as Select from "@radix-ui/react-select";
 import "./UrlSelect.css";
-
-export type UrlItem = { id: string; name: string };
+import { NavigationHistoryItem } from "../../common/Project";
 
 const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.SelectItemProps>>(
   ({ children, ...props }, forwardedRef) => (
@@ -17,12 +16,11 @@ const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.Sel
 interface UrlSelectProps {
   value: string;
   onValueChange: (newValue: string) => void;
-  recentItems: UrlItem[];
-  items: UrlItem[];
+  navigationHistory: NavigationHistoryItem[];
   disabled?: boolean;
 }
 
-function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSelectProps) {
+function UrlSelect({ onValueChange, navigationHistory, value, disabled }: UrlSelectProps) {
   // We use two lists for URL selection: one with recently used URLs and another
   // with all available URLs. Since recentItems is a subset of items, each recentItems's
   // value is prefixed to differentiate their origins when presented in the Select
@@ -45,25 +43,14 @@ function UrlSelect({ onValueChange, recentItems, items, value, disabled }: UrlSe
             <span className="codicon codicon-chevron-up" />
           </Select.ScrollUpButton>
           <Select.Viewport className="url-select-viewport">
-            <Select.Group>
-              <Select.Label className="url-select-label">Recently used:</Select.Label>
-              {recentItems.map(
-                (item) =>
-                  item.name && (
-                    <SelectItem value={`recent#${item.id}`} key={item.id}>
-                      {item.name}
-                    </SelectItem>
-                  )
-              )}
-            </Select.Group>
             <Select.Separator className="url-select-separator" />
             <Select.Group>
               <Select.Label className="url-select-label">All visited paths:</Select.Label>
-              {items.map(
+              {navigationHistory.map(
                 (item) =>
-                  item.name && (
+                  item.displayName && (
                     <SelectItem value={item.id} key={item.id}>
-                      {item.name}
+                      {item.displayName}
                     </SelectItem>
                   )
               )}

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -52,7 +52,6 @@ const PopoverItem = React.forwardRef<HTMLDivElement, PropsWithChildren<PopoverIt
 );
 
 interface UrlSelectProps {
-  value?: string;
   onValueChange: (newValue: string) => void;
   navigationHistory: NavigationHistoryItem[];
   disabled?: boolean;
@@ -62,7 +61,7 @@ type UrlSelectFocusable = HTMLDivElement | HTMLInputElement;
 
 // Currently, recentItems are not used, but they can be mapped to show the most recent
 // URLs in the dropdown. This can be implemented in the future if needed.
-function UrlSelect({ onValueChange, navigationHistory, value, disabled }: UrlSelectProps) {
+function UrlSelect({ onValueChange, navigationHistory, disabled }: UrlSelectProps) {
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const [inputValue, setInputValue] = React.useState("");
   const [filteredItems, setFilteredItems] = React.useState<NavigationHistoryItem[]>([]);
@@ -119,10 +118,8 @@ function UrlSelect({ onValueChange, navigationHistory, value, disabled }: UrlSel
   };
 
   useEffect(() => {
-    if (value !== undefined) {
-      setInputValue(getNameFromId(value));
-    }
-  }, [value]);
+    setInputValue(navigationHistory[0]?.displayName ?? "");
+  }, [navigationHistory[0]?.id]);
 
   useEffect(() => {
     if (disabled) {

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -63,7 +63,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
 
   let description = "Open extension logs to find out what went wrong.";
 
-  if (projectState.status === "buildError") {
+  if (projectState.status === "buildError" && projectState.buildError) {
     const { buildType, message } = projectState.buildError;
     description = message;
     if (buildType && [BuildType.Local, BuildType.EasLocal, BuildType.Custom].includes(buildType)) {

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -57,7 +57,7 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
   const { deviceSessionsManager } = useDevices();
 
   let onReload = () => {
-    deviceSessionsManager.reload("autoReload");
+    deviceSessionsManager.reloadCurrentSession("autoReload");
   };
   let logsButtonDestination: LogsButtonDestination | undefined = undefined;
 
@@ -133,7 +133,7 @@ function BundleErrorActions() {
       <IconButton
         type="secondary"
         onClick={() => {
-          deviceSessionsManager.reload("autoReload");
+          deviceSessionsManager.reloadCurrentSession("autoReload");
         }}
         tooltip={{ label: "Reload Metro", side: "bottom" }}>
         <span className="codicon codicon-refresh" />

--- a/packages/vscode-extension/src/webview/hooks/useNativeRebuildAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useNativeRebuildAlert.tsx
@@ -14,7 +14,7 @@ function Actions({ closeAlert }: Props) {
       <IconButton
         type="secondary"
         onClick={() => {
-          deviceSessionsManager.reload("rebuild");
+          deviceSessionsManager.reloadCurrentSession("rebuild");
           closeAlert();
         }}
         tooltip={{ label: "Rebuild", side: "bottom" }}>

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -78,9 +78,6 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
   const [toolsState, setToolsState] = useState<ToolsState>({});
   const [hasActiveLicense, setHasActiveLicense] = useState(true);
   const [isRecording, setIsRecording] = useState(false);
-  const [isProfilingCPU, setIsProfilingCPU] = useState(false);
-  const [isProfilingReact, setIsProfilingReact] = useState(false);
-  const [isSavingReactProfile, setIsSavingReactProfile] = useState(false);
   const [replayData, setReplayData] = useState<MultimediaData | undefined>(undefined);
 
   useEffect(() => {
@@ -93,15 +90,10 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     project.hasActiveLicense().then(setHasActiveLicense);
     project.addListener("licenseActivationChanged", setHasActiveLicense);
 
-    project.getToolsState().then(setToolsState);
     project.addListener("toolsStateChanged", setToolsState);
 
     project.addListener("isRecording", setIsRecording);
     project.addListener("replayDataCreated", setReplayData);
-
-    project.addListener("isProfilingCPU", setIsProfilingCPU);
-    project.addListener("isProfilingReact", setIsProfilingReact);
-    project.addListener("isSavingReactProfile", setIsSavingReactProfile);
     return () => {
       project.removeListener("projectStateChanged", setProjectState);
       project.removeListener("deviceSettingsChanged", setDeviceSettings);
@@ -120,9 +112,6 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
       replayData,
       setReplayData,
       isRecording,
-      isProfilingCPU,
-      isProfilingReact,
-      isSavingReactProfile,
     };
   }, [
     projectState,
@@ -133,9 +122,6 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     replayData,
     setReplayData,
     isRecording,
-    isProfilingCPU,
-    isProfilingReact,
-    isSavingReactProfile,
   ]);
 
   return <ProjectContext.Provider value={contextValue}>{children}</ProjectContext.Provider>;

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -10,12 +10,11 @@ import {
 } from "react";
 import { makeProxy } from "../utilities/rpc";
 import {
+  DeviceSessionInitialState,
   DeviceSettings,
   MultimediaData,
   ProjectInterface,
   ProjectState,
-  StartupMessage,
-  ToolsState,
 } from "../../common/Project";
 
 const project = makeProxy<ProjectInterface>("Project");
@@ -23,23 +22,15 @@ const project = makeProxy<ProjectInterface>("Project");
 interface ProjectContextProps {
   projectState: ProjectState;
   deviceSettings: DeviceSettings;
-  toolsState: ToolsState;
   project: ProjectInterface;
   hasActiveLicense: boolean;
   replayData: MultimediaData | undefined;
   setReplayData: Dispatch<SetStateAction<MultimediaData | undefined>>;
   isRecording: boolean;
-  isProfilingCPU: boolean;
-  isProfilingReact: boolean;
-  isSavingReactProfile: boolean;
 }
 
 const defaultProjectState: ProjectState = {
-  status: "starting",
-  startupMessage: StartupMessage.InitializingDevice,
-  stageProgress: 0,
-  previewURL: undefined,
-  selectedDevice: undefined,
+  ...DeviceSessionInitialState,
   previewZoom: undefined,
   initialized: false,
 };
@@ -61,21 +52,16 @@ const defaultDeviceSettings: DeviceSettings = {
 const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
-  toolsState: {},
   project,
   hasActiveLicense: false,
   replayData: undefined,
   setReplayData: () => {},
   isRecording: false,
-  isProfilingCPU: false,
-  isProfilingReact: false,
-  isSavingReactProfile: false,
 });
 
 export default function ProjectProvider({ children }: PropsWithChildren) {
   const [projectState, setProjectState] = useState<ProjectState>(defaultProjectState);
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings>(defaultDeviceSettings);
-  const [toolsState, setToolsState] = useState<ToolsState>({});
   const [hasActiveLicense, setHasActiveLicense] = useState(true);
   const [isRecording, setIsRecording] = useState(false);
   const [replayData, setReplayData] = useState<MultimediaData | undefined>(undefined);
@@ -90,15 +76,12 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     project.hasActiveLicense().then(setHasActiveLicense);
     project.addListener("licenseActivationChanged", setHasActiveLicense);
 
-    project.addListener("toolsStateChanged", setToolsState);
-
     project.addListener("isRecording", setIsRecording);
     project.addListener("replayDataCreated", setReplayData);
     return () => {
       project.removeListener("projectStateChanged", setProjectState);
       project.removeListener("deviceSettingsChanged", setDeviceSettings);
       project.removeListener("licenseActivationChanged", setHasActiveLicense);
-      project.removeListener("toolsStateChanged", setToolsState);
     };
   }, []);
 
@@ -108,7 +91,6 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
       deviceSettings,
       project,
       hasActiveLicense,
-      toolsState,
       replayData,
       setReplayData,
       isRecording,
@@ -118,7 +100,6 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     deviceSettings,
     project,
     hasActiveLicense,
-    toolsState,
     replayData,
     setReplayData,
     isRecording,

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -25,7 +25,7 @@ function DeviceRow({ deviceInfo, onDeviceRename, onDeviceDelete, isSelected }: D
 
   const handleDeviceChange = async () => {
     if (!isSelected) {
-      deviceSessionsManager.selectDevice(deviceInfo);
+      deviceSessionsManager.startOrActivateSessionForDevice(deviceInfo);
     }
   };
 

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -13,7 +13,13 @@ import { useProject } from "../providers/ProjectProvider";
 import DeviceSelect from "../components/DeviceSelect";
 import { InspectDataMenu } from "../components/InspectDataMenu";
 import Button from "../components/shared/Button";
-import { Frame, InspectDataStackItem, InspectStackData, ZoomLevelType } from "../../common/Project";
+import {
+  Frame,
+  InspectDataStackItem,
+  InspectStackData,
+  ProfilingState,
+  ZoomLevelType,
+} from "../../common/Project";
 import { Platform, useUtils } from "../providers/UtilsProvider";
 import { AndroidSupportedDevices, iOSSupportedDevices } from "../utilities/deviceContants";
 import "./View.css";
@@ -39,30 +45,28 @@ function ActivateLicenseButton() {
 }
 
 function ProfilingButton({
-  isProfiling,
-  isLoadingProfile,
+  profilingState,
   title,
   onClick,
 }: {
-  isProfiling: boolean;
-  isLoadingProfile: boolean;
+  profilingState: ProfilingState;
   title: string;
   onClick: () => void;
 }) {
-  const showButton = isProfiling || isLoadingProfile;
+  const showButton = profilingState !== "stopped";
   return (
     <IconButton
       className={showButton ? "button-recording-on" : ""}
       tooltip={{
         label: title,
       }}
-      disabled={!isProfiling}
+      disabled={profilingState !== "profiling"}
       onClick={onClick}>
       {showButton && (
         <>
           <span
             className={
-              isLoadingProfile
+              profilingState === "saving"
                 ? "codicon codicon-loading codicon-modifier-spin"
                 : "recording-rec-dot"
             }
@@ -82,9 +86,6 @@ function PreviewView() {
     hasActiveLicense,
     replayData,
     isRecording,
-    isProfilingCPU,
-    isProfilingReact,
-    isSavingReactProfile,
     setReplayData,
   } = useProject();
   const { showDismissableError } = useUtils();
@@ -99,8 +100,6 @@ function PreviewView() {
     },
     [project]
   );
-  const [logCounter, setLogCounter] = useState(0);
-  const [resetKey, setResetKey] = useState(0);
   const [recordingTime, setRecordingTime] = useState(0);
   const { devices } = useDevices();
 
@@ -115,24 +114,6 @@ function PreviewView() {
   });
 
   const { openFileAt } = useUtils();
-
-  useEffect(() => {
-    function incrementLogCounter() {
-      setLogCounter((c) => c + 1);
-    }
-    project.addListener("log", incrementLogCounter);
-
-    return () => {
-      project.removeListener("log", incrementLogCounter);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isStarting) {
-      setLogCounter(0);
-      setResetKey((prevKey) => prevKey + 1);
-    }
-  }, [setLogCounter, isStarting]);
 
   useEffect(() => {
     const disableInspectorOnEscape = (event: KeyboardEvent) => {
@@ -218,18 +199,16 @@ function PreviewView() {
     <div className="panel-view">
       <div className="button-group-top">
         <div className="button-group-top-left">
-          <UrlBar key={resetKey} disabled={hasNoDevices} />
+          <UrlBar disabled={hasNoDevices} />
         </div>
         <div className="button-group-top-right">
           <ProfilingButton
-            isProfiling={isProfilingCPU}
-            isLoadingProfile={false}
+            profilingState={projectState.profilingCPUState}
             title="Stop profiling CPU"
             onClick={stopProfilingCPU}
           />
           <ProfilingButton
-            isProfiling={isProfilingReact}
-            isLoadingProfile={isSavingReactProfile}
+            profilingState={projectState.profilingReactState}
             title="Stop profiling React"
             onClick={stopProfilingReact}
           />
@@ -273,11 +252,8 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            counter={logCounter}
-            onClick={() => {
-              setLogCounter(0);
-              project.focusDebugConsole();
-            }}
+            counter={projectState.logCounter}
+            onClick={() => project.focusDebugConsole()}
             tooltip={{
               label: "Open logs panel",
             }}


### PR DESCRIPTION
This PR refactors a bunch of places in order to straighten up the logic and data flow and to make the project state management more robust and self-contained.

Key objectives:
1) Switching between devices sometimes causes an undesirable state coming from unselected/old device to leak into project settings. As this is undesirable, we update `DeviceSessionManager` to guard against this. Now, all the project state updates are routed via `DeviceSessionManager` which verifies that the device session from which the update comes is the one that is currently selected.
2) Our state is currently distributed between the extension process and webview. Most of the "project state" actually belongs to a particular device session. When we switch between sessions, we don't want to manually keep track of the state updates on the webview site. This was previously happening. When switching we'd need to reset navigation state. But this also applies to other state elements, like whether we're currently profiling or if there's a stale build. Previously, we'd use events to pass that information and then store state in webview. Now, we're moving most of that into the "project state" and update it along all the other variables. This includes things like navigation history which is now kept in the state too.

The biggest change in the PR that affects the biggest number of lines is that we're moving most of the "project state" out of the project class and into device session class. This includes a number of methods and logic responsible for monitoring state updates and responding to them.

This PR also aims to fix some issues and design flaws in project / device-session-manager / device session classes. Below, we're listing notable changes:

1. device settings management moved from device session into device base. Now, device base class is responsible for storing the updates for device settings and also managing replays and show touches settings.
2. we're restructuring the startup flow for the device session class. Before it'd control all the aspects of starting the session. Since we recently added "activate" / "deactivate" methods that aim to control the session "visibility" when switching, we move control over the debug session there. We also branch out from the startup flow to make sure that debugger is only started when in active state.


### How Has This Been Tested: 
1. Run app (test on several versions)
3. Switch devices during boot
4. Test restart options
5. Switch during restart
6. After switching verify there are no multiple debug sessions in the debug console dropdown
7. Test Url bar on expo-router project
8. Verify changing device settings works and persist across device switching
9. Test replays and "show toucches" settings in particular


