### PR TITLE
Add approot select to Preview

### DIFF
--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -51,12 +51,18 @@ export type LaunchConfigUpdater = <K extends keyof LaunchConfigurationOptions>(
 
 export type AddCustomApplicationRoot = (appRoot: string) => void;
 
+export type ApplicationRoot = {
+  path: string;
+  name: string;
+  displayName?: string;
+};
+
 export interface LaunchConfig {
   getConfig(): Promise<LaunchConfigurationOptions>;
   update: LaunchConfigUpdater;
   addCustomApplicationRoot: AddCustomApplicationRoot;
   getAvailableXcodeSchemes(): Promise<string[]>;
-  getAvailableApplicationRoots(): Promise<string[]>;
+  getAvailableApplicationRoots(): Promise<ApplicationRoot[]>;
   getAvailableEasProfiles(): Promise<EasBuildConfig>;
   addListener<K extends keyof LaunchConfigEventMap>(
     eventType: K,

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -40,6 +40,7 @@ export type ProjectState =
   | ProjectStateBuildError;
 
 type ProjectStateCommon = {
+  appRootPath: string | undefined;
   previewURL: string | undefined;
   selectedDevice: DeviceInfo | undefined;
   initialized: boolean;

--- a/packages/vscode-extension/src/panels/LaunchConfigController.ts
+++ b/packages/vscode-extension/src/panels/LaunchConfigController.ts
@@ -103,17 +103,24 @@ export class LaunchConfigController implements Disposable, LaunchConfig {
     return Promise.all(
       applicationRoots.map(async (appRootPath) => {
         const appRootAbsolutePath = path.resolve(workspacePath, appRootPath);
-        const appRootConfig = JSON.parse(
-          await promises.readFile(path.join(appRootAbsolutePath, "app.json"), "utf-8")
-        );
-        const name =
-          appRootConfig.expo?.name || appRootConfig.name || path.basename(appRootAbsolutePath);
-        const displayName = appRootConfig.displayName;
-        return {
-          path: appRootPath,
-          name,
-          displayName,
-        };
+        try {
+          const appRootConfig = JSON.parse(
+            await promises.readFile(path.join(appRootAbsolutePath, "app.json"), "utf-8")
+          );
+          const name =
+            appRootConfig.expo?.name || appRootConfig.name || path.basename(appRootAbsolutePath);
+          const displayName = appRootConfig.displayName;
+          return {
+            path: appRootPath,
+            name,
+            displayName,
+          };
+        } catch (e) {
+          return {
+            path: appRootPath,
+            name: path.basename(appRootAbsolutePath),
+          };
+        }
       })
     );
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -67,15 +67,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   public deviceSessionsManager: DeviceSessionsManager;
 
-  private projectState: ProjectState = {
-    status: "starting",
-    stageProgress: 0,
-    startupMessage: StartupMessage.InitializingDevice,
-    previewURL: undefined,
-    previewZoom: extensionContext.workspaceState.get(PREVIEW_ZOOM_KEY),
-    selectedDevice: undefined,
-    initialized: false,
-  };
+  private projectState: ProjectState;
 
   private disposables: Disposable[] = [];
 
@@ -97,6 +89,18 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
         this.updateProjectState(newState);
       }
     );
+
+    this.projectState = {
+      // NOTE: `relativeAppRootPath` uses `applicationContext`, so it must be initialized after it
+      appRootPath: this.relativeAppRootPath,
+      status: "starting",
+      stageProgress: 0,
+      startupMessage: StartupMessage.InitializingDevice,
+      previewURL: undefined,
+      previewZoom: extensionContext.workspaceState.get(PREVIEW_ZOOM_KEY),
+      selectedDevice: undefined,
+      initialized: false,
+    };
 
     this.disposables.push(refreshTokenPeriodically());
     this.disposables.push(
@@ -126,6 +130,14 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
         }
       })
     );
+  }
+
+  get relativeAppRootPath() {
+    const relativePath = workspace.asRelativePath(this.applicationContext.appRootFolder);
+    if (relativePath.startsWith(".." + path.sep) || relativePath.startsWith("." + path.sep)) {
+      return relativePath;
+    }
+    return `.${path.sep}${relativePath}`;
   }
 
   get appRootFolder() {
@@ -161,6 +173,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       }
     );
     oldDeviceSessionsManager.dispose();
