### PR TITLE
Fix build stage state updates

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -223,7 +223,16 @@ export class DeviceSession
   //#region Build manager delegate methods
 
   onCacheStale = (platform: DevicePlatform) => {
-    if (platform === this.device.platform && this.status === "running") {
+    if (
+      platform === this.device.platform &&
+      (this.status === "running" ||
+        this.status === "refreshing" ||
+        this.status === "debuggerPaused")
+    ) {
+      // we only consider "stale cache" in a non-error state that happens
+      // after the launch phase if complete. Otherwsie, it may be a result of
+      // the build process that triggers the callback in which case we don't want
+      // to warn users about it.
       this.hasStaleBuildCache = true;
       this.emitStateChange();
     }


### PR DESCRIPTION
This PR fixes stage progress updates after #1154 

1) We're resetting stageProgress to undefined as it is only expected to be set for stages that can actually report progress (build and bundle)
2) We're resetting stale build cache flag when restarting the device
3) We're only updating stale build cache flag when in running state to prevent accidental reports when build is ongoing and modifies files inside the build folder.

### How Has This Been Tested: 
1. Run app
2. Use "clean build" option
3. See the progress is only reported in build and bundle phases and there's no "0%" progress reported elsewhere
4. Make sure that the stale build dialog doesn't pop up when in build process
5. Add some dummy line to podfile and see the stale build dialog appear
6. Use restart button from the dialog
7. It should be gone immediately and not show up after the device reboots. Further updates to Podfile should make the alert re-appear