### PR TITLE
Fix bundle error popup after fast refresh

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -265,6 +265,9 @@ export class DeviceSession
       this.emitStateChange();
     });
     devtools.onEvent("RNIDE_fastRefreshComplete", () => {
+      if (this.status !== "refreshing") {
+        return;
+      }
       this.status = "running";
       this.emitStateChange();
     });


### PR DESCRIPTION
This PR fixes an issue with bundle error popup either flashing or completely not showing when bundle error is caused be "fast refresh". The problem was happening because even if fast refresh is unsuccessful it is reported and coupled which means that `RNIDE_fastRefreshComplete` event does not mean that the app is running. 

To avoid this issue we update device status, only if the current status is "refreshing" which means that the refresh process has been uninterrupted.

### How Has This Been Tested: 

- run `react-native-77` test app and cause bundle error with fast refresh



