### PR TITLE
Fix replay overlay styles

### DIFF
--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.css
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.css
@@ -4,7 +4,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: var(--swm-replay-overlay-backgroud);
+  background: var(--swm-replay-overlay-background);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -295,7 +295,7 @@ body[data-vscode-theme-kind="vscode-high-contrast-light"] {
   --swm-zoom-select-separator: var(--navy-light-40);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
+  --swm-replay-overlay-background: linear-gradient(
     0deg,
     rgba(232, 232, 232, 0.9),
     rgba(185, 185, 185, 0.9)
@@ -471,7 +471,7 @@ body[data-vscode-theme-kind="vscode-high-contrast"] {
   --swm-zoom-select-separator: var(--background-dark-50);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
+  --swm-replay-overlay-background: linear-gradient(
     0deg,
     rgba(0, 0, 0, 1),
     rgba(0, 0, 0, 0.5),
@@ -659,10 +659,10 @@ body[data-use-code-theme="true"] {
   --swm-zoom-select-separator: var(--vscode-dropdown-border);
 
   /* Replay */
-  --swm-replay-overlay-backgroud: linear-gradient(
+  --swm-replay-overlay-background: linear-gradient(
     0deg,
-    rgba(232, 232, 232, 0.9),
-    rgba(185, 185, 185, 0.9)
+    var(--vscode-editor-foldBackground),
+    var(--vscode-widget-shadow)
   );
 
   --swm-replay-len-select: var(--swm-default-text);

--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -575,7 +575,7 @@ body[data-use-code-theme="true"] {
 
   --swm-button-recording-on: var(--vscode-activityBarBadge-foreground);
   --swm-button-recording-on-background: var(--vscode-activityBarBadge-background);
-  --swm-button-replay-hover: var(--navy-light-transparent);
+  --swm-button-replay-hover: var(--swm-button-hover);
 
   /* Tooltip */
   --swm-tooltip-primary: var(--swm-default-text);
@@ -665,10 +665,10 @@ body[data-use-code-theme="true"] {
     var(--vscode-widget-shadow)
   );
 
-  --swm-replay-len-select: var(--swm-default-text);
-  --swm-replay-len-select-background: var(--grey-light-60);
-  --swm-replay-len-select-hover-background: var(--navy-light-transparent);
-  --swm-replay-len-select-highlighted-background: var(--grey-light-80);
+  --swm-replay-len-select: var(--swm-button);
+  --swm-replay-len-select-background: var(--swm-button-background);
+  --swm-replay-len-select-hover-background: var(--swm-button-hover);
+  --swm-replay-len-select-highlighted-background: var(--swm-button-selected-hover-background);
 
   /* Open Deep Link */
   --deep-link-history-border: var(--navy-light-10);


### PR DESCRIPTION
The background overlay for Replay feature was hardcoded and didn't adjust to the currently selected vscode theme.

This PR makes the background color aligned to the current vscode theme. Also, fixed the length selector background color. 

## Before
https://github.com/user-attachments/assets/d799b5d6-85d3-44ad-9c23-ecaa979a0c58

## After
https://github.com/user-attachments/assets/24b6b4cc-cf0a-46e9-a899-068cb1b2450c

