### PR TITLE
Make app and device seletor look prettier

### DIFF
--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -3,14 +3,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
+  padding: 5px 10px;
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
-  height: var(--swm-button-size);
-  border: 0px solid transparent;
-  border-radius: 18px 0 0 18px;
-  gap: 5px;
+  border-radius: 18px;
   background-color: var(--swm-device-select-trigger);
   color: var(--swm-device-select-trigger-text);
   user-select: none;
@@ -40,7 +37,7 @@
   overflow: hidden;
   background-color: var(--swm-device-select-background);
   width: var(--swm-device-select-width);
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px;
   padding-top: 4px;
   max-height: var(--radix-select-content-available-height);
   box-shadow: var(--swm-backdrop-shadow);

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -1,16 +1,20 @@
 .approot-select-trigger {
   box-sizing: border-box;
-  display: inline-flex;
+  display: flex;
+  flex-shrink: 2;
   align-items: center;
-  justify-content: center;
-  padding: 5px 10px;
+  padding: 0px 10px;
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
   border-radius: 18px;
   background-color: var(--swm-device-select-trigger);
+  height: var(--swm-button-size);
   color: var(--swm-device-select-trigger-text);
   user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .approot-select-trigger:hover {
   background-color: var(--swm-device-select-trigger-hover);

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -8,7 +8,6 @@
   line-height: 1;
   cursor: pointer;
   border-radius: 18px;
-  background-color: var(--swm-device-select-trigger);
   height: var(--swm-button-size);
   color: var(--swm-device-select-trigger-text);
   user-select: none;

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.css
@@ -3,15 +3,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 10px;
+  padding: 5px 10px;
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
-  height: var(--swm-button-size);
   border: 0px solid transparent;
-  border-radius: 0 18px 18px 0;
-  gap: 5px;
-  background-color: var(--swm-device-select-trigger);
+  border-radius: 18px;
   color: var(--swm-device-select-trigger-text);
   user-select: none;
 }
@@ -40,7 +37,7 @@
   overflow: hidden;
   background-color: var(--swm-device-select-background);
   width: var(--swm-device-select-width);
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px;
   padding-top: 4px;
   max-height: var(--radix-select-content-available-height);
   box-shadow: var(--swm-backdrop-shadow);

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.css
@@ -1,16 +1,20 @@
 .device-select-trigger {
   box-sizing: border-box;
-  display: inline-flex;
+  display: flex;
+  flex-shrink: 1;
   align-items: center;
-  justify-content: center;
-  padding: 5px 10px;
+  padding: 0px 10px;
   font-size: 13px;
   line-height: 1;
   cursor: pointer;
   border: 0px solid transparent;
   border-radius: 18px;
+  height: var(--swm-button-size);
   color: var(--swm-device-select-trigger-text);
   user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .device-select-trigger:hover {
   background-color: var(--swm-device-select-trigger-hover);

--- a/packages/vscode-extension/src/webview/components/shared/RichSelectItem.css
+++ b/packages/vscode-extension/src/webview/components/shared/RichSelectItem.css
@@ -18,13 +18,13 @@
   pointer-events: none;
 }
 .rich-item-title {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--swm-device-select-rich-item-text);
   margin-bottom: 4px;
   padding-right: 10px;
 }
 .rich-item-subtitle {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--swm-device-select-rich-item-subtitle);
   overflow: hidden;
   white-space: nowrap;

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -130,10 +130,10 @@
   display: flex;
   align-items: center;
   border-radius: 18px;
-  padding: 0 5px;
   height: var(--swm-button-size);
   background-color: var(--swm-device-select-trigger);
   user-select: none;
+  overflow: hidden;
 }
 
 @media (max-width: 385px) {

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -132,6 +132,7 @@
   border-radius: 18px;
   height: var(--swm-button-size);
   background-color: var(--swm-device-select-trigger);
+  color: var(--swm-device-select-trigger-text);
   user-select: none;
   overflow: hidden;
 }

--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -125,6 +125,17 @@
   animation: pulse 1.5s ease-in-out infinite;
 }
 
+.app-device-group {
+  border: 0px solid transparent;
+  display: flex;
+  align-items: center;
+  border-radius: 18px;
+  padding: 0 5px;
+  height: var(--swm-button-size);
+  background-color: var(--swm-device-select-trigger);
+  user-select: none;
+}
+
 @media (max-width: 385px) {
   .button-group-top,
   .button-group-bottom {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -342,8 +342,11 @@ function PreviewView() {
 
         <span className="group-separator" />
 
-        <AppRootSelect />
-        <DeviceSelect />
+        <div className="app-device-group">
+          <AppRootSelect />
+          <span className="codicon codicon-chevron-right" />
+          <DeviceSelect />
+        </div>
 
         <div className="spacer" />
         {Platform.OS === "macos" && !hasActiveLicense && <ActivateLicenseButton />}


### PR DESCRIPTION
This PR updates the style of app and device switcher to look a bit better in my opinion.

Before the buttons would only be rounded on one side with a gap in between. This looked a bit weird as you don't typically expect buttons to only be rounded on one side and not the other. This might've resembled the zoom switcher but that one doesn't have gaps.

Also, the highlighted version blends too much with the background, and the "opened" menu has a flat bottom without rounded corners which also look a bit off.

What we're changing here:
1) Both buttons are now in a single container with background and rounded corners
2) In between the buttons we placed a chevron icon
3) We're changing the highlight effect to be fully enclosed within the group background
4) The menu now is rounded from all the sides + we reduce the font size such that it matches the size in the trigger
5) Handle shrinking when the panel is narrow

Before:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/7a71a4dc-fa77-46e8-a7c1-508c1b7e2634" />

Before highlighted:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/1e4259ab-8ec6-4129-97c7-dfb2a4834024" />

Before opened:
<img width="369" alt="image" src="https://github.com/user-attachments/assets/af311e14-9525-4b9a-ba85-f74965d08c5c" />


After:
<img width="327" alt="image" src="https://github.com/user-attachments/assets/459f9925-60f6-4b6f-93cf-a0ef793bb93a" />

After highlighted:
<img width="290" alt="image" src="https://github.com/user-attachments/assets/579b7fe0-dd32-4058-9ecb-31d78d9167b4" />

After opened: 
<img width="395" alt="image" src="https://github.com/user-attachments/assets/58be9427-9573-478f-8055-f0a3867a1a19" />

After on narrow panel:
<img width="332" alt="image" src="https://github.com/user-attachments/assets/bf0c5f80-517d-4ba8-8bc7-8412190289d5" />


### How Has This Been Tested: 
1. Open IDE and play with the select buttons to check if everything is in order


