### PR TITLE
improve build error alert messages

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -222,8 +222,21 @@ async function buildLocal(
     buildAndroidProgressProcessor.processLine(line);
   });
 
-  await buildProcess;
+  try {
+    await buildProcess;
+  } catch (e) {
+    Logger.error("Android build failed", e);
+    throw new Error("Failed to build the Android app with gradle. See the build logs for details.");
+  }
   Logger.debug("Android build successful");
-  const apkInfo = await getAndroidBuildPaths(appRoot, cancelToken, productFlavor, buildType);
-  return { ...apkInfo, platform: DevicePlatform.Android };
+  try {
+    const apkInfo = await getAndroidBuildPaths(appRoot, cancelToken, productFlavor, buildType);
+    return { ...apkInfo, platform: DevicePlatform.Android };
+  } catch (e) {
+    Logger.error("Failed to extract package name from APK", e);
+    throw new Error(
+      "The Android build was successful, but the APK file could not be accessed. " +
+        "See the build logs for details. "
+    );
+  }
 }

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -215,13 +215,25 @@ async function buildLocal(
     buildIOSProgressProcessor.processLine(line);
   });
 
-  await buildProcess;
+  try {
+    await buildProcess;
+  } catch (e) {
+    Logger.error("Error building iOS project", e);
+    throw new Error(
+      "Failed to build the iOS app with xcodebuild. Check the build logs for details."
+    );
+  }
 
-  const appPath = await getBuildPath(xcodeProject, sourceDir, scheme, configuration, cancelToken);
-
-  const bundleID = await getBundleID(appPath);
-
-  return { appPath, bundleID, platform: DevicePlatform.IOS };
+  try {
+    const appPath = await getBuildPath(xcodeProject, sourceDir, scheme, configuration, cancelToken);
+    const bundleID = await getBundleID(appPath);
+    return { appPath, bundleID, platform: DevicePlatform.IOS };
+  } catch (e) {
+    Logger.error("Error getting app path", e);
+    throw new Error(
+      "The iOS app build was successful, but the app file could not be accessed. See the build logs for details."
+    );
+  }
 }
 
 async function getBuildPath(

--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -169,11 +169,16 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
 
     this.emitEvent("nodeModules", { status: "installing", isOptional: false });
 
-    // all package managers support the `install` command
-    await command(`${packageManager.name} install`, {
-      cwd: packageManager.workspacePath ?? appRoot,
-      quietErrorsOnExit: true,
-    });
+    try {
+      // all package managers support the `install` command
+      await command(`${packageManager.name} install`, {
+        cwd: packageManager.workspacePath ?? appRoot,
+        quietErrorsOnExit: true,
+      });
+    } catch (e) {
+      Logger.error("Failed to install node modules", e);
+      throw new Error("Failed to install node modules. Check the logs for details.");
+    }
 
     this.emitEvent("nodeModules", { status: "installed", isOptional: false });
 


### PR DESCRIPTION
After #1068, the build error alerts display the error messages of the exceptions thrown while starting the app.
This resulted in the IDE showing non-user-friendly messages to the user.
This PR wraps some of these errors with user-friendly messages redirecting the user to the logs for details.

### How Has This Been Tested: 
- break the native code (`ios`/`android` directory) in order to cause a build error
- verify the message redirects you to the build logs to check for details
- break your node install and restart the IDE
- verify the error message when installing node modules redirects you to the Radon logs