### PR TITLE
fix "shut down devices" toggle not responding on first click

### DIFF
--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -34,7 +34,7 @@ export class WorkspaceConfigController implements Disposable, WorkspaceConfig {
         panelLocation: config.get<PanelLocation>("panelLocation")!,
         showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
         themeType: config.get<ThemeType>("themeType")!,
-        stopPreviousDevices: configuration.get<boolean>("stopPreviousDevices")!,
+        stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
       };
 
       if (newConfig.panelLocation !== this.config.panelLocation) {


### PR DESCRIPTION
When toggling the "Shut down devices when switching" switch  for the first time, it would not visually change until a second press.
This was due to a typo, where the config reported by the `"configChange"` event used the value initially loaded by the extension instead of the current one.

### How Has This Been Tested: 
- go to "Manage Devices"
- toggle the switch
- the switch should visually toggle
- the behaviour should match the visual state of the switch



