### PR TITLE
fallback to app name "app" on Android

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -66,7 +66,7 @@ export async function getAndroidBuildPaths(
   return { apkPath, packageName };
 }
 
-function makeBuildTaskName(productFlavor: string, buildType: string, appName?: string) {
+function makeBuildTaskName(productFlavor: string, buildType: string, appName: string) {
   // task name is in the format of :<appName>:assemble<ProductFlavor><BuildType> where productFlavor and buildType
   // are the names of the productFlavor and buildType that each start with a capital letter.
   // By default, Android Gradle Plugin always creates staging and release buildTypes and does not define any productFlavor.
@@ -75,8 +75,7 @@ function makeBuildTaskName(productFlavor: string, buildType: string, appName?: s
   const flavorUppercase =
     productFlavor && productFlavor.charAt(0).toUpperCase() + productFlavor.slice(1);
   const buildTypeUppercase = buildType && buildType.charAt(0).toUpperCase() + buildType.slice(1);
-  const prefix = appName ? `:${appName}:` : "";
-  return `${prefix}assemble${flavorUppercase}${buildTypeUppercase}`;
+  return `:${appName}:assemble${flavorUppercase}${buildTypeUppercase}`;
 }
 
 export async function buildAndroid(
@@ -176,10 +175,11 @@ async function buildLocal(
 ): Promise<AndroidBuildResult> {
   let { appRoot, forceCleanBuild, env, productFlavor = "", buildType = "debug" } = buildConfig;
   const androidSourceDir = getAndroidSourceDir(appRoot);
-  const androidAppName = loadConfig({
+  const androidConfig = loadConfig({
     projectRoot: appRoot,
     selectedPlatform: "android",
-  }).platforms.android?.projectConfig(appRoot)?.appName;
+  });
+  const androidAppName = androidConfig.platforms.android?.projectConfig(appRoot)?.appName ?? "app";
 
   const gradleArgs = [
     "-x",


### PR DESCRIPTION
When building android, the task invoked by Android Studio and Expo cli to build the apk is `{appName}:assemble{Variant}`. Currently, if Radon cannot read an app name from the application's config, it falls back to executing `assemble{Variant}` which at least on one project tested failed due to `.aar` dependencies (when using `react-native-executorch`).
This PR changes the behaviour to fall back to `appName = "app"` when none is specified in the config, which is the default app name in React Native projects and the app name assumed by expo cli (https://github.com/expo/expo-cli/blob/54997b9b1aa66329f91e33e913f98155bcbb2464/packages/expo-cli/src/commands/run/android/runAndroid.ts#L107)

### How Has This Been Tested: 
I cannot reproduce the problem in a fresh app, but this fixed it for me on the internal appjs app.