### PR TITLE
Send and handle init event for react query plugin

### DIFF
--- a/packages/vscode-extension/lib/plugins/react-query-devtools.js
+++ b/packages/vscode-extension/lib/plugins/react-query-devtools.js
@@ -3,6 +3,7 @@ import { register } from "../expo_dev_plugins";
 import { AppExtensionProxy } from "./AppExtensionProxy";
 
 function broadcastQueryClient(queryClient) {
+  register("react-query");
   const proxy = new AppExtensionProxy("react-query");
 
   let transaction = false;
@@ -72,9 +73,22 @@ function broadcastQueryClient(queryClient) {
       }
     });
   });
-}
 
-register("react-query");
+  proxy.addMessageListener("init", () => {
+    tx(() => {
+      queryClient
+        .getQueryCache()
+        .getAll()
+        .forEach((query) => {
+          proxy.sendMessage("updated", {
+            queryHash: query.queryHash,
+            queryKey: query.queryKey,
+            state: query.state,
+          });
+        });
+    });
+  });
+}
 
 const origMount = QueryClient.prototype.mount;
 

--- a/packages/vscode-extension/src/plugins/react-query-devtools-plugin/ReactQueryDevToolsPluginWebviewProvider.ts
+++ b/packages/vscode-extension/src/plugins/react-query-devtools-plugin/ReactQueryDevToolsPluginWebviewProvider.ts
@@ -85,8 +85,6 @@ export class ReactQueryDevToolsPluginWebviewProvider implements WebviewViewProvi
       localResourceRoots: [Uri.joinPath(this.context.extensionUri, PATH)],
     };
 
-    webview.html = generateWebviewContent(extensionContext, webview, extensionContext.extensionUri);
-
     const devTools = IDE.getInstanceIfExists()?.project?.deviceSession?.devtools;
 
     const listener = devTools?.onEvent("RNIDE_pluginMessage", (payload) => {
@@ -106,6 +104,13 @@ export class ReactQueryDevToolsPluginWebviewProvider implements WebviewViewProvi
 
     webviewView.onDidDispose(() => {
       listener?.dispose();
+    });
+
+    webview.html = generateWebviewContent(extensionContext, webview, extensionContext.extensionUri);
+
+    devTools?.send("RNIDE_pluginMessage", {
+      scope: REACT_QUERY_PLUGIN_ID,
+      type: "init",
     });
   }
 }


### PR DESCRIPTION
React Query plugin only sends and receives communication when the webview panel is opened. Sometimes when working with the app, we only open the query plugin at some later point in time. This lands us in a situation where we start with an empty panel despite the fact the queries have run in our app for a while.

The plugin currently works by having a proxy client that sends all the updates to another client that works within the webview panel. However, we only send updates made after the webview client is initialized. In this PR we're adding a new "init" event that lets the runtime know when the webview is ready, such that runtime can feed previous queries making the plugin start in a pre-initialized state.

### How Has This Been Tested: 
1. Run app with react query plugin
2. Enable react query plugin
3. Reload app but don't open react query panel
4. Click in the app to trigger some queries
5. Open the react query panel now and see the queries made in the meantime. Before this change the panel would be empty and only start receiving the data from that point.


