### PR TITLE
only enable device switching shortcut when the Preview is focused

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -121,13 +121,13 @@
         "command": "RNIDE.nextRunningDevice",
         "title": "Switch to next running device",
         "category": "Radon IDE",
-        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && RNIDE.isPreviewFocused"
       },
       {
         "command": "RNIDE.previousRunningDevice",
         "title": "Switch to previous running device",
         "category": "Radon IDE",
-        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && RNIDE.isPreviewFocused"
       }
     ],
     "keybindings": [

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -82,6 +82,10 @@ export class WebviewController implements Disposable {
 
         if (message.command === "call") {
           this.handleRemoteCall(message);
+        } else if (message.command === "focusPreview") {
+          commands.executeCommand("setContext", "RNIDE.isPreviewFocused", true);
+        } else if (message.command === "blurPreview") {
+          commands.executeCommand("setContext", "RNIDE.isPreviewFocused", false);
         }
       },
       undefined,

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -29,6 +29,7 @@ import RecordingIcon from "../components/icons/RecordingIcon";
 import { ActivateLicenseView } from "./ActivateLicenseView";
 import ToolsDropdown from "../components/ToolsDropdown";
 import AppRootSelect from "../components/AppRootSelect";
+import { vscode } from "../utilities/vscode";
 
 function ActivateLicenseButton() {
   const { openModal } = useModal();
@@ -198,7 +199,18 @@ function PreviewView() {
     .padStart(2, "0")}`;
 
   return (
-    <div className="panel-view">
+    <div
+      className="panel-view"
+      onFocus={(e) => {
+        vscode.postMessage({
+          command: "focusPreview",
+        });
+      }}
+      onBlur={(e) => {
+        vscode.postMessage({
+          command: "blurPreview",
+        });
+      }}>
       <div className="button-group-top">
         <div className="button-group-top-left">
           <UrlBar disabled={hasNoDevices} />


### PR DESCRIPTION
- sets the extension context whenever the Radon panel is focused/blurred
- only enables the device switching shortcut when the Radon panel is focused

### How Has This Been Tested: 
- start multiple devices
- focus on the Radon panel
- "Cmd+Shift+]" should switch between running devices
- focus on an editor with multiple open tabs
- "Cmd+Shift+]" should switch between editor tabs (unless unset)



