### PR TITLE
Simplify settings management by moving it out of device session manager

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -244,10 +244,10 @@ export class AndroidEmulatorDevice extends DeviceBase {
     return promise;
   }
 
-  async bootDevice(deviceSettings: DeviceSettings): Promise<void> {
+  async bootDevice(): Promise<void> {
     await this.internalBootDevice();
 
-    let shouldRestart = await this.changeSettings(deviceSettings);
+    let shouldRestart = await this.changeSettings(this.deviceSettings);
     if (shouldRestart) {
       await this.forcefullyResetDevice();
     }

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -5,6 +5,9 @@ import { BuildResult } from "../builders/BuildManager";
 import { AppPermissionType, DeviceSettings, TouchPoint, DeviceButtonType } from "../common/Project";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { tryAcquiringLock } from "../utilities/common";
+import { extensionContext } from "../utilities/extensionContext";
+import { getTelemetryReporter } from "../utilities/telemetry";
+import { getChanges } from "../utilities/diffing";
 
 const LEFT_META_HID_CODE = 0xe3;
 const RIGHT_META_HID_CODE = 0xe7;
@@ -13,12 +16,31 @@ const C_KEY_HID_CODE = 0x06;
 
 export const REBOOT_TIMEOUT = 3000;
 
+export const DEVICE_SETTINGS_KEY = "device_settings_v4";
+export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
+  appearance: "dark",
+  contentSize: "normal",
+  location: {
+    latitude: 50.048653,
+    longitude: 19.965474,
+    isDisabled: false,
+  },
+  hasEnrolledBiometrics: false,
+  locale: "en_US",
+  replaysEnabled: false,
+  showTouches: false,
+};
+
 export abstract class DeviceBase implements Disposable {
   protected preview: Preview | undefined;
   private previewStartPromise: Promise<string> | undefined;
   private acquired = false;
   private pressingLeftMetaKey = false;
   private pressingRightMetaKey = false;
+  protected deviceSettings: DeviceSettings = extensionContext.workspaceState.get(
+    DEVICE_SETTINGS_KEY,
+    DEVICE_SETTINGS_DEFAULT
+  );
 
   abstract get lockFilePath(): string;
 
@@ -26,13 +48,47 @@ export abstract class DeviceBase implements Disposable {
     return this.preview?.streamURL;
   }
 
+  public get previewReady() {
+    return this.preview?.streamURL !== undefined;
+  }
+
   async reboot(): Promise<void> {
     this.preview?.dispose();
     this.preview = undefined;
     this.previewStartPromise = undefined;
   }
-  abstract bootDevice(deviceSettings: DeviceSettings): Promise<void>;
-  abstract changeSettings(settings: DeviceSettings): Promise<boolean>;
+
+  async updateDeviceSettings(settings: DeviceSettings) {
+    const changes = getChanges(this.deviceSettings, settings);
+
+    getTelemetryReporter().sendTelemetryEvent("device-settings:update-device-settings", {
+      platform: this.platform,
+      changedSetting: JSON.stringify(changes),
+    });
+
+    extensionContext.workspaceState.update(DEVICE_SETTINGS_KEY, settings);
+    if (this.previewReady) {
+      if (changes.replaysEnabled !== undefined) {
+        if (changes.replaysEnabled) {
+          this.enableReplay();
+        } else {
+          this.disableReplays();
+        }
+      }
+      if (changes.showTouches !== undefined) {
+        if (changes.showTouches) {
+          this.showTouches();
+        } else {
+          this.hideTouches();
+        }
+      }
+    }
+
+    return this.changeSettings(settings);
+  }
+
+  abstract bootDevice(): Promise<void>;
+  protected abstract changeSettings(settings: DeviceSettings): Promise<boolean>;
   abstract sendBiometricAuthorization(isMatch: boolean): Promise<void>;
   abstract getClipboard(): Promise<string | void>;
   abstract installApp(build: BuildResult, forceReinstall: boolean): Promise<void>;
@@ -165,6 +221,14 @@ export abstract class DeviceBase implements Disposable {
     if (!this.previewStartPromise) {
       this.preview = this.makePreview();
       this.previewStartPromise = this.preview.start();
+      this.previewStartPromise.then(() => {
+        if (this.deviceSettings.replaysEnabled) {
+          this.enableReplay();
+        }
+        if (this.deviceSettings.showTouches) {
+          this.showTouches();
+        }
+      });
     }
     return this.previewStartPromise;
   }

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -117,14 +117,14 @@ export class IosSimulatorDevice extends DeviceBase {
     }
   }
 
-  async bootDevice(settings: DeviceSettings) {
-    if (await this.shouldUpdateLocale(settings.locale)) {
-      await this.changeLocale(settings.locale);
+  async bootDevice() {
+    if (await this.shouldUpdateLocale(this.deviceSettings.locale)) {
+      await this.changeLocale(this.deviceSettings.locale);
     }
 
     await this.internalBootDevice();
 
-    await this.changeSettings(settings);
+    await this.changeSettings(this.deviceSettings);
   }
 
   private async shouldUpdateLocale(locale: Locale): Promise<boolean> {

--- a/packages/vscode-extension/src/devices/preview.ts
+++ b/packages/vscode-extension/src/devices/preview.ts
@@ -21,6 +21,7 @@ export class Preview implements Disposable {
   private subprocess?: ChildProcess;
   private tokenChangeListener?: Disposable;
   public streamURL?: string;
+  private replaysStarted = false;
 
   constructor(private args: string[]) {}
 
@@ -167,10 +168,17 @@ export class Preview implements Disposable {
   }
 
   public startReplays() {
-    this.sendCommandOrThrow(`video replay start -m -b 50\n`); // 50MB buffer for in-memory video
+    if (!this.replaysStarted) {
+      // starting replay if one was already started will crop the previous buffer
+      // we therefore need to check if a replay is already started
+      this.replaysStarted = true;
+      this.sendCommandOrThrow(`video replay start -m -b 50\n`); // 50MB buffer for in-memory video
+    }
   }
 
   public stopReplays() {
+    // we don't need to check if replay was already stopped because the stop command is idempotent
+    this.replaysStarted = false;
     this.sendCommandOrThrow(`video replay stop\n`);
   }
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -382,7 +382,6 @@ export class DeviceSession implements Disposable {
       platform: this.device.platform,
     });
     this.isLaunching = true;
-    this.device.disableReplays();
 
     // FIXME: Windows getting stuck waiting for the promise to resolve. This
     // seems like a problem with app connecting to Metro and using embedded

--- a/packages/vscode-extension/src/utilities/diffing.ts
+++ b/packages/vscode-extension/src/utilities/diffing.ts
@@ -1,0 +1,13 @@
+import { isEqual } from "lodash";
+
+export function getChanges<T extends Record<string, any>>(oldObj: T, newObj: T): Partial<T> {
+  const changes: Partial<T> = {};
+
+  for (const key in newObj) {
+    if (!isEqual(oldObj[key], newObj[key])) {
+      changes[key] = newObj[key];
+    }
+  }
+
+  return changes;
+}


### PR DESCRIPTION
This PR extracts fragments of the changes made in #1154 that simplifies the management of device settings.

Before, we'd store settings in device session which is already a pretty complex class with a dozen of different responsibilities. Eventually, the device settings need to be passed to individual device, so I figured it'd be simpler to move them there avoiding extra logic to be held in the session.

This PR refactors the code such that we move the responsibility of managing the device settings onto the base device class that android and iOS device subclesses inherit. This allows the subclasses to access settings when needed as protected class member. The base class also handles the settings that apply only to the preview which is managed by the base device class already (like replays or display touches).

As a consequence, we also refactor project class a bit. We don't need device change callback, as the change can only happen as a result of the project call. 

TODO: For supporting parallel sessions, we'd need to implement additional mechanism for monitoring device session updates that happen to the active device and apply them onto the inactive one. This is out of the scope of the current change as it'd require modification to the way we activate sessions and is also something that we doesn't handle right now.

### How Has This Been Tested: 
1. Boot device, change settings (show touches in particular), switch to a different device and make sure the changes are reflected.
2. Reboot the IDE to see the changes are persistent


