### PR TITLE
Fix CPU profiler not showing the profile after finishing

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -1,18 +1,7 @@
 import { EventEmitter } from "stream";
 import os from "os";
 import path from "path";
-import fs from "fs";
-import {
-  env,
-  Disposable,
-  commands,
-  workspace,
-  window,
-  DebugSessionCustomEvent,
-  Uri,
-  extensions,
-  ConfigurationChangeEvent,
-} from "vscode";
+import { env, Disposable, commands, workspace, window, ConfigurationChangeEvent } from "vscode";
 import _ from "lodash";
 import { minimatch } from "minimatch";
 import {
@@ -230,61 +219,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       commands.executeCommand("vscode.open", uri);
     }
   }
-
-  onProfilingCPUStarted(event: DebugSessionCustomEvent): void {
-    this.eventEmitter.emit("isProfilingCPU", true);
-  }
-
-  async onProfilingCPUStopped(event: DebugSessionCustomEvent) {
-    this.eventEmitter.emit("isProfilingCPU", false);
-
-    // Handle the profile file if a file path is provided
-    if (event.body && event.body.filePath) {
-      const tempFilePath = event.body.filePath;
-
-      // Show save dialog to save the profile file to the workspace folder:
-      let defaultUri = Uri.file(tempFilePath);
-      const workspaceFolder = workspace.workspaceFolders?.[0];
-      if (workspaceFolder) {
-        defaultUri = Uri.file(path.join(workspaceFolder.uri.fsPath, path.basename(tempFilePath)));
-      }
-
-      const saveDialog = await window.showSaveDialog({
-        defaultUri,
-        filters: {
-          "CPU Profile": ["cpuprofile"],
-        },
-      });
-
-      if (saveDialog) {
-        await fs.promises.copyFile(tempFilePath, saveDialog.fsPath);
-        commands.executeCommand("vscode.open", Uri.file(saveDialog.fsPath));
-
-        // verify whether flame chart visualizer extension is installed
-        // flame chart visualizer is not necessary to open the cpuprofile file, but when it is installed,
-        // the user can use the flame button from cpuprofile view to visualize it differently
-        const flameChartExtension = extensions.getExtension("ms-vscode.vscode-js-profile-flame");
-        if (!flameChartExtension) {
-          const GO_TO_EXTENSION_BUTTON = "Go to Extension";
-          window
-            .showInformationMessage(
-              "Flame Chart Visualizer extension is not installed. It is recommended to install it for better profiling insights.",
-              GO_TO_EXTENSION_BUTTON
-            )
-            .then((action) => {
-              if (action === GO_TO_EXTENSION_BUTTON) {
-                commands.executeCommand(
-                  "workbench.extensions.search",
-                  "ms-vscode.vscode-js-profile-flame"
-                );
-              }
-            });
-        }
-      }
-    }
-  }
-
-  onDebugSessionTerminated() {}
 
   async captureAndStopRecording() {
     const recording = await this.stopRecording();


### PR DESCRIPTION
Fixes an issue where the CPU Profiler would not display the file saving dialog or display the profile file after profiling was finished.

### How Has This Been Tested: 
- open an app in Radon
- start the CPU Profiler
- stop the CPU Profiler
- the file saving dialog should pop up
- after saving the profile file, it should be opened by vscode