### PR TITLE
fix command registration causing the IDE to not reopen correctly

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -216,6 +216,16 @@ export async function activate(context: ExtensionContext) {
   );
   context.subscriptions.push(commands.registerCommand("RNIDE.openChat", openChat));
 
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.nextRunningDevice", () =>
+      IDE.getInstanceIfExists()?.project.deviceSessionsManager.selectNextNthRunningSession(1)
+    )
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.previousRunningDevice", () =>
+      IDE.getInstanceIfExists()?.project.deviceSessionsManager.selectNextNthRunningSession(-1)
+    )
+  );
   // Debug adapter used by custom launch configuration, we register it in case someone tries to run the IDE configuration
   // The current workflow is that people shouldn't run it, but since it is listed under launch options it might happen
   // When it does happen, we open the IDE panel and restart the app.

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -29,8 +29,11 @@ export class ApplicationContext implements Disposable {
 
     await this.dependencyManager.runAllDependencyChecks();
 
+    disposeAll(this.disposables);
+
     this.launchConfig = new LaunchConfigController(newAppRoot);
     this.buildCache = new BuildCache(newAppRoot);
+    this.disposables.push(this.launchConfig, this.dependencyManager);
   }
 
   public dispose() {

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -1,4 +1,4 @@
-import { commands, Disposable, window } from "vscode";
+import { Disposable, window } from "vscode";
 import _ from "lodash";
 import { DeviceInfo, DevicePlatform } from "../common/DeviceManager";
 import { DeviceAlreadyUsedError, DeviceManager } from "../devices/DeviceManager";
@@ -32,7 +32,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
   private activeSessionId: DeviceId | undefined;
   private findingDevice: boolean = false;
   private previousDevices: DeviceInfo[] = [];
-  private disposables: Disposable[] = [];
 
   constructor(
     private readonly applicationContext: ApplicationContext,
@@ -42,14 +41,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     this.findInitialDeviceAndStartSession();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.addListener("devicesChanged", this.devicesChangedListener);
-    this.disposables.push(
-      commands.registerCommand("RNIDE.nextRunningDevice", () => this.selectNextNthRunningSession(1))
-    );
-    this.disposables.push(
-      commands.registerCommand("RNIDE.previousRunningDevice", () =>
-        this.selectNextNthRunningSession(-1)
-      )
-    );
   }
 
   public get selectedDeviceSession(): DeviceSession | undefined {
@@ -271,7 +262,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     return undefined;
   }
 
-  private selectNextNthRunningSession = _.throttle((offset: number) => {
+  public selectNextNthRunningSession = _.throttle((offset: number) => {
     const runningSessions = this.deviceSessions.keys().toArray();
     const currentSessionIndex =
       this.activeSessionId !== undefined ? runningSessions.indexOf(this.activeSessionId) : -offset;
@@ -281,7 +272,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
   }, SWITCH_DEVICE_THROTTLE_MS);
 
   dispose() {
-    disposeAll(this.disposables);
     disposeAll(this.deviceSessions.values().toArray());
     this.deviceManager.removeListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.removeListener("devicesChanged", this.devicesChangedListener);


### PR DESCRIPTION
Fixes a bug introduced in #1247 caused by registering vscode commands multiple times (in the ctor of `DeviceSessionsManager`, which is not a singleton) which broke the AppRoot switcher and broke the IDE tab when closing and reopening

### How Has This Been Tested: 
- just switch an app
- or reopen the radon tab