### PR TITLE
Fix back button behavior after the state refactor

### DIFF
--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -33,6 +33,12 @@ function useRouterPluginMainHook({ onNavigationChange }) {
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {
+    if (pathname === "__BACK__") {
+      if (router.canGoBack()) {
+        router.back();
+      }
+      return;
+    }
     router.navigate(pathname);
     router.setParams(params);
   }

--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -30,6 +30,12 @@ function useRouterPluginMainHook({ onNavigationChange }) {
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {
+    if (pathname === "__BACK__") {
+      if (router.canGoBack()) {
+        router.back();
+      }
+      return;
+    }
     router.push(pathname);
     router.setParams(params);
   }

--- a/packages/vscode-extension/lib/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v5_plugin.js
@@ -29,6 +29,12 @@ function useRouterPluginMainHook({ onNavigationChange }) {
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {
+    if (pathname === "__BACK__") {
+      if (router.canGoBack()) {
+        router.back();
+      }
+      return;
+    }
     router.navigate(pathname);
     router.setParams(params);
   }

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -117,8 +117,8 @@ function UrlSelect({ onValueChange, navigationHistory, disabled, dropdownOnly }:
   };
 
   useEffect(() => {
-    setInputValue(navigationHistory[0]?.displayName ?? "");
-  }, [navigationHistory[0]?.id]);
+    setInputValue(navigationHistory[0]?.displayName ?? "/");
+  }, [navigationHistory]);
 
   useEffect(() => {
     if (disabled) {


### PR DESCRIPTION
This PR changes the UrlBar back button logic to use the built-in `.back()` method of Expo Router instead of relying on our custom navigation history. This way we avoid manipulating the `navigationHistory` array kept in `deviceSession`, which caused history entries to disappear from the UrlSelect.

Because the `.back()` method operates on the navigation stack of the Router, the back button will now resemble the behavior of the native Android "back" action ("pop the current screen off the stack"), as opposed to the previous browser-like "open the previous route" behavior. This allows the user to check the app's reaction to the actual "go back" instruction, instead of just simulating it with `.navigate()`.

There are still some small bugs related to the navigation, but they are not related to the back button, therefore they will be fixed in #1160 to avoid conflicts.

### How Has This Been Tested: 
- open a multi-screen Expo Router project (without ER the button is disabled)
- test different navigator types (Stack, Tabs, etc.), compare the behavior of the button with the native back button
- open the UrlSelect, ensure the routes dismissed with the button are still present in the correct order
- refresh the app - the historic routes should still be saved

https://github.com/user-attachments/assets/5993c0e5-47e7-480c-95ed-bffff4680266


