### PR TITLE
Fix launch config changes reloading the application

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -139,6 +139,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   private setupAppRoot() {
     const newAppRoot = findAndSetupNewAppRootFolder();
+    if (newAppRoot === this.appRootFolder) {
+      return;
+    }
 
     const oldApplicationContext = this.applicationContext;
     this.applicationContext = new ApplicationContext(newAppRoot);


### PR DESCRIPTION
Currently, any changes to the `launch.json` file cause the application to be reloaded when no custom `appRoot` is set in the config.
This is caused by the launch config change listener to always setup a new app root which causes the `DeviceSessionManager` to be disposed, even if the app root didn't actually change.
This PR changes that behavior to instead check if the actual app root changed and only reset in that case.

### How Has This Been Tested: 
- open a project without an `appRoot` specified in `launch.json`
- change the contents of `launch.json`
- the application should not restart


