### PR TITLE
Add label to approot select dropdown

### DIFF
--- a/packages/vscode-extension/src/webview/components/AppRootSelect.css
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.css
@@ -56,6 +56,14 @@
   padding: 6px;
 }
 
+.approot-select-label {
+  padding: 0 10px;
+  font-size: 12px;
+  line-height: 25px;
+  color: var(--swm-device-select-label);
+  user-select: none;
+}
+
 .approot-select-scroll {
   display: flex;
   justify-content: center;

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -16,6 +16,7 @@ function renderAppRoots(
 
   return (
     <Select.Group>
+      <Select.Label className="approot-select-label">Select project</Select.Label>
       {applicationRoots.map(({ path, displayName, name }) => (
         <RichSelectItem
           value={path}

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -16,7 +16,7 @@ function renderAppRoots(
 
   return (
     <Select.Group>
-      <Select.Label className="approot-select-label">Select project</Select.Label>
+      <Select.Label className="approot-select-label">Select application</Select.Label>
       {applicationRoots.map(({ path, displayName, name }) => (
         <RichSelectItem
           value={path}


### PR DESCRIPTION
Adds a label to select dropdown to match the look from device select dropdown. Also, the dropdown w/o any label look very "mysterious" for projects where only one option is available.

### How Has This Been Tested: 
1. Open project select dropdown

**Before**
<img width="341" alt="image" src="https://github.com/user-attachments/assets/9354d735-47fa-4997-b6fa-98510eb51974" />

**After**
<img width="389" alt="image" src="https://github.com/user-attachments/assets/4eafb7e6-7405-4f8d-a548-f3eaa14a9f74" />



