### PR TITLE
Fix webview showing crashed preview

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -445,6 +445,9 @@ export class DeviceSession
     const cancelToken = new CancelToken();
     this.cancelToken = cancelToken;
 
+    this.status = "starting";
+    this.updateStartupMessage(StartupMessage.InitializingDevice);
+
     if (cleanCache) {
       const oldDevtools = this.devtools;
       const oldMetro = this.metro;


### PR DESCRIPTION
This PR solves an issue with with webview showing crashed preview state in the following scenario: 

1) run application 
2) when on "waiting for an app to load" screen click on the device to show preview
3) when app loads use restart option for example "clean metro cache" 
4) now you should see crashed preview 

this was happening because we changed the device status only when the build started and not limitedly after restart this pr fixes that 

### How Has This Been Tested: 

run reproduction steps on `expo-53`


