### PR TITLE
Prevent sending early and duplicate navigation events

### DIFF
--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -6,6 +6,18 @@ export function computeRouteIdentifier(pathname, params) {
   return query ? `${pathname}?${query}` : pathname;
 }
 
+export function compareNavigationDescriptors(a, b) {
+  if (a.pathname !== b.pathname) {
+    return false;
+  }
+  for (const key in a.params) {
+    if (a.params[key] !== b.params[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Helper function to extract the route list from Expo Router's routeNode, which is a tree-like object
 // returned by the router store and the getRoutes() function, containing all indexed routes.
 // For future reference: https://github.com/expo/expo/blob/main/packages/expo-router/src/getRoutes.ts


### PR DESCRIPTION
This PR fixes the issues exposed after the switch to a custom bridge in #1180, that is:
- empty or `undefined` `navigationChanged` events being sent before the app started and appearing in path suggestions
- paths from outside the main application (e.g. previews) being reset to the last in-app path in the URL bar after a split second from opening, caused by sending duplicated `navigationChanged`

The `useEffect` responsible for sending the events was already activating in those situations before the bridge change, but the events were usually blocked by the `devtoolsAgent` being `null`, whereas the new `inspectorBridge` is available all the time, so we need to actively prevent sending the problematic updates.

### How Has This Been Tested: 
1. Open an Expo Router app
2. Open the UrlSelect - there should be no `undefined` or `""` on the list
3. Play with the navigation, confirm all paths are displayed correctly
4. Open a preview - the `preview:...` path should stay in the bar properly
5. Open a "404" route - the path should reflect the app's current location and update on `.goBack()`

