### PR TITLE
Fix debugger overlay not showing when the debugger pauses

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -45,7 +45,6 @@ export type DeviceSessionStatus =
   | "running"
   | "bootError"
   | "bundlingError"
-  | "debuggerPaused"
   | "refreshing"
   | "buildError";
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -223,9 +223,7 @@ export class DeviceSession
   onCacheStale = (platform: DevicePlatform) => {
     if (
       platform === this.device.platform &&
-      (this.status === "running" ||
-        this.status === "refreshing" ||
-        this.status === "debuggerPaused")
+      (this.status === "running" || this.status === "refreshing")
     ) {
       // we only consider "stale cache" in a non-error state that happens
       // after the launch phase if complete. Otherwsie, it may be a result of

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -93,7 +93,7 @@ function Preview({
   const hasBootError = projectStatus === "bootError";
   const hasBundlingError = projectStatus === "bundlingError";
 
-  const debugPaused = projectStatus === "debuggerPaused";
+  const debugPaused = projectState.isDebuggerPaused;
 
   const previewURL = projectState.previewURL;
 


### PR DESCRIPTION
Fixes a small oversight in #1154  causing the debugger overlay to never appear.

### How Has This Been Tested: 
- open an app
- set a breakpoint
- trigger the breakpoint
- verify the "Paused in debugger" overlay with debugger controls appears



