### PR TITLE
fix last selected session saved incorrectly workspace state

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -193,6 +193,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     }
     previousSession?.deactivate();
     session.activate();
+    extensionContext.workspaceState.update(LAST_SELECTED_DEVICE_KEY, this.activeSessionId);
     this.deviceSessionManagerDelegate.onDeviceSessionsManagerStateChange(this.state);
   }
 
@@ -220,7 +221,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
 
     if (device) {
       Logger.debug("Device selected", deviceInfo.displayName);
-      extensionContext.workspaceState.update(LAST_SELECTED_DEVICE_KEY, deviceInfo.id);
       return device;
     }
     return undefined;


### PR DESCRIPTION
Previously we saved the last selected session when we started a device instead of when switching. After #1231 this means the device that launches after restarting the IDE might be different from the one that was last shown.
This PR changes the behaviour to instead save the last selected device whenever a device is selected.

### How Has This Been Tested: 
- launch Radon with "Shut down devices when switching" turned off
- start a device
- start a second device
- switch back to the first device
- restart Radon
- the first device should start automatically (previously, the second device would)