### PR TITLE
Fix tool detection for older react-query versions

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -122,7 +122,10 @@ function transformWrapper({ filename, src, ...rest }) {
     if (version.startsWith("0.78") || version.startsWith("0.79")) {
       src = `module.exports = require("__RNIDE_lib__/JSXRuntime/react-native-78-79/${jsxRuntimeFileName}");`;
     }
-  } else if (isTransforming("node_modules/@tanstack/react-query/src/index.ts")) {
+  } else if (
+    isTransforming("node_modules/@tanstack/react-query/src/index.ts") ||
+    isTransforming("node_modules/@tanstack/react-query/build/lib/index.js")
+  ) {
     src = `require("__RNIDE_lib__/plugins/react-query-devtools.js");${src}`;
   } else if (isTransforming("/lib/rn-internals/rn-internals.js")) {
     const { version } = requireFromAppDir("react-native/package.json");


### PR DESCRIPTION
With `react-query` version 4, the library is imported through the compiled file `build/lib/index.js`, which was not recognized by Radon. This PR fixes that.

### How was this tested
- open an app using `@tanstack/react-query@4`
- verify the "react-query" tool shows up in the tools menu

