### PR TITLE
Fix dynamic route params duplicating as query params in route displayNames

### DIFF
--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -6,6 +6,22 @@ export function computeRouteIdentifier(pathname, params) {
   return query ? `${pathname}?${query}` : pathname;
 }
 
+// Helper function to prevent duplicating dynamic segments of the route
+// in the params object, as they are already part of the route path.
+export function getParamsWithoutDynamicSegments(routeInfo) {
+  const params = routeInfo?.params || {};
+  const dynamicSegments = routeInfo?.segments.filter((segment) => segment.startsWith("[") && segment.endsWith("]")) || [];
+
+  Object.keys(params).forEach((key) => {
+    if (dynamicSegments.map((segment) => segment.slice(1, -1)).includes(key)) {
+      delete params[key];
+    }
+  });
+
+  return params;
+}
+
+
 // Helper function to extract the route list from Expo Router's routeNode, which is a tree-like object
 // returned by the router store and the getRoutes() function, containing all indexed routes.
 // For future reference: https://github.com/expo/expo/blob/main/packages/expo-router/src/getRoutes.ts

--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -11,13 +11,15 @@ export function computeRouteIdentifier(pathname, params) {
 export function getParamsWithoutDynamicSegments(routeInfo) {
   const params = routeInfo?.params || {};
   const dynamicSegments = routeInfo?.segments.filter((segment) => segment.startsWith("[") && segment.endsWith("]")) || [];
-
+  const dynamicSegmentKeys = dynamicSegments.map((segment) => segment.slice(1, -1));
+  
   Object.keys(params).forEach((key) => {
-    if (dynamicSegments.map((segment) => segment.slice(1, -1)).includes(key)) {
+    if (dynamicSegmentKeys.includes(key)) {
       delete params[key];
     }
   });
-
+  delete params.__EXPO_ROUTER_key;
+  
   return params;
 }
 

--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -15,8 +15,6 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const params = routeInfo?.params;
 
   const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
-  delete filteredParams.__EXPO_ROUTER_key;
-
   const displayParams = new URLSearchParams(filteredParams).toString();
   const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
 

--- a/packages/vscode-extension/lib/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_plugin.js
@@ -1,7 +1,7 @@
 import { useSyncExternalStore, useEffect } from "react";
 import { useRouter } from "expo-router";
 import { store } from "expo-router/build/global-state/router-store.js";
-import { computeRouteIdentifier, extractNestedRouteList } from "./expo_router_helpers.js";
+import { computeRouteIdentifier, extractNestedRouteList, getParamsWithoutDynamicSegments } from "./expo_router_helpers.js";
 
 function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const router = useRouter();
@@ -14,7 +14,7 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const pathname = routeInfo?.pathname;
   const params = routeInfo?.params;
 
-  const filteredParams = params ?? {};
+  const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
   delete filteredParams.__EXPO_ROUTER_key;
 
   const displayParams = new URLSearchParams(filteredParams).toString();

--- a/packages/vscode-extension/lib/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v2_plugin.js
@@ -1,7 +1,7 @@
 import { useSyncExternalStore, useEffect } from "react";
 import { useRouter } from "expo-router";
 import { store } from "expo-router/src/global-state/router-store";
-import { computeRouteIdentifier, extractNestedRouteList } from "./expo_router_helpers.js";
+import { computeRouteIdentifier, extractNestedRouteList, getParamsWithoutDynamicSegments } from "./expo_router_helpers.js";
 
 function computeRouteIdentifier(pathname, params) {
   return pathname + JSON.stringify(params);
@@ -18,7 +18,9 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const pathname = routeInfo?.pathname;
   const params = routeInfo?.params;
   
-  const displayParams = new URLSearchParams(params).toString();
+  const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
+
+  const displayParams = new URLSearchParams(filteredParams).toString();
   const displayName = `${pathname}${displayParams ? `?${displayParams}` : ''}`;
 
   useEffect(() => {

--- a/packages/vscode-extension/lib/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v5_plugin.js
@@ -11,8 +11,6 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const params = routeInfo?.params;
   
   const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
-  delete filteredParams.__EXPO_ROUTER_key;
-
   const displayParams = new URLSearchParams(filteredParams).toString();
   const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
 

--- a/packages/vscode-extension/lib/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router_v5_plugin.js
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useRouter } from "expo-router";
 import { store, useRouteInfo } from "expo-router/build/global-state/router-store.js";
-import { computeRouteIdentifier, extractNestedRouteList } from "./expo_router_helpers.js";
+import { computeRouteIdentifier, extractNestedRouteList, getParamsWithoutDynamicSegments } from "./expo_router_helpers.js";
 
 function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   const router = useRouter();
@@ -9,8 +9,8 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
 
   const pathname = routeInfo?.pathname;
   const params = routeInfo?.params;
-
-  const filteredParams = params ?? {};
+  
+  const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
   delete filteredParams.__EXPO_ROUTER_key;
 
   const displayParams = new URLSearchParams(filteredParams).toString();


### PR DESCRIPTION
This PR enhances the readability of displayed dynamic paths by removing all params already present in the route URL from the query (from after the `?` sign). This way, the values won't be passed twice, significantly shortening the path string.

Before:
![Zrzut ekranu 2025-06-2 o 16 17 53](https://github.com/user-attachments/assets/2eae42a5-a9a6-45c0-ad02-7e60d941304f)
After:
![Zrzut ekranu 2025-06-2 o 16 18 12](https://github.com/user-attachments/assets/1aa43852-7b22-4932-a4b1-72a071ecdf52)

### How Has This Been Tested: 
1. Open an Expo Router project
2. Navigate to a dynamic route - params should now only be present inside the actual path
3. Navigate to a "not-found" route or a static route that accepts query params - normal params are still displayed in the route name


