### PR TITLE
fix sim-server download script fetching from wrong repo

### DIFF
--- a/packages/vscode-extension/scripts/build-sim-server-debug.sh
+++ b/packages/vscode-extension/scripts/build-sim-server-debug.sh
@@ -12,8 +12,7 @@ submodule_status=$(git submodule status ../simulator-server)
 if [[ $submodule_status == -* ]]; then # submodule is not initialized
 
 # get version of npm module
-latest_tag=$(git describe --tags --abbrev=0)
-download_base_url="https://github.com/software-mansion/radon-ide/releases/download/${latest_tag}/"
+download_base_url="https://github.com/software-mansion-labs/simulator-server-releases/releases/latest/download/"
 
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     product_path="$output_dir/simulator-server-windows.exe"


### PR DESCRIPTION
Changes the setup script which downloads the simulator server binary to fetch the newest build from the `simulator-server-releases` repository

Fixes #1178

### How Has This Been Tested: 
- deinit the `simulator-server` submodule
- remove the sim server from the `dist` folder
- run `npm run build:sim-server-debug` and verify the binary is downloaded correctly


