### PR TITLE
Use skip files for logs in radon connect

### DIFF
--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -301,8 +301,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       stackTrace?.callFrames.splice(0, originalCallFrameIndex);
     }
 
-    if (stackTrace?.callFrames) {
-      stackTrace.callFrames = stackTrace?.callFrames.filter((frame) => {
+    if (stackTrace) {
+      const filteredCallFrames = stackTrace?.callFrames.filter((frame) => {
         const { scriptId, lineNumber, columnNumber } = frame;
         const { sourceURL } = this.sourceMapRegistry.findOriginalPosition(
           scriptId,
@@ -311,6 +311,11 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         );
         return !this.shouldSkipFile(sourceURL);
       });
+      if (filteredCallFrames.length > 0) {
+        // we only filter frames if there's at least one frame left, otherwise we would still
+        // want some location information to be available so we keep the original one.
+        stackTrace.callFrames = filteredCallFrames;
+      }
     }
 
     this.consoleAPICalledEmitter.fire({});


### PR DESCRIPTION
This PR updates the Proxy Debug Adapter such that it considers the skipFiles setting when filtering the stack frame for console logs.

This fixes an issue when using Radon Connect which doesn't override the built-in console log method in a way that'd provide accurate stack frames. For the main IDE panel experience, we append the extra frame data to the log calls and the extract them in the code that handles console logging. Then we use that to strip out the frame from the framework code that supports logging.

With Radon connect we don't have that, and all logs just appear with lines from withing the framework code which isn't super helpful. To fix this, we use skip files to filter the log call frame. This code is universal enough that we should use it in all the configuration hence no Radon Connect checks are necessary.

### How Has This Been Tested: 
1. Run app with Radon Connect
2. Print some logs
3. See that the logs no longer point to console.js file in framework internals


