### PR TITLE
bump package version to 1.7.1

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-ide",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-ide",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "hasInstallScript": true,
       "license": "https://ide.swmansion.com/legal",
       "devDependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -22,7 +22,7 @@
     "workspaceContains:**/app.config.ts",
     "onWebviewPanel:RadonIDETabPanel"
   ],
-  "version": "1.7.0",
+  "version": "1.7.1",
   "engines": {
     "vscode": "^1.75.0"
   },


### PR DESCRIPTION
This PR bumps the version to 1.7.1, a patch release which updates the simulator server version which was omitted from 1.7.0 by mistake.



