### PR TITLE
Fix previous paths staying in the bar after refresh on non-ER projects

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -35,7 +35,7 @@ function UrlSelect({
 
   const dropdownItemsRef = React.useRef<Array<HTMLDivElement>>([]);
   const textfieldRef = React.useRef<HTMLInputElement>(null);
-  const { project } = useProject();
+  const { project, projectState } = useProject();
 
   const routeItems = React.useMemo(
     () =>
@@ -142,6 +142,13 @@ function UrlSelect({
     );
     return [...navigationHistory, ...routesNotInHistory];
   }, [navigationHistory, routeItems]);
+
+  // Reset the input on app reload
+  useEffect(() => {
+    if (projectState.status === "starting") {
+      setInputValue("/");
+    }
+  }, [projectState.status]);
 
   // Refresh the input value when the navigation history changes
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the issue of the last path staying in the UrlSelect after `navigateHome()` was called or reload was performed on a non-Expo Router app. The input field is reset every time the app is restarting, ensuring the previous path won't stay after reset.

### How Has This Been Tested: 
- open a non-ER app like react-native-78
- open a preview or navigate to a non-index route
- reload the app or go home - the path is now refreshing correctly


