### PR TITLE
Add an option to remove navigation history entries

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -38,6 +38,7 @@ export type ProfilingState = "stopped" | "profiling" | "saving";
 export type NavigationHistoryItem = {
   displayName: string;
   id: string;
+  removable?: boolean;
 };
 
 export type NavigationRoute = {
@@ -207,6 +208,7 @@ export interface ProjectInterface {
   openNavigation(navigationItemID: string): Promise<void>;
   navigateBack(): Promise<void>;
   navigateHome(): Promise<void>;
+  removeNavigationHistoryEntry(id: string): Promise<void>;
   openDevMenu(): Promise<void>;
 
   activateLicense(activationKey: string): Promise<ActivateDeviceResult>;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -984,6 +984,11 @@ export class DeviceSession
     this.inspectorBridge.sendOpenNavigationRequest("__BACK__");
   }
 
+  public removeNavigationHistoryEntry(id: string) {
+    this.navigationHistory = this.navigationHistory.filter((record) => record.id !== id);
+    this.emitStateChange();
+  }
+
   public async openDevMenu() {
     await this.metro.openDevMenu();
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -324,6 +324,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     }
   }
 
+  public async removeNavigationHistoryEntry(id: string): Promise<void> {
+    this.deviceSession?.removeNavigationHistoryEntry(id);
+  }
+
   async resetAppPermissions(permissionType: AppPermissionType) {
     const needsRestart = await this.deviceSession?.resetAppPermissions(permissionType);
     if (needsRestart) {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.css
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.css
@@ -84,6 +84,8 @@
   line-height: 1.2;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 4px;
   min-height: 30px;
   height: auto;
   padding: 0 8px;
@@ -117,6 +119,24 @@
 
 .url-select-item-text-dynamic {
   color: var(--swm-url-select-special-text);
+}
+
+.url-select-item-remove {
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: var(--swm-icon-button);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 200ms 0ms ease-in-out;
+}
+.url-select-item-remove:hover {
+  color: var(--swm-icon-button-hover);
+}
+.url-select-item-remove:active {
+  color: var(--swm-icon-button-active);
+  transform: scale(0.9);
 }
 
 @media (height <= 450px) {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -56,6 +56,10 @@ function UrlSelect({
     return itemForID.displayName;
   };
 
+  const removeHistoryEntry = (id: string) => {
+    project.removeNavigationHistoryEntry(id);
+  };
+
   const findDynamicSegments = (item: NavigationHistoryItem) => {
     const matchingRoute = routeList.find((route) => route.path === item.id);
     if (matchingRoute && matchingRoute.dynamic) {
@@ -132,16 +136,23 @@ function UrlSelect({
     textfieldRef: textfieldRef as React.RefObject<HTMLInputElement>,
     onArrowPress: focusBetweenItems,
     getNameFromId,
+    onRemove: removeHistoryEntry,
   };
 
   // Compute combinedItems inline
   const combinedItems = React.useMemo(() => {
+    // Items from navigation history can be removed except the current one,
+    // but all extracted routes should always be present in the dropdown.
+    const navigationHistoryWithRemovable = navigationHistory.map((item, index) => ({
+      ...item,
+      removable: index !== 0,
+    }));
     const routesNotInHistory = differenceBy(
       routeItems,
       navigationHistory,
       (item: NavigationHistoryItem) => item.displayName
     );
-    return [...navigationHistory, ...routesNotInHistory];
+    return [...navigationHistoryWithRemovable, ...routesNotInHistory];
   }, [navigationHistory, routeItems]);
 
   // Reset the input on app reload

--- a/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
@@ -1,7 +1,6 @@
 import React, { PropsWithChildren } from "react";
 import { UrlSelectFocusable } from "./UrlSelect";
 import { NavigationHistoryItem } from "../../common/Project";
-import Tooltip from "./shared/Tooltip";
 
 interface UrlSelectItemProps {
   item: NavigationHistoryItem;

--- a/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from "react";
 import { UrlSelectFocusable } from "./UrlSelect";
 import { NavigationHistoryItem } from "../../common/Project";
+import Tooltip from "./shared/Tooltip";
 
 interface UrlSelectItemProps {
   item: NavigationHistoryItem;
@@ -17,6 +18,7 @@ interface UrlSelectItemProps {
   ) => void;
   getNameFromId: (id: string) => string;
   noHighlight?: boolean;
+  onRemove?: (id: string) => void;
 }
 
 function UrlSelectItem({
@@ -30,6 +32,7 @@ function UrlSelectItem({
   onArrowPress,
   getNameFromId,
   noHighlight = false,
+  onRemove,
   ...props
 }: PropsWithChildren<UrlSelectItemProps>) {
   // For readability, the substring that matches the search query is highlighted.
@@ -150,6 +153,17 @@ function UrlSelectItem({
         }
       }}>
       <div className="url-select-item-text">{nameWithStyles}</div>
+      {item.removable && onRemove && (
+        <button
+          className="url-select-item-remove"
+          tabIndex={-1}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(item.id);
+          }}>
+          <span className="codicon codicon-close" />
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
@@ -17,6 +17,7 @@ interface UrlSelectItemGroupProps {
   ) => void;
   getNameFromId: (id: string) => string;
   noHighlight?: boolean;
+  onRemove?: (id: string) => void;
 }
 
 function UrlSelectItemGroup({
@@ -29,6 +30,7 @@ function UrlSelectItemGroup({
   onArrowPress,
   getNameFromId,
   noHighlight = false,
+  onRemove,
 }: UrlSelectItemGroupProps) {
   return (
     <>
@@ -46,6 +48,7 @@ function UrlSelectItemGroup({
               itemList={itemList}
               textfieldRef={textfieldRef}
               noHighlight={noHighlight}
+              onRemove={onRemove}
             />
           )
       )}


### PR DESCRIPTION
This PR improves the functionality of the `UrlSelect` by allowing the user to remove unwanted entries (e.g. with typos) from the navigation history, since we don't clear it after reload anymore.

If the removed item is a static route present in the `routeList` extracted from Expo Router, it will be moved down to the alphabetically-sorted "other" section, and all other items will just be removed. The currently selected route can't be removed until another route is opened, as this would break the history.

https://github.com/user-attachments/assets/35c745cb-83af-48dc-8eb1-172c1bb493fc

### How Has This Been Tested: 
1. Open an Expo Router app
2. Play with navigation, open some static, dynamic and incorrect routes
3. Open the UrlSelect, there should be an "X" next to each visited entry
4. Click the "X"-es on the items - they should disappear or move down in the suggestions
5. Refresh the app - the deleted items shouldn't show up until visited again


