### PR TITLE
Fix incorrect home button target

### DIFF
--- a/packages/vscode-extension/lib/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router_helpers.js
@@ -19,12 +19,8 @@ export function sendNavigationChange(previousRouteInfo, routeInfo, onNavigationC
   const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
   const displayParams = new URLSearchParams(filteredParams).toString();
   const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
-  
-  if (
-    pathname &&
-    previousRouteInfo.current &&
-    !checkNavigationDescriptorsEqual(previousRouteInfo.current, routeInfo)
-  ) {
+
+  if (pathname && !checkNavigationDescriptorsEqual(previousRouteInfo.current ?? {}, routeInfo)) {
     onNavigationChange({
       name: displayName,
       pathname,


### PR DESCRIPTION
This PR fixes an issue with the "go home" button on Expo Router apps, caused by the first `navigationChanged` event with path `"/"` not being sent, leading to the home button setting the first route opened from `/` as its target instead of the root path.

This definitely resolves #1213, with the rest of the fix being already merged in PR #1211.

### How Has This Been Tested:
1. Open an Expo Router app
2. Navigate to any non-root route
3. Press the home button - it should navigate back to `/`

