### PR TITLE
Fix Radon not starting when no devices are found

### DIFF
--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -3,6 +3,7 @@ import { DeviceSessionState } from "./Project";
 
 export type DeviceSessionsManagerDelegate = {
   onActiveSessionStateChanged(state: DeviceSessionState): void;
+  onInitialized(): void;
 };
 
 export type SelectDeviceOptions = {

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -88,6 +88,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
 
     this.deviceSessions.set(deviceInfo.id, newDeviceSession);
     this.updateSelectedSession(newDeviceSession);
+    this.deviceSessionManagerDelegate.onInitialized();
 
     if (killPreviousDeviceSession) {
       await this.terminatePreviousSessions();
@@ -121,6 +122,8 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
       }
     } finally {
       this.findingDevice = false;
+      // even if no device can be selected mark project as initialized
+      this.deviceSessionManagerDelegate.onInitialized();
     }
   };
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -171,6 +171,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.updateProjectState(state);
   };
 
+  onInitialized(): void {
+    this.updateProjectState({ initialized: true });
+  }
+
   private recordingTimeout: NodeJS.Timeout | undefined = undefined;
 
   startRecording(): void {
@@ -571,7 +575,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   private updateProjectState(newState: Partial<ProjectState>) {
-    const mergedState = { ...this.projectState, ...newState, initialized: true };
+    const mergedState = { ...this.projectState, ...newState };
     this.projectState = mergedState;
     this.eventEmitter.emit("projectStateChanged", this.projectState);
   }


### PR DESCRIPTION
This PR fixes an issue with radon not loading when no devices are available. 

The problem was caused by `initialized` in `projectState` not being updated as after #1154 `initialized` is only updated when `updateProjectState` and it does not happen if no devices are found. 

To solve this problem we introduce a new `deviceSessionsManagerDelegate` method and update `initialized` even when no device can be selected 

### How Has This Been Tested: 

- Run radon with no devices


