### PR TITLE
Shorten activate license button text on narrow screens

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -137,6 +137,17 @@
   overflow: hidden;
 }
 
+.activate-license-button::before {
+  content: "Activate License";
+  text-wrap: nowrap;
+}
+
+@media (max-width: 400px) {
+  .activate-license-button::before {
+    content: "Activate";
+  }
+}
+
 @media (max-width: 385px) {
   .button-group-top,
   .button-group-bottom {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -40,7 +40,7 @@ function ActivateLicenseButton() {
         sendTelemetry("activateLicenseButtonClicked");
         openModal("Activate License", <ActivateLicenseView />);
       }}>
-      Activate License
+      {""} {/* using empty string here as the content is controlled via css */}
     </Button>
   );
 }


### PR DESCRIPTION
This PR uses media query to control text on "Activate License" button. On narrow panels where there's not enough space we will show just "Activate" text instead.

https://github.com/user-attachments/assets/034250d3-0bce-4ba2-8dbf-0c7d1647cc37

### How Has This Been Tested: 
1. Run any app, change size of the panel to see the button text update at certain threshold


