### PR TITLE
Fix and restore ensureDependenciesAndNodeVersion functionality 

### DIFF
--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -3,6 +3,7 @@ import { DeviceSessionState } from "./Project";
 
 export type DeviceSessionsManagerDelegate = {
   onActiveSessionStateChanged(state: DeviceSessionState): void;
+  ensureDependenciesAndNodeVersion(): Promise<void>;
 };
 
 export type SelectDeviceOptions = {

--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -3,7 +3,6 @@ import { DeviceSessionState } from "./Project";
 
 export type DeviceSessionsManagerDelegate = {
   onActiveSessionStateChanged(state: DeviceSessionState): void;
-  ensureDependenciesAndNodeVersion(): Promise<void>;
 };
 
 export type SelectDeviceOptions = {

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -84,8 +84,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
           this.deviceSessionManagerDelegate.onActiveSessionStateChanged(state);
         }
       },
-      ensureDependenciesAndNodeVersion:
-        this.deviceSessionManagerDelegate.ensureDependenciesAndNodeVersion,
     });
 
     this.deviceSessions.set(deviceInfo.id, newDeviceSession);

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -84,7 +84,8 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
           this.deviceSessionManagerDelegate.onActiveSessionStateChanged(state);
         }
       },
-      ensureDependenciesAndNodeVersion: async () => {},
+      ensureDependenciesAndNodeVersion:
+        this.deviceSessionManagerDelegate.ensureDependenciesAndNodeVersion,
     });
 
     this.deviceSessions.set(deviceInfo.id, newDeviceSession);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -674,8 +674,7 @@ export class DeviceSession
     Logger.debug("Metro & devtools ready");
   }
 
-  // used in callbacks, needs to be an arrow function
-  private ensureDependenciesAndNodeVersion = async () => {
+  private async ensureDependenciesAndNodeVersion() {
     if (this.applicationContext.dependencyManager === undefined) {
       Logger.error(
         "[PROJECT] Dependency manager not initialized. this code should be unreachable."
@@ -701,7 +700,7 @@ export class DeviceSession
         "Node.js was not found, or the version in the PATH does not satisfy minimum version requirements."
       );
     }
-  };
+  }
 
   public async start() {
     try {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -580,34 +580,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.updateProjectState({ previewZoom: zoom });
     extensionContext.workspaceState.update(PREVIEW_ZOOM_KEY, zoom);
   }
-
-  // used in callbacks, needs to be an arrow function
-  public ensureDependenciesAndNodeVersion = async () => {
-    if (this.dependencyManager === undefined) {
-      Logger.error(
-        "[PROJECT] Dependency manager not initialized. this code should be unreachable."
-      );
-      throw new Error("[PROJECT] Dependency manager not initialized");
-    }
-
-    const installed = await this.dependencyManager.checkNodeModulesInstallationStatus();
-
-    if (!installed) {
-      Logger.info("Installing node modules");
-      await this.dependencyManager.installNodeModules();
-      Logger.debug("Installing node modules succeeded");
-    } else {
-      Logger.debug("Node modules already installed - skipping");
-    }
-
-    const supportedNodeInstalled =
-      await this.dependencyManager.checkSupportedNodeVersionInstalled();
-    if (!supportedNodeInstalled) {
-      throw new Error(
-        "Node.js was not found, or the version in the PATH does not satisfy minimum version requirements."
-      );
-    }
-  };
 }
 
 export function isAppSourceFile(filePath: string) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -581,7 +581,8 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     extensionContext.workspaceState.update(PREVIEW_ZOOM_KEY, zoom);
   }
 
-  public async ensureDependenciesAndNodeVersion() {
+  // used in callbacks, needs to be an arrow function
+  public ensureDependenciesAndNodeVersion = async () => {
     if (this.dependencyManager === undefined) {
       Logger.error(
         "[PROJECT] Dependency manager not initialized. this code should be unreachable."
@@ -606,7 +607,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
         "Node.js was not found, or the version in the PATH does not satisfy minimum version requirements."
       );
     }
-  }
+  };
 }
 
 export function isAppSourceFile(filePath: string) {

--- a/packages/vscode-extension/src/utilities/packageManager.ts
+++ b/packages/vscode-extension/src/utilities/packageManager.ts
@@ -176,17 +176,15 @@ async function isPnpmModulesInstalled(workspacePath: string): Promise<boolean> {
     if (packages && packages.length === 0) {
       return false;
     }
-
-    // check whether each package has dependencies with a valid versions to prevent issues
+    // check whether each package has dependencies
     for (const pkg of packages) {
-      if (!pkg || !pkg.dependencies || Object.keys(pkg.dependencies).length === 0) {
+      if (
+        !pkg ||
+        (!pkg.dependencies && !pkg.unsavedDependencies) ||
+        (Object.keys(pkg.dependencies ?? {}).length === 0 &&
+          Object.keys(pkg.unsavedDependencies ?? {}).length === 0)
+      ) {
         return false;
-      }
-
-      for (const depInfo of Object.values<{ version: string }>(pkg.dependencies)) {
-        if (!depInfo || !depInfo.version) {
-          return false;
-        }
       }
     }
 


### PR DESCRIPTION
After #1154 `ensureDependenciesAndNodeVersion` was not passed into device session, this PR changes that and restores the functionality it provided. 

Additionally investigation into #1163 revealed a problem withhoisted pnpm monorepos namely dependencies installed directly in `node_modules` and not in `node_modules/.pnpm` are reported as `unsavedDependencies` by `pnpm ls` command, which caused us to reinstall pnpm every time, potentially causing problems with the set up. 

The changes made to the `isPnpmModulesInstalled` function change the assumption that `node_modules` are installed only if `dependencies` are detected and also allow `unsavedDependencies`  which prevents unnecessary  installs in hoisted setups. 

### How Has This Been Tested: 

- run `expo-52` template application in pnpm monorepo, with `node-linker=hoisted` setting in `.npmrc` 



