### PR TITLE
fix Network Inspector crash caused by invalid request URLs

### DIFF
--- a/packages/vscode-extension/src/network/components/PayloadTab.tsx
+++ b/packages/vscode-extension/src/network/components/PayloadTab.tsx
@@ -5,12 +5,16 @@ interface PayloadTabProps {
 }
 
 const getParams = (url: string): Record<string, string> => {
-  const urlObj = new URL(url);
-  const params: Record<string, string> = {};
-  urlObj.searchParams.forEach((value, key) => {
-    params[key] = value;
-  });
-  return params;
+  try {
+    const urlObj = new URL(url);
+    const params: Record<string, string> = {};
+    urlObj.searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+    return params;
+  } catch {
+    return {};
+  }
 };
 
 const PayloadTab = ({ networkLog }: PayloadTabProps) => {


### PR DESCRIPTION
Currently, if a request with a malformed URL is made, the Network Inspector will crash when you try to open the request details.
This PR safeguards against that.

Fixes #1215

### How Has This Been Tested: 
- open the network inspector
- make a request to an invalid URL
- open the details of the request
- don't crash :)


