### PR TITLE
Add a reliable Expo Router availability check for the frontend and fix navbar for multi-app projects

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -204,11 +204,13 @@ export interface ProjectInterface {
   focusBuildOutput(): Promise<void>;
   focusExtensionLogsOutput(): Promise<void>;
   focusDebugConsole(): Promise<void>;
+  
+  usesExpoRouter(): Promise<boolean>;
   openNavigation(navigationItemID: string): Promise<void>;
   navigateBack(): Promise<void>;
   navigateHome(): Promise<void>;
   openDevMenu(): Promise<void>;
-
+  
   activateLicense(activationKey: string): Promise<ActivateDeviceResult>;
   hasActiveLicense(): Promise<boolean>;
 

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -204,13 +204,13 @@ export interface ProjectInterface {
   focusBuildOutput(): Promise<void>;
   focusExtensionLogsOutput(): Promise<void>;
   focusDebugConsole(): Promise<void>;
-  
+
   usesExpoRouter(): Promise<boolean>;
   openNavigation(navigationItemID: string): Promise<void>;
   navigateBack(): Promise<void>;
   navigateHome(): Promise<void>;
   openDevMenu(): Promise<void>;
-  
+
   activateLicense(activationKey: string): Promise<ActivateDeviceResult>;
   hasActiveLicense(): Promise<boolean>;
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -414,10 +414,14 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     commands.executeCommand("workbench.panel.repl.view.focus");
   }
 
+  async usesExpoRouter(): Promise<boolean> {
+    return this.dependencyManager.checkProjectUsesExpoRouter();
+  }
+  
   public async openNavigation(navigationItemID: string) {
     this.deviceSession?.openNavigation(navigationItemID);
   }
-
+  
   public async navigateBack() {
     this.deviceSession?.navigateBack();
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -417,11 +417,11 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   async usesExpoRouter(): Promise<boolean> {
     return this.dependencyManager.checkProjectUsesExpoRouter();
   }
-  
+
   public async openNavigation(navigationItemID: string) {
     this.deviceSession?.openNavigation(navigationItemID);
   }
-  
+
   public async navigateBack() {
     this.deviceSession?.navigateBack();
   }

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -2,7 +2,6 @@ import { useProject } from "../providers/ProjectProvider";
 import UrlSelect from "./UrlSelect";
 import { IconButtonWithOptions } from "./IconButtonWithOptions";
 import IconButton from "./shared/IconButton";
-import { useDependencies } from "../providers/DependenciesProvider";
 import { useDevices } from "../providers/DevicesProvider";
 
 function ReloadButton({ disabled }: { disabled: boolean }) {
@@ -29,14 +28,12 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
 }
 
 function UrlBar({ disabled }: { disabled?: boolean }) {
-  const { project, projectState } = useProject();
-  const { dependencies } = useDependencies();
+  const { project, projectState, isExpoRouterProject } = useProject();
 
   const navigationHistory = projectState.navigationHistory;
   const routeList = projectState.navigationRouteList;
 
   const disabledAlsoWhenStarting = disabled || projectState.status === "starting";
-  const isExpoRouterProject = !dependencies.expoRouter?.isOptional;
 
   return (
     <>

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -23,6 +23,7 @@ interface ProjectContextProps {
   projectState: ProjectState;
   deviceSettings: DeviceSettings;
   project: ProjectInterface;
+  isExpoRouterProject: boolean;
   hasActiveLicense: boolean;
   replayData: MultimediaData | undefined;
   setReplayData: Dispatch<SetStateAction<MultimediaData | undefined>>;
@@ -53,6 +54,7 @@ const ProjectContext = createContext<ProjectContextProps>({
   projectState: defaultProjectState,
   deviceSettings: defaultDeviceSettings,
   project,
+  isExpoRouterProject: false,
   hasActiveLicense: false,
   replayData: undefined,
   setReplayData: () => {},
@@ -61,6 +63,7 @@ const ProjectContext = createContext<ProjectContextProps>({
 export default function ProjectProvider({ children }: PropsWithChildren) {
   const [projectState, setProjectState] = useState<ProjectState>(defaultProjectState);
   const [deviceSettings, setDeviceSettings] = useState<DeviceSettings>(defaultDeviceSettings);
+  const [isExpoRouterProject, setIsExpoRouterProject] = useState(false);
   const [hasActiveLicense, setHasActiveLicense] = useState(true);
   const [replayData, setReplayData] = useState<MultimediaData | undefined>(undefined);
 
@@ -82,16 +85,29 @@ export default function ProjectProvider({ children }: PropsWithChildren) {
     };
   }, []);
 
+  useEffect(() => {
+    project.usesExpoRouter().then(setIsExpoRouterProject);
+  }, [projectState.appRootPath]);
+
   const contextValue = useMemo(() => {
     return {
       projectState,
       deviceSettings,
       project,
+      isExpoRouterProject,
       hasActiveLicense,
       replayData,
       setReplayData,
     };
-  }, [projectState, deviceSettings, project, hasActiveLicense, replayData, setReplayData]);
+  }, [
+    projectState,
+    deviceSettings,
+    project,
+    isExpoRouterProject,
+    hasActiveLicense,
+    replayData,
+    setReplayData,
+  ]);
 
   return <ProjectContext.Provider value={contextValue}>{children}</ProjectContext.Provider>;
 }


### PR DESCRIPTION
This PR introduces a new `isExpoRouterProject` field in the `ProjectProvider` context value, which indicates if the currently running app uses Expo Router for navigation, and updates each time the `appRoot` changes.

This allows the webview components to reliably depend on Expo Router availability, especially in monorepo projects, where some apps can use different navigation solutions.

The change was motivated mainly by the navigation bar breaking if the `appRoot` was switched from an Expo Router app to a non-Expo one and vice versa, as the dependency check was performed only on component mount.

### How Has This Been Tested: 
1. Open a folder with more than one React Native app, e.g. [radon-ide-test-apps](https://github.com/software-mansion-labs/radon-ide-test-apps)
2. Launch the IDE panel and open an app with Expo Router - the navigation bar has full functionality
3. Change the app to a bare RN one with the `AppRootSelect` - the navbar switches to dropdown mode and disables the back button
4. Switch back to the ER app - appropriate functions are enabled again


