### PR TITLE
Fix internal extension errors when switching from an iOS device to Android

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -76,7 +76,9 @@ export class IosSimulatorDevice extends DeviceBase {
 
   public dispose() {
     super.dispose();
-    this.nativeLogsOutputChannel?.dispose();
+    const nativeLogsOutputChannel = this.nativeLogsOutputChannel;
+    this.nativeLogsOutputChannel = undefined;
+    nativeLogsOutputChannel?.dispose();
     this.runningAppProcess?.cancel();
     return exec("xcrun", [
       "simctl",
@@ -385,7 +387,9 @@ export class IosSimulatorDevice extends DeviceBase {
 
     this.runningAppProcess = exec("xcrun", launchAppArgs);
 
-    lineReader(this.runningAppProcess).onLineRead(this.nativeLogsOutputChannel.appendLine);
+    lineReader(this.runningAppProcess).onLineRead((line) =>
+      this.nativeLogsOutputChannel?.appendLine(line)
+    );
   }
 
   async launchWithExpoDeeplink(bundleID: string, expoDeeplink: string) {


### PR DESCRIPTION
Fixes #1204

### How Has This Been Tested: 
- open the IDE in extension development host
- switch from an iOS simulator to Android
- don't get an "internal extension error" dialog