+    this.updateProjectState({
+      appRootPath: this.relativeAppRootPath,
+    });
   }
 
   //#region Device Session Delegate

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -134,6 +134,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   get relativeAppRootPath() {
     const relativePath = workspace.asRelativePath(this.applicationContext.appRootFolder);
+    if (relativePath === this.applicationContext.appRootFolder) {
+      return "./";
+    }
     if (relativePath.startsWith(".." + path.sep) || relativePath.startsWith("." + path.sep)) {
       return relativePath;
     }

--- a/packages/vscode-extension/src/utilities/extensionContext.ts
+++ b/packages/vscode-extension/src/utilities/extensionContext.ts
@@ -137,20 +137,6 @@ export function findAppRootFolder() {
 
   const appRootCandidates = findAppRootCandidates();
 
-  if (appRootCandidates.length > 1) {
-    const openLaunchConfigButton = "Open Launch Configuration";
-    window
-      .showWarningMessage(
-        `Multiple react-native applications were detected in the workspace. "${appRootCandidates[0]}" was automatically chosen as your application root. To change that or remove this warning in the future, you can setup a permanent appRoot in Launch Configuration.`,
-        openLaunchConfigButton
-      )
-      .then((item) => {
-        if (item === openLaunchConfigButton) {
-          commands.executeCommand("workbench.action.debug.configure");
-        }
-      });
-  }
-
   if (appRootCandidates.length > 0) {
     return appRootCandidates[0];
   }

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -29,3 +29,29 @@
 .approot-select-trigger:focus {
   box-shadow: var(--swm-focus-outline);
 }
+
+.approot-select-value {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.approot-select-content {
+  overflow: hidden;
+  background-color: var(--swm-device-select-background);
+  width: var(--swm-device-select-width);
+  border-radius: 18px 18px 0 0;
+  padding-top: 4px;
+  max-height: var(--radix-select-content-available-height);
+  box-shadow: var(--swm-backdrop-shadow);
+}
+
+.approot-select-viewport {
+  padding: 6px;
+}
+
+.approot-select-scroll {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -1,0 +1,31 @@
+.approot-select-trigger {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  height: var(--swm-button-size);
+  border: 0px solid transparent;
+  border-radius: 18px 0 0 18px;
+  gap: 5px;
+  background-color: var(--swm-device-select-trigger);
+  color: var(--swm-device-select-trigger-text);
+  user-select: none;
+}
+.approot-select-trigger:hover {
+  background-color: var(--swm-device-select-trigger-hover);
+}
+.approot-select-trigger[data-state="open"] {
+  border-radius: 0 0 0 18px;
+}
+.approot-select-trigger[data-disabled] {
+  background-color: var(--swm-device-select-trigger-disabled);
+  color: var(--swm-secondary-text);
+  pointer-events: none;
+}
+.approot-select-trigger:focus {
+  box-shadow: var(--swm-focus-outline);
+}

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -1,10 +1,12 @@
 import React, { PropsWithChildren } from "react";
 import * as Select from "@radix-ui/react-select";
 import "./DeviceSelect.css";
+import "./AppRootSelect.css";
 import "./shared/Dropdown.css";
 import Tooltip from "./shared/Tooltip";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
 import { useProject } from "../providers/ProjectProvider";
+import { ApplicationRoot } from "../../common/LaunchConfig";
 
 interface RichSelectItemProps extends Select.SelectItemProps {
   icon: React.ReactNode;
@@ -55,8 +57,10 @@ const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSe
   }
 );
 
-function renderAppRoots() {
-  const { applicationRoots, appRoot } = useLaunchConfig();
+function renderAppRoots(
+  applicationRoots: ApplicationRoot[],
+  selectedAppRootPath: string | undefined
+) {
   if (applicationRoots.length === 0) {
     return null;
   }
@@ -70,7 +74,7 @@ function renderAppRoots() {
           icon={<span className="codicon codicon-folder" />}
           title={displayName || name}
           subtitle={path}
-          isSelected={path === appRoot}
+          isSelected={path === selectedAppRootPath}
         />
       ))}
     </Select.Group>
@@ -91,7 +95,7 @@ function AppRootSelect() {
 
   return (
     <Select.Root onValueChange={handleAppRootChange} value={selectedAppRootPath}>
-      <Select.Trigger className="device-select-trigger" disabled={applicationRoots.length === 0}>
+      <Select.Trigger className="approot-select-trigger" disabled={applicationRoots.length === 0}>
         <Select.Value placeholder="No applications found">
           <div className="device-select-value">
             <span className="codicon codicon-folder-opened" />
@@ -108,7 +112,9 @@ function AppRootSelect() {
           <Select.ScrollUpButton className="device-select-scroll">
             <span className="codicon codicon-chevron-up" />
           </Select.ScrollUpButton>
-          <Select.Viewport className="device-select-viewport">{renderAppRoots()}</Select.Viewport>
+          <Select.Viewport className="device-select-viewport">
+            {renderAppRoots(applicationRoots, selectedAppRootPath)}
+          </Select.Viewport>
           <Select.ScrollDownButton className="device-select-scroll">
             <span className="codicon codicon-chevron-down" />
           </Select.ScrollDownButton>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -32,12 +32,12 @@ const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSe
 
     return (
       <Select.Item className="device-select-rich-item" {...props} ref={forwardedRef}>
-        {/* <div
+        <div
           className={
             isSelected ? "device-select-rich-item-icon-selected" : "device-select-rich-item-icon"
           }>
           {icon}
-        </div> */}
+        </div>
         <div>
           {isSelected ? (
             <div className="device-select-rich-item-title">
@@ -62,12 +62,12 @@ function renderAppRoots() {
 
   return (
     <Select.Group>
-      {applicationRoots.map((path) => (
+      {applicationRoots.map(({ path, displayName, name }) => (
         <RichSelectItem
           value={path}
           key={path}
-          icon={<span className="codicon codicon-device-mobile" />}
-          title={path}
+          icon={<span className="codicon codicon-folder" />}
+          title={displayName || name}
           subtitle={path}
           isSelected={path === appRoot}
         />
@@ -78,6 +78,8 @@ function renderAppRoots() {
 
 function AppRootSelect() {
   const { applicationRoots, appRoot } = useLaunchConfig();
+  const selectedAppRootName =
+    applicationRoots.find((root) => root.path === appRoot)?.displayName || appRoot;
 
   const handleAppRootChange = async (value: string) => {};
 
@@ -86,8 +88,8 @@ function AppRootSelect() {
       <Select.Trigger className="device-select-trigger" disabled={applicationRoots.length === 0}>
         <Select.Value placeholder="No applications found">
           <div className="device-select-value">
-            <span className="codicon codicon-root-folder-opened" />
-            {appRoot}
+            <span className="codicon codicon-folder-opened" />
+            {selectedAppRootName}
           </div>
         </Select.Value>
       </Select.Trigger>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -4,6 +4,7 @@ import "./DeviceSelect.css";
 import "./shared/Dropdown.css";
 import Tooltip from "./shared/Tooltip";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
+import { useProject } from "../providers/ProjectProvider";
 
 interface RichSelectItemProps extends Select.SelectItemProps {
   icon: React.ReactNode;
@@ -77,16 +78,19 @@ function renderAppRoots() {
 }
 
 function AppRootSelect() {
-  const { applicationRoots, appRoot, update } = useLaunchConfig();
+  const { applicationRoots, update } = useLaunchConfig();
+  const { projectState } = useProject();
+  const selectedAppRootPath = projectState.appRootPath;
+  const selectedAppRoot = applicationRoots.find((root) => root.path === selectedAppRootPath);
   const selectedAppRootName =
-    applicationRoots.find((root) => root.path === appRoot)?.displayName || appRoot;
+    selectedAppRoot?.displayName ?? selectedAppRoot?.name ?? selectedAppRootPath;
 
   const handleAppRootChange = async (value: string) => {
     update("appRoot", value);
   };
 
   return (
-    <Select.Root onValueChange={handleAppRootChange} value={appRoot}>
+    <Select.Root onValueChange={handleAppRootChange} value={selectedAppRootPath}>
       <Select.Trigger className="device-select-trigger" disabled={applicationRoots.length === 0}>
         <Select.Value placeholder="No applications found">
           <div className="device-select-value">

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -1,61 +1,11 @@
-import React, { PropsWithChildren } from "react";
 import * as Select from "@radix-ui/react-select";
 import "./DeviceSelect.css";
 import "./AppRootSelect.css";
 import "./shared/Dropdown.css";
-import Tooltip from "./shared/Tooltip";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
 import { useProject } from "../providers/ProjectProvider";
 import { ApplicationRoot } from "../../common/LaunchConfig";
-
-interface RichSelectItemProps extends Select.SelectItemProps {
-  icon: React.ReactNode;
-  title: string;
-  subtitle?: string;
-  isSelected?: boolean;
-}
-
-const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSelectItemProps>>(
-  ({ children, icon, title, subtitle, isSelected, ...props }, forwardedRef) => {
-    function renderSubtitle() {
-      if (!subtitle) {
-        return null;
-      }
-
-      const subtitleComponent = <div className="device-select-rich-item-subtitle">{subtitle}</div>;
-      const isLongText = subtitle.length > 20;
-
-      if (isLongText) {
-        <Tooltip label={subtitle} side="right" instant>
-          {subtitleComponent}
-        </Tooltip>;
-      }
-      return subtitleComponent;
-    }
-
-    return (
-      <Select.Item className="device-select-rich-item" {...props} ref={forwardedRef}>
-        <div
-          className={
-            isSelected ? "device-select-rich-item-icon-selected" : "device-select-rich-item-icon"
-          }>
-          {icon}
-        </div>
-        <div>
-          {isSelected ? (
-            <div className="device-select-rich-item-title">
-              <b>{title}</b>
-            </div>
-          ) : (
-            <div className="device-select-rich-item-title">{title}</div>
-          )}
-
-          {renderSubtitle()}
-        </div>
-      </Select.Item>
-    );
-  }
-);
+import RichSelectItem from "./shared/RichSelectItem";
 
 function renderAppRoots(
   applicationRoots: ApplicationRoot[],

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -1,5 +1,4 @@
 import * as Select from "@radix-ui/react-select";
-import "./DeviceSelect.css";
 import "./AppRootSelect.css";
 import "./shared/Dropdown.css";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
@@ -47,7 +46,7 @@ function AppRootSelect() {
     <Select.Root onValueChange={handleAppRootChange} value={selectedAppRootPath}>
       <Select.Trigger className="approot-select-trigger" disabled={applicationRoots.length === 0}>
         <Select.Value placeholder="No applications found">
-          <div className="device-select-value">
+          <div className="approot-select-value">
             <span className="codicon codicon-folder-opened" />
             {selectedAppRootName}
           </div>
@@ -56,16 +55,16 @@ function AppRootSelect() {
 
       <Select.Portal>
         <Select.Content
-          className="device-select-content"
+          className="approot-select-content"
           position="popper"
           onCloseAutoFocus={(e) => e.preventDefault()}>
-          <Select.ScrollUpButton className="device-select-scroll">
+          <Select.ScrollUpButton className="approot-select-scroll">
             <span className="codicon codicon-chevron-up" />
           </Select.ScrollUpButton>
-          <Select.Viewport className="device-select-viewport">
+          <Select.Viewport className="approot-select-viewport">
             {renderAppRoots(applicationRoots, selectedAppRootPath)}
           </Select.Viewport>
-          <Select.ScrollDownButton className="device-select-scroll">
+          <Select.ScrollDownButton className="approot-select-scroll">
             <span className="codicon codicon-chevron-down" />
           </Select.ScrollDownButton>
         </Select.Content>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -77,11 +77,13 @@ function renderAppRoots() {
 }
 
 function AppRootSelect() {
-  const { applicationRoots, appRoot } = useLaunchConfig();
+  const { applicationRoots, appRoot, update } = useLaunchConfig();
   const selectedAppRootName =
     applicationRoots.find((root) => root.path === appRoot)?.displayName || appRoot;
 
-  const handleAppRootChange = async (value: string) => {};
+  const handleAppRootChange = async (value: string) => {
+    update("appRoot", value);
+  };
 
   return (
     <Select.Root onValueChange={handleAppRootChange} value={appRoot}>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -1,0 +1,113 @@
+import React, { PropsWithChildren } from "react";
+import * as Select from "@radix-ui/react-select";
+import "./DeviceSelect.css";
+import "./shared/Dropdown.css";
+import Tooltip from "./shared/Tooltip";
+import { useLaunchConfig } from "../providers/LaunchConfigProvider";
+
+interface RichSelectItemProps extends Select.SelectItemProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  isSelected?: boolean;
+}
+
+const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSelectItemProps>>(
+  ({ children, icon, title, subtitle, isSelected, ...props }, forwardedRef) => {
+    function renderSubtitle() {
+      if (!subtitle) {
+        return null;
+      }
+
+      const subtitleComponent = <div className="device-select-rich-item-subtitle">{subtitle}</div>;
+      const isLongText = subtitle.length > 20;
+
+      if (isLongText) {
+        <Tooltip label={subtitle} side="right" instant>
+          {subtitleComponent}
+        </Tooltip>;
+      }
+      return subtitleComponent;
+    }
+
+    return (
+      <Select.Item className="device-select-rich-item" {...props} ref={forwardedRef}>
+        {/* <div
+          className={
+            isSelected ? "device-select-rich-item-icon-selected" : "device-select-rich-item-icon"
+          }>
+          {icon}
+        </div> */}
+        <div>
+          {isSelected ? (
+            <div className="device-select-rich-item-title">
+              <b>{title}</b>
+            </div>
+          ) : (
+            <div className="device-select-rich-item-title">{title}</div>
+          )}
+
+          {renderSubtitle()}
+        </div>
+      </Select.Item>
+    );
+  }
+);
+
+function renderAppRoots() {
+  const { applicationRoots, appRoot } = useLaunchConfig();
+  if (applicationRoots.length === 0) {
+    return null;
+  }
+
+  return (
+    <Select.Group>
+      {applicationRoots.map((path) => (
+        <RichSelectItem
+          value={path}
+          key={path}
+          icon={<span className="codicon codicon-device-mobile" />}
+          title={path}
+          subtitle={path}
+          isSelected={path === appRoot}
+        />
+      ))}
+    </Select.Group>
+  );
+}
+
+function AppRootSelect() {
+  const { applicationRoots, appRoot } = useLaunchConfig();
+
+  const handleAppRootChange = async (value: string) => {};
+
+  return (
+    <Select.Root onValueChange={handleAppRootChange} value={appRoot}>
+      <Select.Trigger className="device-select-trigger" disabled={applicationRoots.length === 0}>
+        <Select.Value placeholder="No applications found">
+          <div className="device-select-value">
+            <span className="codicon codicon-root-folder-opened" />
+            {appRoot}
+          </div>
+        </Select.Value>
+      </Select.Trigger>
+
+      <Select.Portal>
+        <Select.Content
+          className="device-select-content"
+          position="popper"
+          onCloseAutoFocus={(e) => e.preventDefault()}>
+          <Select.ScrollUpButton className="device-select-scroll">
+            <span className="codicon codicon-chevron-up" />
+          </Select.ScrollUpButton>
+          <Select.Viewport className="device-select-viewport">{renderAppRoots()}</Select.Viewport>
+          <Select.ScrollDownButton className="device-select-scroll">
+            <span className="codicon codicon-chevron-down" />
+          </Select.ScrollDownButton>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+export default AppRootSelect;

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.css
@@ -1,7 +1,3 @@
-:root {
-  --swm-device-select-width: 240px;
-}
-
 .device-select-trigger {
   box-sizing: border-box;
   display: inline-flex;
@@ -13,18 +9,17 @@
   cursor: pointer;
   height: var(--swm-button-size);
   border: 0px solid transparent;
-  border-radius: 18px;
+  border-radius: 0 18px 18px 0;
   gap: 5px;
   background-color: var(--swm-device-select-trigger);
   color: var(--swm-device-select-trigger-text);
   user-select: none;
-  width: var(--swm-device-select-width);
 }
 .device-select-trigger:hover {
   background-color: var(--swm-device-select-trigger-hover);
 }
 .device-select-trigger[data-state="open"] {
-  border-radius: 0 0 18px 18px;
+  border-radius: 0 0 18px 0;
 }
 .device-select-trigger[data-disabled] {
   background-color: var(--swm-device-select-trigger-disabled);

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.css
@@ -77,55 +77,6 @@
   pointer-events: none;
 }
 
-.device-select-rich-item {
-  display: grid;
-  grid-template-columns: 32px 1fr;
-  align-items: center;
-  gap: 5px;
-  line-height: 1;
-  height: 48px;
-  border-radius: 4px;
-  padding: 0 5px;
-}
-.device-select-rich-item[data-highlighted] {
-  outline: none;
-  background-color: var(--swm-device-select-highlighted);
-  cursor: pointer;
-}
-.device-select-rich-item[data-disabled] {
-  color: var(--swm-device-select-disabled-text);
-  pointer-events: none;
-}
-.device-select-rich-item-title {
-  font-size: 14px;
-  color: var(--swm-device-select-rich-item-text);
-  margin-bottom: 4px;
-  padding-right: 10px;
-}
-.device-select-rich-item-subtitle {
-  font-size: 12px;
-  color: var(--swm-device-select-rich-item-subtitle);
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  width: 185px;
-}
-.device-select-rich-item-icon,
-.device-select-rich-item-icon-selected {
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 16px;
-  color: var(--swm-default-text);
-  background-color: var(--swm-device-icon-background);
-}
-.device-select-rich-item-icon-selected {
-  background-color: var(--swm-device-icon-background-selected);
-  color: var(--swm-device-icon-selected);
-}
-
 .device-select-label {
   padding: 0 10px;
   font-size: 12px;

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -3,11 +3,11 @@ import * as Select from "@radix-ui/react-select";
 import { DeviceInfo, DevicePlatform } from "../../common/DeviceManager";
 import "./DeviceSelect.css";
 import "./shared/Dropdown.css";
-import Tooltip from "./shared/Tooltip";
 import { useProject } from "../providers/ProjectProvider";
 import { useDevices } from "../providers/DevicesProvider";
 import { useModal } from "../providers/ModalProvider";
 import ManageDevicesView from "../views/ManageDevicesView";
+import RichSelectItem from "./shared/RichSelectItem";
 
 const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.SelectItemProps>>(
   ({ children, ...props }, forwardedRef) => (
@@ -15,55 +15,6 @@ const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.Sel
       <Select.ItemText>{children}</Select.ItemText>
     </Select.Item>
   )
-);
-
-interface RichSelectItemProps extends Select.SelectItemProps {
-  icon: React.ReactNode;
-  title: string;
-  subtitle?: string;
-  isSelected?: boolean;
-}
-
-const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSelectItemProps>>(
-  ({ children, icon, title, subtitle, isSelected, ...props }, forwardedRef) => {
-    function renderSubtitle() {
-      if (!subtitle) {
-        return null;
-      }
-
-      const subtitleComponent = <div className="device-select-rich-item-subtitle">{subtitle}</div>;
-      const isLongText = subtitle.length > 20;
-
-      if (isLongText) {
-        <Tooltip label={subtitle} side="right" instant>
-          {subtitleComponent}
-        </Tooltip>;
-      }
-      return subtitleComponent;
-    }
-
-    return (
-      <Select.Item className="device-select-rich-item" {...props} ref={forwardedRef}>
-        <div
-          className={
-            isSelected ? "device-select-rich-item-icon-selected" : "device-select-rich-item-icon"
-          }>
-          {icon}
-        </div>
-        <div>
-          {isSelected ? (
-            <div className="device-select-rich-item-title">
-              <b>{title}</b>
-            </div>
-          ) : (
-            <div className="device-select-rich-item-title">{title}</div>
-          )}
-
-          {renderSubtitle()}
-        </div>
-      </Select.Item>
-    );
-  }
 );
 
 function renderDevices(

--- a/packages/vscode-extension/src/webview/components/shared/RichSelectItem.css
+++ b/packages/vscode-extension/src/webview/components/shared/RichSelectItem.css
@@ -1,0 +1,48 @@
+.rich-item {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  align-items: center;
+  gap: 5px;
+  line-height: 1;
+  height: 48px;
+  border-radius: 4px;
+  padding: 0 5px;
+}
+.rich-item[data-highlighted] {
+  outline: none;
+  background-color: var(--swm-device-select-highlighted);
+  cursor: pointer;
+}
+.rich-item[data-disabled] {
+  color: var(--swm-device-select-disabled-text);
+  pointer-events: none;
+}
+.rich-item-title {
+  font-size: 14px;
+  color: var(--swm-device-select-rich-item-text);
+  margin-bottom: 4px;
+  padding-right: 10px;
+}
+.rich-item-subtitle {
+  font-size: 12px;
+  color: var(--swm-device-select-rich-item-subtitle);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 185px;
+}
+.rich-item-icon,
+.rich-item-icon-selected {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  color: var(--swm-default-text);
+  background-color: var(--swm-device-icon-background);
+}
+.rich-item-icon-selected {
+  background-color: var(--swm-device-icon-background-selected);
+  color: var(--swm-device-icon-selected);
+}

--- a/packages/vscode-extension/src/webview/components/shared/RichSelectItem.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/RichSelectItem.tsx
@@ -1,0 +1,52 @@
+import React, { PropsWithChildren } from "react";
+import * as Select from "@radix-ui/react-select";
+import "../DeviceSelect.css";
+import "./Dropdown.css";
+import "./RichSelectItem.css";
+import Tooltip from "./Tooltip";
+
+interface RichSelectItemProps extends Select.SelectItemProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  isSelected?: boolean;
+}
+
+const RichSelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<RichSelectItemProps>>(
+  ({ children, icon, title, subtitle, isSelected, ...props }, forwardedRef) => {
+    function renderSubtitle() {
+      if (!subtitle) {
+        return null;
+      }
+
+      const subtitleComponent = <div className="rich-item-subtitle">{subtitle}</div>;
+      const isLongText = subtitle.length > 20;
+
+      if (isLongText) {
+        <Tooltip label={subtitle} side="right" instant>
+          {subtitleComponent}
+        </Tooltip>;
+      }
+      return subtitleComponent;
+    }
+
+    return (
+      <Select.Item className="rich-item" {...props} ref={forwardedRef}>
+        <div className={isSelected ? "rich-item-icon-selected" : "rich-item-icon"}>{icon}</div>
+        <div>
+          {isSelected ? (
+            <div className="rich-item-title">
+              <b>{title}</b>
+            </div>
+          ) : (
+            <div className="rich-item-title">{title}</div>
+          )}
+
+          {renderSubtitle()}
+        </div>
+      </Select.Item>
+    );
+  }
+);
+
+export default RichSelectItem;

--- a/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/LaunchConfigProvider.tsx
@@ -10,6 +10,7 @@ import {
 import { makeProxy } from "../utilities/rpc";
 import {
   AddCustomApplicationRoot,
+  ApplicationRoot,
   EasConfig,
   LaunchConfig,
   LaunchConfigUpdater,
@@ -22,7 +23,7 @@ const launchConfig = makeProxy<LaunchConfig>("LaunchConfig");
 type LaunchConfigContextType = LaunchConfigurationOptions & {
   update: LaunchConfigUpdater;
   xcodeSchemes: string[];
-  applicationRoots: string[];
+  applicationRoots: ApplicationRoot[];
   addCustomApplicationRoot: AddCustomApplicationRoot;
   easBuildProfiles: EasBuildConfig;
   eas?: {
@@ -42,7 +43,7 @@ const LaunchConfigContext = createContext<LaunchConfigContextType>({
 export default function LaunchConfigProvider({ children }: PropsWithChildren) {
   const [config, setConfig] = useState<LaunchConfigurationOptions>({});
   const [xcodeSchemes, setXcodeSchemes] = useState<string[]>([]);
-  const [applicationRoots, setApplicationRoots] = useState<string[]>([]);
+  const [applicationRoots, setApplicationRoots] = useState<ApplicationRoot[]>([]);
   const [easBuildProfiles, setEasBuildProfiles] = useState<EasBuildConfig>({});
 
   useEffect(() => {

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -35,6 +35,7 @@ interface ProjectContextProps {
 }
 
 const defaultProjectState: ProjectState = {
+  appRootPath: "./",
   status: "starting",
   startupMessage: StartupMessage.InitializingDevice,
   stageProgress: 0,

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -5,6 +5,7 @@ import Label from "../components/shared/Label";
 import { useLaunchConfig } from "../providers/LaunchConfigProvider";
 import {
   AddCustomApplicationRoot,
+  ApplicationRoot,
   EasConfig,
   LaunchConfigUpdater,
   LaunchConfigurationOptions,
@@ -54,7 +55,7 @@ function LaunchConfigurationView() {
       <AppRootConfiguration
         appRoot={appRoot}
         update={update}
-        applicationRoots={applicationRoots.map((root) => root.path)}
+        applicationRoots={applicationRoots}
         addCustomApplicationRoot={addCustomApplicationRoot}
       />
       <div className="launch-configuration-section-margin" />
@@ -193,7 +194,7 @@ function AndroidConfiguration({ buildType, productFlavor, update }: androidConfi
 interface appRootConfigurationProps {
   appRoot?: string;
   update: LaunchConfigUpdater;
-  applicationRoots: string[];
+  applicationRoots: ApplicationRoot[];
   addCustomApplicationRoot: AddCustomApplicationRoot;
 }
 
@@ -293,7 +294,7 @@ function AppRootConfiguration({
   };
 
   const availableAppRoots = applicationRoots.map((applicationRoot) => {
-    return { value: applicationRoot, label: applicationRoot };
+    return { value: applicationRoot.path, label: applicationRoot.path };
   });
 
   availableAppRoots.push({ value: "Auto", label: "Auto" });

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -54,7 +54,7 @@ function LaunchConfigurationView() {
       <AppRootConfiguration
         appRoot={appRoot}
         update={update}
-        applicationRoots={applicationRoots}
+        applicationRoots={applicationRoots.map((root) => root.path)}
         addCustomApplicationRoot={addCustomApplicationRoot}
       />
       <div className="launch-configuration-section-margin" />

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -22,6 +22,7 @@ import ReplayIcon from "../components/icons/ReplayIcon";
 import RecordingIcon from "../components/icons/RecordingIcon";
 import { ActivateLicenseView } from "./ActivateLicenseView";
 import ToolsDropdown from "../components/ToolsDropdown";
+import AppRootSelect from "../components/AppRootSelect";
 
 function ActivateLicenseButton() {
   const { openModal } = useModal();
@@ -342,6 +343,7 @@ function PreviewView() {
         <span className="group-separator" />
 
         <DeviceSelect />
+        <AppRootSelect />
 
         <div className="spacer" />
         {Platform.OS === "macos" && !hasActiveLicense && <ActivateLicenseButton />}

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -342,8 +342,8 @@ function PreviewView() {
 
         <span className="group-separator" />
 
-        <DeviceSelect />
         <AppRootSelect />
+        <DeviceSelect />
 
         <div className="spacer" />
         {Platform.OS === "macos" && !hasActiveLicense && <ActivateLicenseButton />}


### PR DESCRIPTION
Adds a dropdown to the main Preview screen which allows the user to quickly switch between applications in a monorepo as well as see at a glance which app root is selected.

### Known issues:
- sometimes after switching the AppRoot, a "Couldn't start selected device" error appears. This doesn't prevent the app to build and run correctly (and after it does, Radon will stop showing the error and work normally), so it seems to be an issue with error handling in device startup.

### TODO:
- [x] ~cleanup css classes in webview code~ I gave up
- [x] improve how application's name is derived (support `app.config.js`, use `package.json` as a fallback)

![Screenshot 2025-05-20 at 14 26 06](https://github.com/user-attachments/assets/7898979d-54ca-4ebd-a7d1-a6cb06a531c2)
![Screenshot 2025-05-20 at 14 27 26](https://github.com/user-attachments/assets/254717f0-04dc-41c2-9c0a-591c80c60e3c)


### How this was tested:
- open a monorepo or a folder containing multiple RN apps
- the half-pill button next to the device picker should display the name of the current application
- press the button
- the dropdown should contain all the RN apps in the workspace
- selecting an entry should switch Radon to that app

