### PR TITLE
Use a login shell to evaluate the PATH variable

### DIFF
--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -25,7 +25,12 @@ async function getPathEnv(appRoot: string) {
   // which would otherwise fill missing variables with those from the currently running process.
   const { stdout } = await execa(
     shellPath,
-    ["-i", "-c", `cd "${appRoot}" && echo "${RNIDE_PATH_DELIMITER}$PATH${RNIDE_PATH_DELIMITER}"`],
+    [
+      "-i",
+      "-l",
+      "-c",
+      `cd "${appRoot}" && echo "${RNIDE_PATH_DELIMITER}$PATH${RNIDE_PATH_DELIMITER}"`,
+    ],
     {
       extendEnv: false,
       env: {},


### PR DESCRIPTION
This PR makes the shell process used for determining the `PATH` variable a "login" shell. This allows us to read the configuration from `.profile`/`.zprofile` and similar.

### How Has This Been Tested: 
- set up some important PATH variable (`node` via `nvm` or `ruby` via `rbenv`) in `.zprofile` (if using `zsh`)
- start Radon
- verify the correct version is used


