### PR TITLE
add keyboard shortcuts for quickly switching running devices

### DIFF
--- a/packages/docs/docs/guides/keyboard-shortcuts.md
+++ b/packages/docs/docs/guides/keyboard-shortcuts.md
@@ -6,15 +6,17 @@ sidebar_position: 4
 
 Radon IDE lets you perform some repetitive actions through keyboard shortcuts.
 
-| Result                                 | macOS                 | Windows             |
-| -------------------------------------- | --------------------- | ------------------- |
-| Open developer menu                    | Command + Control + Z | Control + Alt + Z   |
-| Capture replay                         | Command + Shift + R   | Control + Shift + R |
-| Toggle recording                       | Command + Shift + E   | Control + Shift + E |
-| Capture screenshot                     | Command + Shift + A   | Control + Shift + A |
-| Perform biometric authorization        | Command + Shift + M   | Control + Shift + M |
+| Result                                 | macOS                 | Windows              |
+| -------------------------------------- | --------------------- | -------------------- |
+| Open developer menu                    | Command + Control + Z | Control + Alt + Z    |
+| Capture replay                         | Command + Shift + R   | Control + Shift + R  |
+| Toggle recording                       | Command + Shift + E   | Control + Shift + E  |
+| Capture screenshot                     | Command + Shift + A   | Control + Shift + A  |
+| Perform biometric authorization        | Command + Shift + M   | Control + Shift + M  |
 | Perform failed biometric authorization | Option + Command + Shift + M   | Control + Alt + Shift + M |
-| Close IDE Panel with confirmation      | Command + W           | Control + W         |
+| Close IDE Panel with confirmation      | Command + W           | Control + W          |
+| Switch to next running device          | Command + Shift + \]  | Control + Shift + \] |
+| Switch to previous running device      | Command + Shift + \[  | Control + Shift + \[ |
 
 ## Customize shortcuts
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -116,6 +116,18 @@
         "title": "Chat with Radon AI",
         "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
+      },
+      {
+        "command": "RNIDE.nextRunningDevice",
+        "title": "Switch to next running device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
+      },
+      {
+        "command": "RNIDE.previousRunningDevice",
+        "title": "Switch to previous running device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
       }
     ],
     "keybindings": [
@@ -159,6 +171,16 @@
         "command": "RNIDE.captureScreenshot",
         "key": "ctrl+shift+A",
         "mac": "cmd+shift+A"
+      },
+      {
+        "command": "RNIDE.nextRunningDevice",
+        "key": "ctrl+shift+]",
+        "mac": "cmd+shift+]"
+      },
+      {
+        "command": "RNIDE.previousRunningDevice",
+        "key": "ctrl+shift+[",
+        "mac": "cmd+shift+["
       }
     ],
     "configuration": {

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -223,21 +223,21 @@ export class ProxyDebugAdapter extends DebugSession {
     args: DebugProtocol.DisconnectArguments,
     request?: DebugProtocol.Request
   ) {
-    this.terminate();
+    await this.terminate();
     // since the application resumes once the debugger is disconnected, we need to send a continued event
     // to the frontend to update the UI
     this.sendEvent(new Event("RNIDE_continued"));
     this.sendResponse(response);
   }
 
-  private terminate() {
+  private async terminate() {
     if (this.terminated) {
       return;
     }
     this.terminated = true;
-    this.cdpProxy.stopServer();
+    await this.cdpProxy.stopServer();
     disposeAll(this.disposables);
-    vscode.commands.executeCommand("workbench.action.debug.stop", undefined, {
+    await vscode.commands.executeCommand("workbench.action.debug.stop", undefined, {
       sessionId: this.session.id,
     });
   }

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -17,7 +17,7 @@ import { disposeAll } from "../utilities/disposables";
 import { DeviceId, DeviceSessionsManagerState } from "../common/Project";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
-const SWITCH_DEVICE_THROTTLE_MS = 300;
+const SWITCH_DEVICE_THROTTLE_MS = 500;
 
 export type DeviceSessionsManagerDelegate = {
   onInitialized(): void;

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -1,4 +1,5 @@
 import { commands, Disposable, window } from "vscode";
+import _ from "lodash";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
 import { Logger } from "../Logger";
@@ -16,6 +17,7 @@ import { disposeAll } from "../utilities/disposables";
 import { DeviceId, DeviceSessionsManagerState } from "../common/Project";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
+const SWITCH_DEVICE_THROTTLE_MS = 300;
 
 export type DeviceSessionsManagerDelegate = {
   onInitialized(): void;
@@ -38,11 +40,15 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.addListener("devicesChanged", this.devicesChangedListener);
     this.disposables.push(
-      commands.registerCommand("RNIDE.nextRunningDevice", () => this.selectNextNthRunningSession(1))
+      commands.registerCommand(
+        "RNIDE.nextRunningDevice",
+        _.throttle(() => this.selectNextNthRunningSession(1), SWITCH_DEVICE_THROTTLE_MS)
+      )
     );
     this.disposables.push(
-      commands.registerCommand("RNIDE.previousRunningDevice", () =>
-        this.selectNextNthRunningSession(-1)
+      commands.registerCommand(
+        "RNIDE.previousRunningDevice",
+        _.throttle(() => this.selectNextNthRunningSession(-1), SWITCH_DEVICE_THROTTLE_MS)
       )
     );
   }


### PR DESCRIPTION
Adds vscode commands and keyboard shortcuts for quickly switching between running devices.
- "Cmd + Shift + ]" switches to the next running device
- "Cmd + Shift + [" switches to the previous running device

### Known issues:
- holding the shortcut causes the devices to be switched rapidly, extra debug consoles appear (#1254)

### How Has This Been Tested: 
- open a project in radon
- launch multiple devices at the same time
- check the keyboard shortcuts work