### PR TITLE
Safeguard agains debug sessions started in parallel

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -144,7 +144,7 @@ export class DeviceSession implements Disposable {
       deviceSessionDelegate,
       device.platform
     );
-    this.debugSession = new DebugSession(debugEventDelegate);
+    this.debugSession = new DebugSession(debugEventDelegate, { useParentDebugSession: true });
   }
 
   private makeDevtools() {


### PR DESCRIPTION
This PR extracts some code changes from #1154 that can be landed separately and improves the codebase regardless.

We've recently struggled with an error that was caused because of the session management is very complex right now. As a consequence, we'd end up getting a multiple debug sessions opened and sticking around in the debug console.

This PR updates the DebugSession code, such that we always guard against the sessions being started in parallel. What would happen before, is that from two different places, we'd request the debug session to start. We'd typically store the debug session in a member variable, that the assignment is only done after await. So, when another call happens before the session is assigned to variable, we don't detect that and the newly created session would override that member variable resulting in one of the debug session leaking.

What we do here is simply store the awaited session in a local variable and check if the session was set in  the meantime after awaiting again. If that happens we print a warning, as it could be helpful to track down the root cause of this behavior regardless.

### How Has This Been Tested: 
1. Test whether the app loads properly and that we get metro errors logged on the startup time.


