### PR TITLE
Refactor device session management in project state

### DIFF
--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -1,10 +1,4 @@
 import { DeviceInfo } from "./DeviceManager";
-import { DeviceSessionState } from "./Project";
-
-export type DeviceSessionsManagerDelegate = {
-  onActiveSessionStateChanged(state: DeviceSessionState): void;
-  onInitialized(): void;
-};
 
 export type SelectDeviceOptions = {
   preservePreviousDevice?: boolean;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -76,13 +76,16 @@ export type DeviceSessionState = {
 
 export type DeviceId = DeviceInfo["id"];
 
+export interface DeviceSessionsManagerState {
+  selectedSessionId: DeviceId | null;
+  deviceSessions: Record<DeviceId, DeviceSessionState>;
+}
+
 export type ProjectState = {
   initialized: boolean;
   appRootPath: string | undefined;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
-  selectedSessionId: DeviceId | null;
-  deviceSessions: Record<DeviceId, DeviceSessionState>;
-};
+} & DeviceSessionsManagerState;
 
 export type ZoomLevelType = number | "Fit";
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -93,11 +93,14 @@ export const DEVICE_SESSION_INITIAL_STATE: DeviceSessionState = {
   isRecordingScreen: false,
 };
 
+export type DeviceId = DeviceInfo["id"];
+
 export type ProjectState = {
   initialized: boolean;
   appRootPath: string | undefined;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
   activeDeviceSession: DeviceSessionState;
+  deviceSessions: Record<DeviceId, DeviceSessionState>;
 };
 
 export type ZoomLevelType = number | "Fit";

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -99,7 +99,7 @@ export type ProjectState = {
   initialized: boolean;
   appRootPath: string | undefined;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
-  activeDeviceSession: DeviceSessionState;
+  selectedSessionId: DeviceId | null;
   deviceSessions: Record<DeviceId, DeviceSessionState>;
 };
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -61,7 +61,7 @@ export type DeviceSessionState = {
   stageProgress: number | undefined;
   buildError: BuildErrorDescriptor | undefined;
   isRefreshing: boolean;
-  selectedDevice: DeviceInfo | undefined;
+  deviceInfo: DeviceInfo | undefined;
   previewURL: string | undefined;
   profilingReactState: ProfilingState;
   profilingCPUState: ProfilingState;
@@ -80,7 +80,7 @@ export const DEVICE_SESSION_INITIAL_STATE: DeviceSessionState = {
   stageProgress: undefined,
   buildError: undefined,
   isRefreshing: false,
-  selectedDevice: undefined,
+  deviceInfo: undefined,
   previewURL: undefined,
   profilingReactState: "stopped",
   profilingCPUState: "stopped",
@@ -97,7 +97,8 @@ export type ProjectState = {
   initialized: boolean;
   appRootPath: string | undefined;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
-} & DeviceSessionState;
+  activeDeviceSession: DeviceSessionState;
+};
 
 export type ZoomLevelType = number | "Fit";
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -61,7 +61,7 @@ export type DeviceSessionState = {
   stageProgress: number | undefined;
   buildError: BuildErrorDescriptor | undefined;
   isRefreshing: boolean;
-  deviceInfo: DeviceInfo | undefined;
+  deviceInfo: DeviceInfo;
   previewURL: string | undefined;
   profilingReactState: ProfilingState;
   profilingCPUState: ProfilingState;
@@ -72,25 +72,6 @@ export type DeviceSessionState = {
   logCounter: number;
   hasStaleBuildCache: boolean;
   isRecordingScreen: boolean;
-};
-
-export const DEVICE_SESSION_INITIAL_STATE: DeviceSessionState = {
-  status: "starting",
-  startupMessage: undefined,
-  stageProgress: undefined,
-  buildError: undefined,
-  isRefreshing: false,
-  deviceInfo: undefined,
-  previewURL: undefined,
-  profilingReactState: "stopped",
-  profilingCPUState: "stopped",
-  navigationHistory: [],
-  navigationRouteList: [],
-  toolsState: {},
-  isDebuggerPaused: false,
-  logCounter: 0,
-  hasStaleBuildCache: false,
-  isRecordingScreen: false,
 };
 
 export type DeviceId = DeviceInfo["id"];

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -313,7 +313,8 @@ export class DeviceSession
       this.isActive = true;
       this.toolsManager.activate();
       if (this.startupMessage === StartupMessage.AttachingDebugger) {
-        await this.reconnectJSDebuggerIfNeeded();
+        this.debugSession = new DebugSession(this, { useParentDebugSession: true });
+        await this.connectJSDebugger();
       }
     }
   }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -144,7 +144,7 @@ export class DeviceSession
       profilingReactState: this.profilingReactState,
       navigationHistory: this.navigationHistory,
       navigationRouteList: this.navigationRouteList,
-      selectedDevice: this.device.deviceInfo,
+      deviceInfo: this.device.deviceInfo,
       previewURL: this.previewURL,
       toolsState: this.toolsManager.getToolsState(),
       isDebuggerPaused: this.isDebuggerPaused,

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -8,7 +8,7 @@ import { minimatch } from "minimatch";
 import {
   AppPermissionType,
   DeviceButtonType,
-  DeviceId,
+  DeviceSessionsManagerState,
   DeviceSessionState,
   DeviceSettings,
   InspectData,
@@ -111,31 +111,8 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     );
   }
 
