### PR TITLE
Refactor "refreshing" from project status to boolean flag

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -53,7 +53,6 @@ export type DeviceSessionStatus =
   | "running"
   | "bootError"
   | "bundlingError"
-  | "refreshing"
   | "buildError";
 
 export type DeviceSessionState = {
@@ -61,6 +60,7 @@ export type DeviceSessionState = {
   startupMessage: StartupMessage | undefined;
   stageProgress: number | undefined;
   buildError: BuildErrorDescriptor | undefined;
+  isRefreshing: boolean;
   selectedDevice: DeviceInfo | undefined;
   previewURL: string | undefined;
   profilingReactState: ProfilingState;
@@ -79,6 +79,7 @@ export const DEVICE_SESSION_INITIAL_STATE: DeviceSessionState = {
   startupMessage: undefined,
   stageProgress: undefined,
   buildError: undefined,
+  isRefreshing: false,
   selectedDevice: undefined,
   previewURL: undefined,
   profilingReactState: "stopped",

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -159,6 +159,7 @@ export class DeviceSession
     this.startupMessage = startupMessage;
     this.stageProgress = undefined;
     this.buildError = undefined;
+    this.isRefreshing = false;
     this.hasStaleBuildCache = false;
     this.profilingCPUState = "stopped";
     this.profilingReactState = "stopped";

--- a/packages/vscode-extension/src/webview/components/DelayedFastRefreshIndicator.tsx
+++ b/packages/vscode-extension/src/webview/components/DelayedFastRefreshIndicator.tsx
@@ -1,22 +1,17 @@
 import { useState, useEffect, useRef } from "react";
 import classNames from "classnames";
 import "./DelayedFastRefreshIndicator.css";
-import { ProjectState } from "../../common/Project";
 
-export default function DelayedFastRefreshIndicator({
-  projectStatus,
-}: {
-  projectStatus: ProjectState["status"];
-}) {
+export default function DelayedFastRefreshIndicator({ isRefreshing }: { isRefreshing: boolean }) {
   const [showRefreshing, setShowRefreshing] = useState(false);
   const [showRefreshed, setShowRefreshed] = useState(false);
-  const lastProjectStatusRef = useRef<ProjectState["status"]>(projectStatus);
+  const lastIsRefreshing = useRef<boolean>(false);
 
   useEffect(() => {
-    const lastProjectStatus = lastProjectStatusRef.current;
-    lastProjectStatusRef.current = projectStatus;
+    const wasRefreshing = lastIsRefreshing.current;
+    lastIsRefreshing.current = isRefreshing;
 
-    if (projectStatus === "refreshing") {
+    if (isRefreshing) {
       const timer = setTimeout(() => {
         setShowRefreshing(true);
       }, 500);
@@ -25,7 +20,7 @@ export default function DelayedFastRefreshIndicator({
       setShowRefreshing(false);
     }
 
-    if (lastProjectStatus === "refreshing" && projectStatus === "running") {
+    if (wasRefreshing && !isRefreshing) {
       setShowRefreshed(true);
       const timer = setTimeout(() => {
         setShowRefreshed(false);
@@ -35,7 +30,7 @@ export default function DelayedFastRefreshIndicator({
         setShowRefreshed(false);
       };
     }
-  }, [projectStatus]);
+  }, [isRefreshing]);
 
   const showIndicator = showRefreshing || showRefreshed;
   return (

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -94,6 +94,7 @@ function Preview({
   const hasBundlingError = projectStatus === "bundlingError";
 
   const debugPaused = projectState.isDebuggerPaused;
+  const isRefreshing = projectState.isRefreshing;
 
   const previewURL = projectState.previewURL;
 
@@ -203,7 +204,7 @@ function Preview({
   }
 
   const shouldPreventInputEvents =
-    debugPaused || projectStatus === "refreshing" || !showDevicePreview || !!replayData;
+    debugPaused || isRefreshing || !showDevicePreview || !!replayData;
 
   const shouldPreventFromSendingTouch = isInspecting || !!inspectFrame;
 
@@ -536,7 +537,7 @@ function Preview({
                   )}
                 </div>
               )}
-              {projectStatus === "refreshing" && (
+              {isRefreshing && (
                 <div className="phone-screen phone-refreshing-overlay">
                   <div>Project is performing Fast Refresh...</div>
                   <div>(screen is inactive until refresh is complete)</div>
@@ -565,7 +566,7 @@ function Preview({
         )}
       </div>
 
-      <DelayedFastRefreshIndicator projectStatus={projectStatus} />
+      {showDevicePreview && <DelayedFastRefreshIndicator isRefreshing={isRefreshing} />}
 
       <div className="button-group-left-wrapper">
         <div className="button-group-left">


### PR DESCRIPTION
Refactors the "refreshing" project state from a separate project status to a boolean flag in device session state and hides the refreshing indicator when the preview is not displayed.

### How Has This Been Tested: 
- open an app
- start a fast refresh
- verify the fast refresh indicator is shown and hidden as expected
- verify the fast refresh indicator doesn't appear when installing pods/dependencies or installing the app while the app is still loading


