### PR TITLE
Fix network panel scroll on start and blinking column borders

### DIFF
--- a/packages/vscode-extension/src/network/App.tsx
+++ b/packages/vscode-extension/src/network/App.tsx
@@ -23,6 +23,9 @@ function App() {
       }
     }, 30);
 
+    handleResize();
+    handleResize.flush();
+
     window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);

--- a/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
+++ b/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
@@ -135,7 +135,13 @@ const NetworkRequestLog = ({
     <div className="table-container" ref={containerRef}>
       <div style={{ width: "100%", overflowX: "hidden" }}>
         {/* DIRTY HACK: table rerenders on window resize, including scroll position which sucks */}
-        <VscodeTable zebra resizable responsive style={{ height: parentHeight }} key={parentHeight}>
+        <VscodeTable
+          zebra
+          bordered-columns
+          resizable
+          responsive
+          style={{ height: parentHeight }}
+          key={parentHeight}>
           <VscodeTableHeader slot="header">
             {logDetailsConfig.map(({ title }) => (
               <VscodeTableHeaderCell key={title}>{title}</VscodeTableHeaderCell>


### PR DESCRIPTION
This PR fixes two visual issues in the network panel:
1) When network panel is just opened, the content isn't scrollable until you resize the panel pane
2) When hovering over the requests lists, we'd get the column bar appearing and disappearing

The first issue is fixed by triggering the resize change on component mount.

The second issue is fixed by adding `bordered-columns` prop to `VscodeTable` component. Apparently, this option is require for `resizable` tables, as otherwise the columns only appear when you try to "resize" them which is when you hover. It look better when the columns are shown at all times in that case.

### How Has This Been Tested: 
1. Open network panel
2. Make it show a bunch of requests, make sure you can scroll the payload window w/o previously resizing the editor window or the panel pane
3. Make sure the column borders are shown at all time on the requests list.