-  onDeviceSessionSelected(sessionId: DeviceId | undefined): void {
-    this.updateProjectState({ selectedSessionId: sessionId });
-  }
-
-  onDeviceSessionChange(state: DeviceSessionState): void {
-    const deviceId = state.deviceInfo.id;
-    assert(deviceId in this.projectState.deviceSessions, "A session must already exist");
-    const newDeviceSessions = { ...this.projectState.deviceSessions, [deviceId]: state };
-    this.updateProjectState({ deviceSessions: newDeviceSessions });
-  }
-
-  onDeviceSessionStarted(state: DeviceSessionState): void {
-    const deviceId = state.deviceInfo.id;
-    const newDeviceSessions = {
-      ...this.projectState.deviceSessions,
-      [deviceId]: state,
-    };
-    this.updateProjectState({ deviceSessions: newDeviceSessions });
-  }
-
-  onDeviceSessionStopped(state: DeviceSessionState): void {
-    const deviceId = state.deviceInfo.id;
-    const newDeviceSessions = { ...this.projectState.deviceSessions };
-    delete newDeviceSessions[deviceId];
-    this.updateProjectState({ deviceSessions: newDeviceSessions });
+  onDeviceSessionsManagerStateChange(state: DeviceSessionsManagerState): void {
+    this.updateProjectState(state);
   }
 
   get relativeAppRootPath() {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -533,6 +533,20 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   public async renameDevice(deviceInfo: DeviceInfo, newDisplayName: string) {
     await this.deviceManager.renameDevice(deviceInfo, newDisplayName);
     deviceInfo.displayName = newDisplayName;
+    // NOTE: this should probably be handled via some listener on Device instead:
+    const deviceId = deviceInfo.id;
+    if (!(deviceId in this.projectState.deviceSessions)) {
+      return;
+    }
+    const newDeviceState = {
+      ...this.projectState.deviceSessions[deviceId],
+      deviceInfo,
+    };
+    const newDeviceSessions = {
+      ...this.projectState.deviceSessions,
+      [deviceId]: newDeviceState,
+    };
+    this.updateProjectState({ deviceSessions: newDeviceSessions });
   }
 
   public async runCommand(command: string): Promise<void> {

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -49,10 +49,10 @@ function DeviceSelect() {
   const { projectState } = useProject();
   const { devices, deviceSessionsManager } = useDevices();
   const { openModal } = useModal();
-  const selectedProjectDevice = projectState?.selectedDevice;
+  const selectedProjectDevice = projectState?.activeDeviceSession.deviceInfo;
 
   const hasNoDevices = devices.length === 0;
-  const selectedDevice = projectState.selectedDevice;
+  const selectedDevice = projectState.activeDeviceSession.deviceInfo;
 
   const iosDevices = devices.filter(
     ({ platform, modelId }) => platform === DevicePlatform.IOS && modelId.length > 0

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -46,13 +46,13 @@ function renderDevices(
 }
 
 function DeviceSelect() {
-  const { activeDeviceSession } = useProject();
+  const { selectedDeviceSession } = useProject();
   const { devices, deviceSessionsManager } = useDevices();
   const { openModal } = useModal();
-  const selectedProjectDevice = activeDeviceSession?.deviceInfo;
+  const selectedProjectDevice = selectedDeviceSession?.deviceInfo;
 
   const hasNoDevices = devices.length === 0;
-  const selectedDevice = activeDeviceSession?.deviceInfo;
+  const selectedDevice = selectedDeviceSession?.deviceInfo;
 
   const iosDevices = devices.filter(
     ({ platform, modelId }) => platform === DevicePlatform.IOS && modelId.length > 0

--- a/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSelect.tsx
@@ -46,13 +46,13 @@ function renderDevices(
 }
 
 function DeviceSelect() {
-  const { projectState } = useProject();
+  const { activeDeviceSession } = useProject();
   const { devices, deviceSessionsManager } = useDevices();
   const { openModal } = useModal();
-  const selectedProjectDevice = projectState?.activeDeviceSession.deviceInfo;
+  const selectedProjectDevice = activeDeviceSession?.deviceInfo;
 
   const hasNoDevices = devices.length === 0;
-  const selectedDevice = projectState.activeDeviceSession.deviceInfo;
+  const selectedDevice = activeDeviceSession?.deviceInfo;
 
   const iosDevices = devices.filter(
     ({ platform, modelId }) => platform === DevicePlatform.IOS && modelId.length > 0

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -56,7 +56,9 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
   const { openModal } = useModal();
 
   const resetOptions =
-    projectState.selectedDevice?.platform === "iOS" ? resetOptionsIOS : resetOptionsAndroid;
+    projectState.activeDeviceSession.deviceInfo?.platform === "iOS"
+      ? resetOptionsIOS
+      : resetOptionsAndroid;
 
   return (
     <DropdownMenuRoot>
@@ -138,7 +140,9 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             label="Open App Switcher"
             icon="chrome-restore"
           />
-          {projectState.selectedDevice?.platform === DevicePlatform.IOS && <BiometricsItem />}
+          {projectState.activeDeviceSession.deviceInfo?.platform === DevicePlatform.IOS && (
+            <BiometricsItem />
+          )}
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -51,14 +51,12 @@ const resetOptionsAndroid: Array<{ label: string; value: AppPermissionType; icon
 ];
 
 function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownProps) {
-  const { project, deviceSettings, projectState } = useProject();
+  const { project, activeDeviceSession, deviceSettings } = useProject();
   const { showDeviceFrame, update } = useWorkspaceConfig();
   const { openModal } = useModal();
 
   const resetOptions =
-    projectState.activeDeviceSession.deviceInfo?.platform === "iOS"
-      ? resetOptionsIOS
-      : resetOptionsAndroid;
+    activeDeviceSession?.deviceInfo?.platform === "iOS" ? resetOptionsIOS : resetOptionsAndroid;
 
   return (
     <DropdownMenuRoot>
@@ -140,9 +138,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             label="Open App Switcher"
             icon="chrome-restore"
           />
-          {projectState.activeDeviceSession.deviceInfo?.platform === DevicePlatform.IOS && (
-            <BiometricsItem />
-          )}
+          {activeDeviceSession?.deviceInfo?.platform === DevicePlatform.IOS && <BiometricsItem />}
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -51,12 +51,12 @@ const resetOptionsAndroid: Array<{ label: string; value: AppPermissionType; icon
 ];
 
 function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownProps) {
-  const { project, activeDeviceSession, deviceSettings } = useProject();
+  const { project, selectedDeviceSession, deviceSettings } = useProject();
   const { showDeviceFrame, update } = useWorkspaceConfig();
   const { openModal } = useModal();
 
   const resetOptions =
-    activeDeviceSession?.deviceInfo?.platform === "iOS" ? resetOptionsIOS : resetOptionsAndroid;
+    selectedDeviceSession?.deviceInfo.platform === "iOS" ? resetOptionsIOS : resetOptionsAndroid;
 
   return (
     <DropdownMenuRoot>
@@ -138,7 +138,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             label="Open App Switcher"
             icon="chrome-restore"
           />
-          {activeDeviceSession?.deviceInfo?.platform === DevicePlatform.IOS && <BiometricsItem />}
+          {selectedDeviceSession?.deviceInfo.platform === DevicePlatform.IOS && <BiometricsItem />}
           <DropdownMenu.Item
             className="dropdown-menu-item"
             onSelect={() => {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -85,24 +85,24 @@ function Preview({
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
   const { dispatchKeyPress, clearPressedKeys } = useKeyPresses();
 
-  const { projectState, activeDeviceSession, project } = useProject();
+  const { projectState, selectedDeviceSession, project } = useProject();
 
-  const projectStatus = activeDeviceSession?.status;
+  const projectStatus = selectedDeviceSession?.status;
 
   const hasBuildError = projectStatus === "buildError";
   const hasBootError = projectStatus === "bootError";
   const hasBundlingError = projectStatus === "bundlingError";
 
-  const debugPaused = activeDeviceSession?.isDebuggerPaused;
-  const isRefreshing = activeDeviceSession?.isRefreshing ?? false;
+  const debugPaused = selectedDeviceSession?.isDebuggerPaused;
+  const isRefreshing = selectedDeviceSession?.isRefreshing ?? false;
 
-  const previewURL = activeDeviceSession?.previewURL;
+  const previewURL = selectedDeviceSession?.previewURL;
 
   const isStarting = hasBundlingError
     ? false
-    : !projectState || activeDeviceSession?.status === "starting";
+    : !projectState || selectedDeviceSession?.status === "starting";
   const showDevicePreview =
-    activeDeviceSession?.previewURL &&
+    selectedDeviceSession?.previewURL &&
     (showPreviewRequested || (!isStarting && !hasBuildError && !hasBootError));
 
   useBuildErrorAlert(hasBuildError);
@@ -447,13 +447,13 @@ function Preview({
   }, [project, shouldPreventInputEvents]);
 
   useEffect(() => {
-    if (activeDeviceSession?.hasStaleBuildCache) {
+    if (selectedDeviceSession?.hasStaleBuildCache) {
       openRebuildAlert();
     }
-  }, [activeDeviceSession?.hasStaleBuildCache]);
+  }, [selectedDeviceSession?.hasStaleBuildCache]);
 
   const device = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === activeDeviceSession?.deviceInfo?.modelId;
+    return sd.modelId === selectedDeviceSession?.deviceInfo.modelId;
   });
 
   const resizableProps = useResizableProps({

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -85,24 +85,24 @@ function Preview({
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
   const { dispatchKeyPress, clearPressedKeys } = useKeyPresses();
 
-  const { projectState, project } = useProject();
+  const { projectState, activeDeviceSession, project } = useProject();
 
-  const projectStatus = projectState.activeDeviceSession.status;
+  const projectStatus = activeDeviceSession?.status;
 
   const hasBuildError = projectStatus === "buildError";
   const hasBootError = projectStatus === "bootError";
   const hasBundlingError = projectStatus === "bundlingError";
 
-  const debugPaused = projectState.activeDeviceSession.isDebuggerPaused;
-  const isRefreshing = projectState.activeDeviceSession.isRefreshing;
+  const debugPaused = activeDeviceSession?.isDebuggerPaused;
+  const isRefreshing = activeDeviceSession?.isRefreshing ?? false;
 
-  const previewURL = projectState.activeDeviceSession.previewURL;
+  const previewURL = activeDeviceSession?.previewURL;
 
   const isStarting = hasBundlingError
     ? false
-    : !projectState || projectState.activeDeviceSession.status === "starting";
+    : !projectState || activeDeviceSession?.status === "starting";
   const showDevicePreview =
-    projectState?.activeDeviceSession.previewURL &&
+    activeDeviceSession?.previewURL &&
     (showPreviewRequested || (!isStarting && !hasBuildError && !hasBootError));
 
   useBuildErrorAlert(hasBuildError);
@@ -447,13 +447,13 @@ function Preview({
   }, [project, shouldPreventInputEvents]);
 
   useEffect(() => {
-    if (projectState.activeDeviceSession.hasStaleBuildCache) {
+    if (activeDeviceSession?.hasStaleBuildCache) {
       openRebuildAlert();
     }
-  }, [projectState.activeDeviceSession.hasStaleBuildCache]);
+  }, [activeDeviceSession?.hasStaleBuildCache]);
 
   const device = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === projectState?.activeDeviceSession.deviceInfo?.modelId;
+    return sd.modelId === activeDeviceSession?.deviceInfo?.modelId;
   });
 
   const resizableProps = useResizableProps({

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -87,20 +87,22 @@ function Preview({
 
   const { projectState, project } = useProject();
 
-  const projectStatus = projectState.status;
+  const projectStatus = projectState.activeDeviceSession.status;
 
   const hasBuildError = projectStatus === "buildError";
   const hasBootError = projectStatus === "bootError";
   const hasBundlingError = projectStatus === "bundlingError";
 
-  const debugPaused = projectState.isDebuggerPaused;
-  const isRefreshing = projectState.isRefreshing;
+  const debugPaused = projectState.activeDeviceSession.isDebuggerPaused;
+  const isRefreshing = projectState.activeDeviceSession.isRefreshing;
 
-  const previewURL = projectState.previewURL;
+  const previewURL = projectState.activeDeviceSession.previewURL;
 
-  const isStarting = hasBundlingError ? false : !projectState || projectState.status === "starting";
+  const isStarting = hasBundlingError
+    ? false
+    : !projectState || projectState.activeDeviceSession.status === "starting";
   const showDevicePreview =
-    projectState?.previewURL &&
+    projectState?.activeDeviceSession.previewURL &&
     (showPreviewRequested || (!isStarting && !hasBuildError && !hasBootError));
 
   useBuildErrorAlert(hasBuildError);
@@ -445,13 +447,13 @@ function Preview({
   }, [project, shouldPreventInputEvents]);
 
   useEffect(() => {
-    if (projectState.hasStaleBuildCache) {
+    if (projectState.activeDeviceSession.hasStaleBuildCache) {
       openRebuildAlert();
     }
-  }, [projectState.hasStaleBuildCache]);
+  }, [projectState.activeDeviceSession.hasStaleBuildCache]);
 
   const device = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === projectState?.selectedDevice?.modelId;
+    return sd.modelId === projectState?.activeDeviceSession.deviceInfo?.modelId;
   });
 
   const resizableProps = useResizableProps({

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -17,20 +17,20 @@ const startupStageWeightSum = StartupStageWeight.map((item) => item.weight).redu
 );
 
 function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => void }) {
-  const { projectState, activeDeviceSession, project } = useProject();
+  const { projectState, selectedDeviceSession, project } = useProject();
   const { deviceSessionsManager } = useDevices();
   const [progress, setProgress] = useState(0);
 
   const [isLoadingSlowly, setIsLoadingSlowly] = useState(false);
 
-  const startupMessage = activeDeviceSession?.startupMessage;
+  const startupMessage = selectedDeviceSession?.startupMessage;
 
   useEffect(() => {
-    if (activeDeviceSession?.startupMessage === StartupMessage.Restarting) {
+    if (selectedDeviceSession?.startupMessage === StartupMessage.Restarting) {
       setProgress(0);
     } else {
       const currentIndex = StartupStageWeight.findIndex(
-        (item) => item.StartupMessage === activeDeviceSession?.startupMessage
+        (item) => item.StartupMessage === selectedDeviceSession?.startupMessage
       );
       const currentWeight = StartupStageWeight[currentIndex].weight;
       const startupStageWeightSumUntilNow = StartupStageWeight.slice(0, currentIndex)
@@ -39,8 +39,8 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
       let progressComponent = 0;
 
-      if (activeDeviceSession?.stageProgress !== undefined) {
-        progressComponent = activeDeviceSession?.stageProgress;
+      if (selectedDeviceSession?.stageProgress !== undefined) {
+        progressComponent = selectedDeviceSession?.stageProgress;
       }
       setProgress(
         ((startupStageWeightSumUntilNow + progressComponent * currentWeight) /
@@ -90,12 +90,12 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
               "preview-loader-message",
               isLoadingSlowly && "preview-loader-slow-progress"
             )}>
-            {activeDeviceSession?.startupMessage}
+            {selectedDeviceSession?.startupMessage}
             {isLoadingSlowly && isBuilding ? " (open logs)" : ""}
           </StartupMessageComponent>
-          {activeDeviceSession?.stageProgress !== undefined && (
+          {selectedDeviceSession?.stageProgress !== undefined && (
             <div className="preview-loader-stage-progress">
-              {(activeDeviceSession?.stageProgress * 100).toFixed(1)}%
+              {(selectedDeviceSession?.stageProgress * 100).toFixed(1)}%
             </div>
           )}
         </div>

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -17,20 +17,20 @@ const startupStageWeightSum = StartupStageWeight.map((item) => item.weight).redu
 );
 
 function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => void }) {
-  const { projectState, project } = useProject();
+  const { projectState, activeDeviceSession, project } = useProject();
   const { deviceSessionsManager } = useDevices();
   const [progress, setProgress] = useState(0);
 
   const [isLoadingSlowly, setIsLoadingSlowly] = useState(false);
 
-  const startupMessage = projectState.activeDeviceSession.startupMessage;
+  const startupMessage = activeDeviceSession?.startupMessage;
 
   useEffect(() => {
-    if (projectState.activeDeviceSession.startupMessage === StartupMessage.Restarting) {
+    if (activeDeviceSession?.startupMessage === StartupMessage.Restarting) {
       setProgress(0);
     } else {
       const currentIndex = StartupStageWeight.findIndex(
-        (item) => item.StartupMessage === projectState.activeDeviceSession.startupMessage
+        (item) => item.StartupMessage === activeDeviceSession?.startupMessage
       );
       const currentWeight = StartupStageWeight[currentIndex].weight;
       const startupStageWeightSumUntilNow = StartupStageWeight.slice(0, currentIndex)
@@ -39,8 +39,8 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
       let progressComponent = 0;
 
-      if (projectState.activeDeviceSession.stageProgress !== undefined) {
-        progressComponent = projectState.activeDeviceSession.stageProgress;
+      if (activeDeviceSession?.stageProgress !== undefined) {
+        progressComponent = activeDeviceSession?.stageProgress;
       }
       setProgress(
         ((startupStageWeightSumUntilNow + progressComponent * currentWeight) /
@@ -90,12 +90,12 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
               "preview-loader-message",
               isLoadingSlowly && "preview-loader-slow-progress"
             )}>
-            {projectState.activeDeviceSession.startupMessage}
+            {activeDeviceSession?.startupMessage}
             {isLoadingSlowly && isBuilding ? " (open logs)" : ""}
           </StartupMessageComponent>
-          {projectState.activeDeviceSession.stageProgress !== undefined && (
+          {activeDeviceSession?.stageProgress !== undefined && (
             <div className="preview-loader-stage-progress">
-              {(projectState.activeDeviceSession.stageProgress * 100).toFixed(1)}%
+              {(activeDeviceSession?.stageProgress * 100).toFixed(1)}%
             </div>
           )}
         </div>

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -23,14 +23,14 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
   const [isLoadingSlowly, setIsLoadingSlowly] = useState(false);
 
-  const startupMessage = projectState.startupMessage;
+  const startupMessage = projectState.activeDeviceSession.startupMessage;
 
   useEffect(() => {
-    if (projectState.startupMessage === StartupMessage.Restarting) {
+    if (projectState.activeDeviceSession.startupMessage === StartupMessage.Restarting) {
       setProgress(0);
     } else {
       const currentIndex = StartupStageWeight.findIndex(
-        (item) => item.StartupMessage === projectState.startupMessage
+        (item) => item.StartupMessage === projectState.activeDeviceSession.startupMessage
       );
       const currentWeight = StartupStageWeight[currentIndex].weight;
       const startupStageWeightSumUntilNow = StartupStageWeight.slice(0, currentIndex)
@@ -39,8 +39,8 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
 
       let progressComponent = 0;
 
-      if (projectState.stageProgress !== undefined) {
-        progressComponent = projectState.stageProgress;
+      if (projectState.activeDeviceSession.stageProgress !== undefined) {
+        progressComponent = projectState.activeDeviceSession.stageProgress;
       }
       setProgress(
         ((startupStageWeightSumUntilNow + progressComponent * currentWeight) /
@@ -90,12 +90,12 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
               "preview-loader-message",
               isLoadingSlowly && "preview-loader-slow-progress"
             )}>
-            {projectState.startupMessage}
+            {projectState.activeDeviceSession.startupMessage}
             {isLoadingSlowly && isBuilding ? " (open logs)" : ""}
           </StartupMessageComponent>
-          {projectState.stageProgress !== undefined && (
+          {projectState.activeDeviceSession.stageProgress !== undefined && (
             <div className="preview-loader-stage-progress">
-              {(projectState.stageProgress * 100).toFixed(1)}%
+              {(projectState.activeDeviceSession.stageProgress * 100).toFixed(1)}%
             </div>
           )}
         </div>

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -26,8 +26,8 @@ function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: numbe
 }
 
 function useIsEnabled() {
-  const { activeDeviceSession } = useProject();
-  return activeDeviceSession?.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
+  const { selectedDeviceSession } = useProject();
+  return selectedDeviceSession?.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
 }
 
 function RenderOutlinesOverlay() {

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -26,8 +26,8 @@ function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: numbe
 }
 
 function useIsEnabled() {
-  const { projectState } = useProject();
-  return projectState.activeDeviceSession.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
+  const { activeDeviceSession } = useProject();
+  return activeDeviceSession?.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
 }
 
 function RenderOutlinesOverlay() {

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -27,7 +27,7 @@ function createOutlineRenderer(canvas: HTMLCanvasElement, size: Size, dpr: numbe
 
 function useIsEnabled() {
   const { projectState } = useProject();
-  return projectState.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
+  return projectState.activeDeviceSession.toolsState[RENDER_OUTLINES_PLUGIN_ID]?.enabled;
 }
 
 function RenderOutlinesOverlay() {

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -73,12 +73,12 @@ function ToolsList({
 function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) {
   const { project, projectState } = useProject();
 
-  const allTools = Object.entries(projectState.toolsState);
+  const allTools = Object.entries(projectState.activeDeviceSession.toolsState);
   const panelTools = allTools.filter(([key, tool]) => tool.panelAvailable);
   const nonPanelTools = allTools.filter(([key, tool]) => !tool.panelAvailable);
 
-  const isProfilingCPU = projectState.profilingCPUState !== "stopped";
-  const isProfilingReact = projectState.profilingReactState !== "stopped";
+  const isProfilingCPU = projectState.activeDeviceSession.profilingCPUState !== "stopped";
+  const isProfilingReact = projectState.activeDeviceSession.profilingReactState !== "stopped";
 
   return (
     <DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -71,14 +71,14 @@ function ToolsList({
 }
 
 function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) {
-  const { project, projectState } = useProject();
+  const { project, activeDeviceSession } = useProject();
 
-  const allTools = Object.entries(projectState.activeDeviceSession.toolsState);
+  const allTools = Object.entries(activeDeviceSession?.toolsState ?? {});
   const panelTools = allTools.filter(([key, tool]) => tool.panelAvailable);
   const nonPanelTools = allTools.filter(([key, tool]) => !tool.panelAvailable);
 
-  const isProfilingCPU = projectState.activeDeviceSession.profilingCPUState !== "stopped";
-  const isProfilingReact = projectState.activeDeviceSession.profilingReactState !== "stopped";
+  const isProfilingCPU = activeDeviceSession?.profilingCPUState !== "stopped";
+  const isProfilingReact = activeDeviceSession?.profilingReactState !== "stopped";
 
   return (
     <DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -71,14 +71,14 @@ function ToolsList({
 }
 
 function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disabled?: boolean }) {
-  const { project, activeDeviceSession } = useProject();
+  const { project, selectedDeviceSession } = useProject();
 
-  const allTools = Object.entries(activeDeviceSession?.toolsState ?? {});
+  const allTools = Object.entries(selectedDeviceSession?.toolsState ?? {});
   const panelTools = allTools.filter(([key, tool]) => tool.panelAvailable);
   const nonPanelTools = allTools.filter(([key, tool]) => !tool.panelAvailable);
 
-  const isProfilingCPU = activeDeviceSession?.profilingCPUState !== "stopped";
-  const isProfilingReact = activeDeviceSession?.profilingReactState !== "stopped";
+  const isProfilingCPU = selectedDeviceSession?.profilingCPUState !== "stopped";
+  const isProfilingReact = selectedDeviceSession?.profilingReactState !== "stopped";
 
   return (
     <DropdownMenuRoot>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -29,13 +29,13 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
 }
 
 function UrlBar({ disabled }: { disabled?: boolean }) {
-  const { project, activeDeviceSession } = useProject();
+  const { project, selectedDeviceSession } = useProject();
   const { dependencies } = useDependencies();
 
-  const navigationHistory = activeDeviceSession?.navigationHistory ?? [];
-  const routeList = activeDeviceSession?.navigationRouteList ?? [];
+  const navigationHistory = selectedDeviceSession?.navigationHistory ?? [];
+  const routeList = selectedDeviceSession?.navigationRouteList ?? [];
 
-  const disabledAlsoWhenStarting = disabled || activeDeviceSession?.status === "starting";
+  const disabledAlsoWhenStarting = disabled || selectedDeviceSession?.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
 
   return (

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -29,14 +29,13 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
 }
 
 function UrlBar({ disabled }: { disabled?: boolean }) {
-  const { project, projectState } = useProject();
+  const { project, activeDeviceSession } = useProject();
   const { dependencies } = useDependencies();
 
-  const navigationHistory = projectState.activeDeviceSession.navigationHistory;
-  const routeList = projectState.activeDeviceSession.navigationRouteList;
+  const navigationHistory = activeDeviceSession?.navigationHistory ?? [];
+  const routeList = activeDeviceSession?.navigationRouteList ?? [];
 
-  const disabledAlsoWhenStarting =
-    disabled || projectState.activeDeviceSession.status === "starting";
+  const disabledAlsoWhenStarting = disabled || activeDeviceSession?.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
 
   return (

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -32,10 +32,11 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const { project, projectState } = useProject();
   const { dependencies } = useDependencies();
 
-  const navigationHistory = projectState.navigationHistory;
-  const routeList = projectState.navigationRouteList;
+  const navigationHistory = projectState.activeDeviceSession.navigationHistory;
+  const routeList = projectState.activeDeviceSession.navigationRouteList;
 
-  const disabledAlsoWhenStarting = disabled || projectState.status === "starting";
+  const disabledAlsoWhenStarting =
+    disabled || projectState.activeDeviceSession.status === "starting";
   const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
 
   return (

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -165,10 +165,10 @@ function UrlSelect({
 
   // Reset the input on app reload
   useEffect(() => {
-    if (projectState.status === "starting") {
+    if (projectState.activeDeviceSession.status === "starting") {
       setInputValue("/");
     }
-  }, [projectState.status]);
+  }, [projectState.activeDeviceSession.status]);
 
   // Refresh the input value when the navigation history changes
   useEffect(() => {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -43,7 +43,7 @@ function UrlSelect({
 
   const textfieldRef = React.useRef<HTMLInputElement>(null);
   const { openModal } = useModal();
-  const { project, activeDeviceSession } = useProject();
+  const { project, selectedDeviceSession } = useProject();
 
   const routeItems = React.useMemo(
     () =>
@@ -165,10 +165,10 @@ function UrlSelect({
 
   // Reset the input on app reload
   useEffect(() => {
-    if (activeDeviceSession?.status === "starting") {
+    if (selectedDeviceSession?.status === "starting") {
       setInputValue("/");
     }
-  }, [activeDeviceSession?.status]);
+  }, [selectedDeviceSession?.status]);
 
   // Refresh the input value when the navigation history changes
   useEffect(() => {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -42,8 +42,8 @@ function UrlSelect({
   const dropdownItems: UrlSelectFocusable[] = [];
 
   const textfieldRef = React.useRef<HTMLInputElement>(null);
-  const { project, projectState } = useProject();
   const { openModal } = useModal();
+  const { project, activeDeviceSession } = useProject();
 
   const routeItems = React.useMemo(
     () =>
@@ -165,10 +165,10 @@ function UrlSelect({
 
   // Reset the input on app reload
   useEffect(() => {
-    if (projectState.activeDeviceSession.status === "starting") {
+    if (activeDeviceSession?.status === "starting") {
       setInputValue("/");
     }
-  }, [projectState.activeDeviceSession.status]);
+  }, [activeDeviceSession?.status]);
 
   // Refresh the input value when the navigation history changes
   useEffect(() => {

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -63,8 +63,11 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
 
   let description = "Open extension logs to find out what went wrong.";
 
-  if (projectState.status === "buildError" && projectState.buildError) {
-    const { buildType, message } = projectState.buildError;
+  if (
+    projectState.activeDeviceSession.status === "buildError" &&
+    projectState.activeDeviceSession.buildError
+  ) {
+    const { buildType, message } = projectState.activeDeviceSession.buildError;
     description = message;
     if (buildType && [BuildType.Local, BuildType.EasLocal, BuildType.Custom].includes(buildType)) {
       logsButtonDestination = "build";

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -52,7 +52,7 @@ function BuildErrorActions({
 }
 
 export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
-  const { activeDeviceSession } = useProject();
+  const { selectedDeviceSession } = useProject();
   const { ios, xcodeSchemes } = useLaunchConfig();
   const { deviceSessionsManager } = useDevices();
 
@@ -63,8 +63,8 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
 
   let description = "Open extension logs to find out what went wrong.";
 
-  if (activeDeviceSession?.status === "buildError" && activeDeviceSession?.buildError) {
-    const { buildType, message } = activeDeviceSession.buildError;
+  if (selectedDeviceSession?.status === "buildError" && selectedDeviceSession?.buildError) {
+    const { buildType, message } = selectedDeviceSession.buildError;
     description = message;
     if (buildType && [BuildType.Local, BuildType.EasLocal, BuildType.Custom].includes(buildType)) {
       logsButtonDestination = "build";

--- a/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBuildErrorAlert.tsx
@@ -52,7 +52,7 @@ function BuildErrorActions({
 }
 
 export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
-  const { projectState } = useProject();
+  const { activeDeviceSession } = useProject();
   const { ios, xcodeSchemes } = useLaunchConfig();
   const { deviceSessionsManager } = useDevices();
 
@@ -63,11 +63,8 @@ export function useBuildErrorAlert(shouldDisplayAlert: boolean) {
 
   let description = "Open extension logs to find out what went wrong.";
 
-  if (
-    projectState.activeDeviceSession.status === "buildError" &&
-    projectState.activeDeviceSession.buildError
-  ) {
-    const { buildType, message } = projectState.activeDeviceSession.buildError;
+  if (activeDeviceSession?.status === "buildError" && activeDeviceSession?.buildError) {
+    const { buildType, message } = activeDeviceSession.buildError;
     description = message;
     if (buildType && [BuildType.Local, BuildType.EasLocal, BuildType.Custom].includes(buildType)) {
       logsButtonDestination = "build";

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { makeProxy } from "../utilities/rpc";
 import {
-  DEVICE_SESSION_INITIAL_STATE,
+  DeviceSessionState,
   DeviceSettings,
   MultimediaData,
   ProjectInterface,
@@ -21,6 +21,7 @@ const project = makeProxy<ProjectInterface>("Project");
 
 interface ProjectContextProps {
   projectState: ProjectState;
+  activeDeviceSession: DeviceSessionState | undefined;
   deviceSettings: DeviceSettings;
   project: ProjectInterface;
   hasActiveLicense: boolean;
@@ -29,7 +30,8 @@ interface ProjectContextProps {
 }
 
 const defaultProjectState: ProjectState = {
-  activeDeviceSession: DEVICE_SESSION_INITIAL_STATE,
+  selectedSessionId: null,
+  deviceSessions: {},
   previewZoom: undefined,
   appRootPath: "./",
   initialized: false,
@@ -52,6 +54,7 @@ const defaultDeviceSettings: DeviceSettings = {
 const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
+  activeDeviceSession: undefined,
   project,
   hasActiveLicense: false,
   replayData: undefined,
@@ -83,8 +86,12 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
   }, []);
 
   const contextValue = useMemo(() => {
+    const activeDeviceSession = projectState.selectedSessionId
+      ? projectState.deviceSessions[projectState.selectedSessionId]
+      : undefined;
     return {
       projectState,
+      activeDeviceSession,
       deviceSettings,
       project,
       hasActiveLicense,

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -21,7 +21,7 @@ const project = makeProxy<ProjectInterface>("Project");
 
 interface ProjectContextProps {
   projectState: ProjectState;
-  activeDeviceSession: DeviceSessionState | undefined;
+  selectedDeviceSession: DeviceSessionState | undefined;
   deviceSettings: DeviceSettings;
   project: ProjectInterface;
   hasActiveLicense: boolean;
@@ -54,7 +54,7 @@ const defaultDeviceSettings: DeviceSettings = {
 const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
-  activeDeviceSession: undefined,
+  selectedDeviceSession: undefined,
   project,
   hasActiveLicense: false,
   replayData: undefined,
@@ -86,12 +86,12 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
   }, []);
 
   const contextValue = useMemo(() => {
-    const activeDeviceSession = projectState.selectedSessionId
+    const selectedDeviceSession = projectState.selectedSessionId
       ? projectState.deviceSessions[projectState.selectedSessionId]
       : undefined;
     return {
       projectState,
-      activeDeviceSession,
+      selectedDeviceSession,
       deviceSettings,
       project,
       hasActiveLicense,

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -29,7 +29,7 @@ interface ProjectContextProps {
 }
 
 const defaultProjectState: ProjectState = {
-  ...DEVICE_SESSION_INITIAL_STATE,
+  activeDeviceSession: DEVICE_SESSION_INITIAL_STATE,
   previewZoom: undefined,
   appRootPath: "./",
   initialized: false,

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -109,8 +109,8 @@ function DeviceRow({ deviceInfo, onDeviceRename, onDeviceDelete, isSelected }: D
 }
 
 function ManageDevicesView() {
-  const { projectState } = useProject();
-  const selectedProjectDevice = projectState?.activeDeviceSession.deviceInfo;
+  const { activeDeviceSession } = useProject();
+  const selectedProjectDevice = activeDeviceSession?.deviceInfo;
   const [selectedDevice, setSelectedDevice] = useState<DeviceInfo | undefined>(undefined);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -109,8 +109,8 @@ function DeviceRow({ deviceInfo, onDeviceRename, onDeviceDelete, isSelected }: D
 }
 
 function ManageDevicesView() {
-  const { activeDeviceSession } = useProject();
-  const selectedProjectDevice = activeDeviceSession?.deviceInfo;
+  const { selectedDeviceSession } = useProject();
+  const selectedProjectDevice = selectedDeviceSession?.deviceInfo;
   const [selectedDevice, setSelectedDevice] = useState<DeviceInfo | undefined>(undefined);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -110,7 +110,7 @@ function DeviceRow({ deviceInfo, onDeviceRename, onDeviceDelete, isSelected }: D
 
 function ManageDevicesView() {
   const { projectState } = useProject();
-  const selectedProjectDevice = projectState?.selectedDevice;
+  const selectedProjectDevice = projectState?.activeDeviceSession.deviceInfo;
   const [selectedDevice, setSelectedDevice] = useState<DeviceInfo | undefined>(undefined);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -80,8 +80,15 @@ function ProfilingButton({
 }
 
 function PreviewView() {
-  const { projectState, project, deviceSettings, hasActiveLicense, replayData, setReplayData } =
-    useProject();
+  const {
+    activeDeviceSession,
+    projectState,
+    project,
+    deviceSettings,
+    hasActiveLicense,
+    replayData,
+    setReplayData,
+  } = useProject();
   const { showDismissableError } = useUtils();
 
   const [isInspecting, setIsInspecting] = useState(false);
@@ -98,14 +105,14 @@ function PreviewView() {
   const { devices } = useDevices();
 
   const initialized = projectState.initialized;
-  const selectedDevice = projectState.activeDeviceSession.deviceInfo;
+  const selectedDevice = activeDeviceSession?.deviceInfo;
   const hasNoDevices = projectState !== undefined && devices.length === 0;
-  const isStarting = projectState.activeDeviceSession.status === "starting";
-  const isRunning = projectState.activeDeviceSession.status === "running";
-  const isRecording = projectState.activeDeviceSession.isRecordingScreen;
+  const isStarting = activeDeviceSession?.status === "starting";
+  const isRunning = activeDeviceSession?.status === "running";
+  const isRecording = activeDeviceSession?.isRecordingScreen ?? false;
 
   const deviceProperties = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === projectState?.activeDeviceSession.deviceInfo?.modelId;
+    return sd.modelId === activeDeviceSession?.deviceInfo?.modelId;
   });
 
   const { openFileAt } = useUtils();
@@ -198,12 +205,12 @@ function PreviewView() {
         </div>
         <div className="button-group-top-right">
           <ProfilingButton
-            profilingState={projectState.activeDeviceSession.profilingCPUState}
+            profilingState={activeDeviceSession?.profilingCPUState ?? "stopped"}
             title="Stop profiling CPU"
             onClick={stopProfilingCPU}
           />
           <ProfilingButton
-            profilingState={projectState.activeDeviceSession.profilingReactState}
+            profilingState={activeDeviceSession?.profilingReactState ?? "stopped"}
             title="Stop profiling React"
             onClick={stopProfilingReact}
           />
@@ -247,7 +254,7 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            counter={projectState.activeDeviceSession.logCounter}
+            counter={activeDeviceSession?.logCounter}
             onClick={() => project.focusDebugConsole()}
             tooltip={{
               label: "Open logs panel",

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -98,14 +98,14 @@ function PreviewView() {
   const { devices } = useDevices();
 
   const initialized = projectState.initialized;
-  const selectedDevice = projectState.selectedDevice;
+  const selectedDevice = projectState.activeDeviceSession.deviceInfo;
   const hasNoDevices = projectState !== undefined && devices.length === 0;
-  const isStarting = projectState.status === "starting";
-  const isRunning = projectState.status === "running";
-  const isRecording = projectState.isRecordingScreen;
+  const isStarting = projectState.activeDeviceSession.status === "starting";
+  const isRunning = projectState.activeDeviceSession.status === "running";
+  const isRecording = projectState.activeDeviceSession.isRecordingScreen;
 
   const deviceProperties = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === projectState?.selectedDevice?.modelId;
+    return sd.modelId === projectState?.activeDeviceSession.deviceInfo?.modelId;
   });
 
   const { openFileAt } = useUtils();
@@ -198,12 +198,12 @@ function PreviewView() {
         </div>
         <div className="button-group-top-right">
           <ProfilingButton
-            profilingState={projectState.profilingCPUState}
+            profilingState={projectState.activeDeviceSession.profilingCPUState}
             title="Stop profiling CPU"
             onClick={stopProfilingCPU}
           />
           <ProfilingButton
-            profilingState={projectState.profilingReactState}
+            profilingState={projectState.activeDeviceSession.profilingReactState}
             title="Stop profiling React"
             onClick={stopProfilingReact}
           />
@@ -247,7 +247,7 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            counter={projectState.logCounter}
+            counter={projectState.activeDeviceSession.logCounter}
             onClick={() => project.focusDebugConsole()}
             tooltip={{
               label: "Open logs panel",

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -81,7 +81,7 @@ function ProfilingButton({
 
 function PreviewView() {
   const {
-    activeDeviceSession,
+    selectedDeviceSession,
     projectState,
     project,
     deviceSettings,
@@ -105,14 +105,14 @@ function PreviewView() {
   const { devices } = useDevices();
 
   const initialized = projectState.initialized;
-  const selectedDevice = activeDeviceSession?.deviceInfo;
+  const selectedDevice = selectedDeviceSession?.deviceInfo;
   const hasNoDevices = projectState !== undefined && devices.length === 0;
-  const isStarting = activeDeviceSession?.status === "starting";
-  const isRunning = activeDeviceSession?.status === "running";
-  const isRecording = activeDeviceSession?.isRecordingScreen ?? false;
+  const isStarting = selectedDeviceSession?.status === "starting";
+  const isRunning = selectedDeviceSession?.status === "running";
+  const isRecording = selectedDeviceSession?.isRecordingScreen ?? false;
 
   const deviceProperties = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
-    return sd.modelId === activeDeviceSession?.deviceInfo?.modelId;
+    return sd.modelId === selectedDeviceSession?.deviceInfo.modelId;
   });
 
   const { openFileAt } = useUtils();
@@ -205,12 +205,12 @@ function PreviewView() {
         </div>
         <div className="button-group-top-right">
           <ProfilingButton
-            profilingState={activeDeviceSession?.profilingCPUState ?? "stopped"}
+            profilingState={selectedDeviceSession?.profilingCPUState ?? "stopped"}
             title="Stop profiling CPU"
             onClick={stopProfilingCPU}
           />
           <ProfilingButton
-            profilingState={activeDeviceSession?.profilingReactState ?? "stopped"}
+            profilingState={selectedDeviceSession?.profilingReactState ?? "stopped"}
             title="Stop profiling React"
             onClick={stopProfilingReact}
           />
@@ -254,7 +254,7 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            counter={activeDeviceSession?.logCounter}
+            counter={selectedDeviceSession?.logCounter}
             onClick={() => project.focusDebugConsole()}
             tooltip={{
               label: "Open logs panel",


### PR DESCRIPTION
Refactors project state to store the information about all currently running device sessions in ProjectState. This refactor is necessary to implement running multiple devices simultaneously. 

### How was this tested:
- verify there are no regressions:
  - try switching between devices
  - try adding/removing devices
  - try removing the running device
  - try renaming devices
- to test that multiple device sessions are correctly reported, pass `preservePreviousDevice` to `startOrActivateSessionForDevice` and log the project state to check all sessions are present