### PR TITLE
add option to select camera output for android emulator

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -15,6 +15,10 @@ export type DeviceSettings = {
   locale: Locale;
   replaysEnabled: boolean;
   showTouches: boolean;
+  camera: {
+    back: "emulated" | "none" | "webcam0" | "virtualscene";
+    front: "emulated" | "none" | "webcam0";
+  };
 };
 
 export type ToolState = {

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -29,6 +29,10 @@ export const DEVICE_SETTINGS_DEFAULT: DeviceSettings = {
   locale: "en_US",
   replaysEnabled: false,
   showTouches: false,
+  camera: {
+    back: "virtualscene",
+    front: "emulated",
+  },
 };
 
 export abstract class DeviceBase implements Disposable {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -148,6 +148,9 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             Location
           </DropdownMenu.Item>
           <LocalizationItem />
+          {selectedDeviceSession?.deviceInfo.platform === DevicePlatform.Android && (
+            <CameraItem />
+          )}
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
               <span className="codicon codicon-redo" />
@@ -307,6 +310,101 @@ const BiometricsItem = () => {
             label="Non-Matching ID"
             icon="layout-sidebar-left"
           />
+        </DropdownMenu.SubContent>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Sub>
+  );
+};
+
+const CameraItem = () => {
+  const { project, deviceSettings } = useProject();
+
+  const backCameraOptions = [
+    { label: "Emulated", value: "emulated" },
+    { label: "Virtual Scene", value: "virtualscene" },
+    { label: "Webcam", value: "webcam0" },
+    { label: "None", value: "none" },
+  ];
+
+  const frontCameraOptions = [
+    { label: "Emulated", value: "emulated" },
+    { label: "Webcam", value: "webcam0" },
+    { label: "None", value: "none" },
+  ];
+
+  return (
+    <DropdownMenu.Sub>
+      <DropdownMenu.SubTrigger className="dropdown-menu-item">
+        <span className="codicon codicon-camera" />
+        Camera Settings
+        <span className="codicon codicon-chevron-right right-slot" />
+      </DropdownMenu.SubTrigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.SubContent className="dropdown-menu-subcontent">
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger className="dropdown-menu-item">
+              <span className="codicon codicon-camera" />
+              Back Camera: {backCameraOptions.find(opt => opt.value === deviceSettings.camera.back)?.label}
+              <span className="codicon codicon-chevron-right right-slot" />
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent className="dropdown-menu-subcontent" sideOffset={2} alignOffset={-5}>
+                {backCameraOptions.map((option) => (
+                  <DropdownMenu.Item
+                    key={option.value}
+                    className="dropdown-menu-item"
+                    onSelect={() => {
+                      project.updateDeviceSettings({
+                        ...deviceSettings,
+                        camera: {
+                          ...deviceSettings.camera,
+                          back: option.value as DeviceSettings["camera"]["back"],
+                        },
+                      });
+                    }}>
+                    <span className="codicon codicon-camera" />
+                    {option.label}
+                    {deviceSettings.camera.back === option.value && (
+                      <span className="codicon codicon-check right-slot" />
+                    )}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
+          
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger className="dropdown-menu-item">
+              <span className="codicon codicon-camera" />
+              Front Camera: {frontCameraOptions.find(opt => opt.value === deviceSettings.camera.front)?.label}
+              <span className="codicon codicon-chevron-right right-slot" />
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.SubContent className="dropdown-menu-subcontent" sideOffset={2} alignOffset={-5}>
+                {frontCameraOptions.map((option) => (
+                  <DropdownMenu.Item
+                    key={option.value}
+                    className="dropdown-menu-item"
+                    onSelect={() => {
+                      project.updateDeviceSettings({
+                        ...deviceSettings,
+                        camera: {
+                          ...deviceSettings.camera,
+                          front: option.value as DeviceSettings["camera"]["front"],
+                        },
+                      });
+                    }}>
+                    <span className="codicon codicon-camera" />
+                    {option.label}
+                    {deviceSettings.camera.front === option.value && (
+                      <span className="codicon codicon-check right-slot" />
+                    )}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.SubContent>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Sub>
         </DropdownMenu.SubContent>
       </DropdownMenu.Portal>
     </DropdownMenu.Sub>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -20,6 +20,7 @@ import { DevicePlatform } from "../../common/DeviceManager";
 import { KeybindingInfo } from "./shared/KeybindingInfo";
 import { DeviceLocalizationView } from "../views/DeviceLocalizationView";
 import { OpenDeepLinkView } from "../views/OpenDeepLinkView";
+import { CameraSettingsView } from "../views/CameraSettingsView";
 import ReplayIcon from "./icons/ReplayIcon";
 import { DropdownMenuRoot } from "./DropdownMenuRoot";
 
@@ -317,97 +318,17 @@ const BiometricsItem = () => {
 };
 
 const CameraItem = () => {
-  const { project, deviceSettings } = useProject();
-
-  const backCameraOptions = [
-    { label: "Emulated", value: "emulated" },
-    { label: "Virtual Scene", value: "virtualscene" },
-    { label: "Webcam", value: "webcam0" },
-    { label: "None", value: "none" },
-  ];
-
-  const frontCameraOptions = [
-    { label: "Emulated", value: "emulated" },
-    { label: "Webcam", value: "webcam0" },
-    { label: "None", value: "none" },
-  ];
-
+  const { openModal } = useModal();
+  
   return (
-    <DropdownMenu.Sub>
-      <DropdownMenu.SubTrigger className="dropdown-menu-item">
-        <span className="codicon codicon-camera" />
-        Camera Settings
-        <span className="codicon codicon-chevron-right right-slot" />
-      </DropdownMenu.SubTrigger>
-
-      <DropdownMenu.Portal>
-        <DropdownMenu.SubContent className="dropdown-menu-subcontent">
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger className="dropdown-menu-item">
-              <span className="codicon codicon-camera" />
-              Back Camera: {backCameraOptions.find(opt => opt.value === deviceSettings.camera.back)?.label}
-              <span className="codicon codicon-chevron-right right-slot" />
-            </DropdownMenu.SubTrigger>
-            <DropdownMenu.Portal>
-              <DropdownMenu.SubContent className="dropdown-menu-subcontent" sideOffset={2} alignOffset={-5}>
-                {backCameraOptions.map((option) => (
-                  <DropdownMenu.Item
-                    key={option.value}
-                    className="dropdown-menu-item"
-                    onSelect={() => {
-                      project.updateDeviceSettings({
-                        ...deviceSettings,
-                        camera: {
-                          ...deviceSettings.camera,
-                          back: option.value as DeviceSettings["camera"]["back"],
-                        },
-                      });
-                    }}>
-                    <span className="codicon codicon-camera" />
-                    {option.label}
-                    {deviceSettings.camera.back === option.value && (
-                      <span className="codicon codicon-check right-slot" />
-                    )}
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Portal>
-          </DropdownMenu.Sub>
-          
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger className="dropdown-menu-item">
-              <span className="codicon codicon-camera" />
-              Front Camera: {frontCameraOptions.find(opt => opt.value === deviceSettings.camera.front)?.label}
-              <span className="codicon codicon-chevron-right right-slot" />
-            </DropdownMenu.SubTrigger>
-            <DropdownMenu.Portal>
-              <DropdownMenu.SubContent className="dropdown-menu-subcontent" sideOffset={2} alignOffset={-5}>
-                {frontCameraOptions.map((option) => (
-                  <DropdownMenu.Item
-                    key={option.value}
-                    className="dropdown-menu-item"
-                    onSelect={() => {
-                      project.updateDeviceSettings({
-                        ...deviceSettings,
-                        camera: {
-                          ...deviceSettings.camera,
-                          front: option.value as DeviceSettings["camera"]["front"],
-                        },
-                      });
-                    }}>
-                    <span className="codicon codicon-camera" />
-                    {option.label}
-                    {deviceSettings.camera.front === option.value && (
-                      <span className="codicon codicon-check right-slot" />
-                    )}
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.SubContent>
-            </DropdownMenu.Portal>
-          </DropdownMenu.Sub>
-        </DropdownMenu.SubContent>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Sub>
+    <DropdownMenu.Item
+      className="dropdown-menu-item"
+      onSelect={() => {
+        openModal("Camera Settings", <CameraSettingsView />);
+      }}>
+      <span className="codicon codicon-camera" />
+      Camera Settings
+    </DropdownMenu.Item>
   );
 };
 

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -326,7 +326,7 @@ const CameraItem = () => {
       onSelect={() => {
         openModal("Camera Settings", <CameraSettingsView />);
       }}>
-      <span className="codicon codicon-camera" />
+      <span className="codicon codicon-device-camera" />
       Camera Settings
     </DropdownMenu.Item>
   );

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -49,6 +49,10 @@ const defaultDeviceSettings: DeviceSettings = {
   locale: "en_US",
   replaysEnabled: false,
   showTouches: false,
+  camera: {
+    back: "virtualscene",
+    front: "emulated",
+  },
 };
 
 const ProjectContext = createContext<ProjectContextProps>({

--- a/packages/vscode-extension/src/webview/views/CameraSettingsView.css
+++ b/packages/vscode-extension/src/webview/views/CameraSettingsView.css
@@ -1,0 +1,106 @@
+.camera-settings-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 300px;
+}
+
+.camera-settings-content {
+  flex: 1;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.camera-setting-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.camera-setting-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--vscode-foreground);
+}
+
+.camera-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background-color: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  border: 1px solid var(--vscode-dropdown-border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  min-width: 200px;
+  transition: background-color 0.1s;
+}
+
+.camera-dropdown-trigger:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.camera-dropdown-trigger:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.camera-settings-footer {
+  padding: 20px;
+  border-top: 1px solid var(--vscode-widget-border);
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* Confirmation view styles */
+.camera-change-wrapper {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 400px;
+}
+
+.camera-change-title {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--vscode-foreground);
+  margin: 0;
+}
+
+.camera-change-subtitle {
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+  margin: 0;
+}
+
+.camera-change-details {
+  background-color: var(--vscode-textBlockQuote-background);
+  border-left: 3px solid var(--vscode-textBlockQuote-border);
+  padding: 12px 16px;
+  border-radius: 4px;
+}
+
+.camera-change-details p {
+  margin: 4px 0;
+  font-size: 13px;
+}
+
+.camera-change-details strong {
+  color: var(--vscode-foreground);
+}
+
+.camera-change-button-group {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.camera-change-button {
+  min-width: 100px;
+} 

--- a/packages/vscode-extension/src/webview/views/CameraSettingsView.tsx
+++ b/packages/vscode-extension/src/webview/views/CameraSettingsView.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+import { useProject } from "../providers/ProjectProvider";
+import { useModal } from "../providers/ModalProvider";
+import { DeviceSettings } from "../../common/Project";
+import Button from "../components/shared/Button";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import "../components/shared/Dropdown.css";
+import "./CameraSettingsView.css";
+
+const backCameraOptions = [
+  { label: "Emulated", value: "emulated" },
+  { label: "Virtual Scene", value: "virtualscene" },
+  { label: "Webcam", value: "webcam0" },
+  { label: "None", value: "none" },
+];
+
+const frontCameraOptions = [
+  { label: "Emulated", value: "emulated" },
+  { label: "Webcam", value: "webcam0" },
+  { label: "None", value: "none" },
+];
+
+export function CameraSettingsView() {
+  const { deviceSettings } = useProject();
+  const { openModal } = useModal();
+  
+  const [selectedBackCamera, setSelectedBackCamera] = useState(deviceSettings.camera.back);
+  const [selectedFrontCamera, setSelectedFrontCamera] = useState(deviceSettings.camera.front);
+
+  const handleApplyChanges = () => {
+    if (selectedBackCamera !== deviceSettings.camera.back || selectedFrontCamera !== deviceSettings.camera.front) {
+      openModal("", <CameraChangeConfirmationView 
+        backCamera={selectedBackCamera} 
+        frontCamera={selectedFrontCamera} 
+      />);
+    }
+  };
+
+  return (
+    <div className="camera-settings-container">
+      <div className="camera-settings-content">
+        <div className="camera-setting-group">
+          <label className="camera-setting-label">Back Camera</label>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="camera-dropdown-trigger">
+              <span>{backCameraOptions.find(opt => opt.value === selectedBackCamera)?.label}</span>
+              <span className="codicon codicon-chevron-down" />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className="dropdown-menu-content">
+                {backCameraOptions.map((option) => (
+                  <DropdownMenu.Item
+                    key={option.value}
+                    className="dropdown-menu-item"
+                    onSelect={() => setSelectedBackCamera(option.value as DeviceSettings["camera"]["back"])}>
+                    {option.label}
+                    {selectedBackCamera === option.value && (
+                      <span className="codicon codicon-check right-slot" />
+                    )}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        </div>
+
+        <div className="camera-setting-group">
+          <label className="camera-setting-label">Front Camera</label>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger className="camera-dropdown-trigger">
+              <span>{frontCameraOptions.find(opt => opt.value === selectedFrontCamera)?.label}</span>
+              <span className="codicon codicon-chevron-down" />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content className="dropdown-menu-content">
+                {frontCameraOptions.map((option) => (
+                  <DropdownMenu.Item
+                    key={option.value}
+                    className="dropdown-menu-item"
+                    onSelect={() => setSelectedFrontCamera(option.value as DeviceSettings["camera"]["front"])}>
+                    {option.label}
+                    {selectedFrontCamera === option.value && (
+                      <span className="codicon codicon-check right-slot" />
+                    )}
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
+        </div>
+      </div>
+
+      <div className="camera-settings-footer">
+        <Button 
+          type="primary" 
+          onClick={handleApplyChanges}
+          disabled={selectedBackCamera === deviceSettings.camera.back && selectedFrontCamera === deviceSettings.camera.front}>
+          Apply Changes
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type CameraChangeConfirmationViewProps = {
+  backCamera: string;
+  frontCamera: string;
+};
+
+const CameraChangeConfirmationView = ({
+  backCamera,
+  frontCamera,
+}: CameraChangeConfirmationViewProps) => {
+  const { openModal, closeModal } = useModal();
+  const { project, deviceSettings } = useProject();
+
+  const onCancel = () => {
+    openModal("Camera Settings", <CameraSettingsView />);
+  };
+
+  return (
+    <div className="camera-change-wrapper">
+      <h2 className="camera-change-title">
+        Confirm Camera Settings Change
+      </h2>
+      <p className="camera-change-subtitle">
+        Changing camera settings will require a device reboot to take effect.
+      </p>
+      <div className="camera-change-details">
+        <p><strong>Back Camera:</strong> {backCameraOptions.find(opt => opt.value === backCamera)?.label}</p>
+        <p><strong>Front Camera:</strong> {frontCameraOptions.find(opt => opt.value === frontCamera)?.label}</p>
+      </div>
+      <div className="camera-change-button-group">
+        <Button type="secondary" className="camera-change-button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          className="camera-change-button"
+          type="ternary"
+          onClick={async () => {
+            project.updateDeviceSettings({
+              ...deviceSettings,
+              camera: {
+                back: backCamera as DeviceSettings["camera"]["back"],
+                front: frontCamera as DeviceSettings["camera"]["front"],
+              },
+            });
+            closeModal();
+          }}>
+          Confirm and Reboot
+        </Button>
+      </div>
+    </div>
+  );
+}; 


### PR DESCRIPTION
Adds an option to the device dropdown menu to select camera. Works only for Android

Fixes #1242 

### How Has This Been Tested: 

No testing, could not find clear instructions on how to build. Tried, failed. Requires testing


