### PR TITLE
Fix devtools bridge setup on iOS

### DIFF
--- a/packages/vscode-extension/lib/react_devtools_agent.js
+++ b/packages/vscode-extension/lib/react_devtools_agent.js
@@ -31,7 +31,7 @@ const setDevtoolsAgent = (newDevtoolsAgent) => {
 
 const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 if (hook.reactDevtoolsAgent) {
-  setDevtoolsAgent(hook.devtoolsAgent);
+  setDevtoolsAgent(hook.reactDevtoolsAgent);
 } else {
   hook.on("react-devtools", setDevtoolsAgent);
 }


### PR DESCRIPTION
The refactor in #1180 included a typo which prevented the bridge from initializing correctly on iOS.
This PR fixes that.