### PR TITLE
Fix dependency checks for multi-app projects

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -32,10 +32,25 @@ import { isEasCliInstalled } from "../builders/easCommand";
 import { getMinimumSupportedNodeVersion } from "../utilities/getMinimumSupportedNodeVersion";
 
 export class DependencyManager implements Disposable, DependencyManagerInterface {
-  constructor(private readonly appRootFolder: string) {}
+  private _appRootFolder: string;
   // React Native prepares build scripts based on node_modules, we need to reinstall pods if they change
   private eventEmitter = new EventEmitter();
   private packageManagerInternal: PackageManagerInfo | undefined;
+
+  constructor(appRootFolder: string) {
+    this._appRootFolder = appRootFolder;
+  }
+
+  get appRootFolder() {
+    return this._appRootFolder;
+  }
+
+  set appRootFolder(newRoot: string) {
+    if (this._appRootFolder !== newRoot) {
+      this._appRootFolder = newRoot;
+      this.packageManagerInternal = undefined;
+    }
+  }
 
   public dispose() {
     this.eventEmitter.removeAllListeners();

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -14,10 +14,23 @@ export class ApplicationContext implements Disposable {
     this.dependencyManager = new DependencyManager(appRootFolder);
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
-
     this.buildCache = new BuildCache(appRootFolder);
 
     this.disposables.push(this.launchConfig, this.dependencyManager);
+  }
+
+  public async updateAppRootFolder(newAppRoot: string) {
+    if (this.appRootFolder === newAppRoot) {
+      return;
+    }
+
+    this.appRootFolder = newAppRoot;
+    this.dependencyManager.appRootFolder = newAppRoot;
+
+    await this.dependencyManager.runAllDependencyChecks();
+
+    this.launchConfig = new LaunchConfigController(newAppRoot);
+    this.buildCache = new BuildCache(newAppRoot);
   }
 
   public dispose() {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -137,15 +137,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     return this.applicationContext.buildCache;
   }
 
-  private setupAppRoot() {
+  private async setupAppRoot() {
     const newAppRoot = findAndSetupNewAppRootFolder();
     if (newAppRoot === this.appRootFolder) {
       return;
     }
-
-    const oldApplicationContext = this.applicationContext;
-    this.applicationContext = new ApplicationContext(newAppRoot);
-    oldApplicationContext.dispose();
+    await this.applicationContext.updateAppRootFolder(newAppRoot);
 
     const oldDeviceSessionsManager = this.deviceSessionsManager;
     this.deviceSessionsManager = new DeviceSessionsManager(


### PR DESCRIPTION
This PR changes the `DependencyManager` class to support changing the `appRootFolder` without recreating the instance, fixing the problem where the webview didn't notice dependency changes when switching between apps in monorepos.

This caused bugs with navigation and with UI elements relying on certain dependencies' availability, incorrect results on the "Run diagnostics" screen, and probably more issues we haven't discovered yet.

### How Has This Been Tested: 
Check if the discovered bugs were fixed:
1. Open a folder with more than one React Native app, e.g. [radon-ide-test-apps](https://github.com/software-mansion-labs/radon-ide-test-apps)
2. Launch the IDE panel and open an app with Expo Router - the navigation bar has full functionality, and the Diagnostics screen shows Expo/Router is available
3. Change the app to a bare RN one with the `AppRootSelect` - the navbar switches to dropdown mode and disables the back button, and now there's an "X" next to Expo and Expo Router on the Diagnostics screen
4. Switch back to the ER app - appropriate functions are enabled again

