### PR TITLE
Fix settings changes causing reloads unnecessarily on android

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -105,7 +105,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     // if user did not use the device before it might not have system_locales property
     // as en-US is the default locale, used by the system, when no setting is provided
     // we assume that no value in stdout is the same as en-US
-    if ((stdout ?? "en-US") === locale) {
+    if ((stdout ?? "en-US") === locale || stdout === "null") {
       return false;
     }
     return true;

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -104,7 +104,8 @@ export class AndroidEmulatorDevice extends DeviceBase {
 
     // if user did not use the device before it might not have system_locales property
     // as en-US is the default locale, used by the system, when no setting is provided
-    // we assume that no value in stdout is the same as en-US
+    // we assume that no value in stdout is the same as en-US on some devices
+    // stdout is a string "null" instead of undefined so we need to handle it separately
     if ((stdout ?? "en-US") === locale || stdout === "null") {
       return false;
     }


### PR DESCRIPTION
This PR fixes an issue with android emulator reloading every time, because of `adb shell settings get system system_locales` returning "null" as string. 

We didn't notice this before because it seems it happens only on some android versions.

### How Has This Been Tested: 

run `react-native-77` and change settings on android 



