### PR TITLE
Fix Radon showing dead preview after bundle error and "Reload IDE"

### DIFF
--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -47,8 +47,8 @@ export abstract class BaseInspectorBridge implements RadonInspectorBridge {
     // We need to clone the listeners array to avoid issues with concurrent modifications
     // it is a common pattern to create listeners that dispose themselves which could lead to
     // issues if we modify the array while iterating over it.
-    const listenersIterable = [...listeners];
-    listenersIterable.forEach((listener) => {
+    const listenersCopy = [...listeners];
+    listenersCopy.forEach((listener) => {
       try {
         listener(payload);
       } catch (error) {

--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -45,9 +45,9 @@ export abstract class BaseInspectorBridge implements RadonInspectorBridge {
     }
 
     // We need to clone the listeners array to avoid issues with concurrent modifications
-    // it is a common pattern to create listeners that dispose themselves which could lead to 
+    // it is a common pattern to create listeners that dispose themselves which could lead to
     // issues if we modify the array while iterating over it.
-    const listenersIterable = [...listeners]
+    const listenersIterable = [...listeners];
     listenersIterable.forEach((listener) => {
       try {
         listener(payload);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -68,8 +68,7 @@ export class DeviceBootError extends Error {
 }
 
 export class DeviceSession
-  implements Disposable, MetroDelegate, ToolsDelegate, DebugSessionDelegate, BuildManagerDelegate
-{
+  implements Disposable, MetroDelegate, ToolsDelegate, DebugSessionDelegate, BuildManagerDelegate {
   private isActive = false;
   private metro: MetroLauncher;
   private toolsManager: ToolsManager;
@@ -568,8 +567,6 @@ export class DeviceSession
   }
 
   private async launchApp(cancelToken: CancelToken) {
-    cancelToken.cancel();
-
     const launchRequestTime = Date.now();
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
       platform: this.device.platform,
@@ -579,7 +576,7 @@ export class DeviceSession
     // seems like a problem with app connecting to Metro and using embedded
     // bundle instead.
     const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
-    const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
+    const waitForAppReady = shouldWaitForAppLaunch ? cancelToken.adapt(this.devtools.appReady()) : Promise.resolve();
 
     this.updateStartupMessage(StartupMessage.Launching);
     await cancelToken.adapt(

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -68,7 +68,8 @@ export class DeviceBootError extends Error {
 }
 
 export class DeviceSession
-  implements Disposable, MetroDelegate, ToolsDelegate, DebugSessionDelegate, BuildManagerDelegate {
+  implements Disposable, MetroDelegate, ToolsDelegate, DebugSessionDelegate, BuildManagerDelegate
+{
   private isActive = false;
   private metro: MetroLauncher;
   private toolsManager: ToolsManager;
@@ -576,7 +577,7 @@ export class DeviceSession
     // seems like a problem with app connecting to Metro and using embedded
     // bundle instead.
     const shouldWaitForAppLaunch = getLaunchConfiguration().preview?.waitForAppLaunch !== false;
-    const waitForAppReady = shouldWaitForAppLaunch ? cancelToken.adapt(this.devtools.appReady()) : Promise.resolve();
+    const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
     this.updateStartupMessage(StartupMessage.Launching);
     await cancelToken.adapt(


### PR DESCRIPTION
This PR fixes an issue introduces after abstracting inspector bridge interface in #1180. In this PR we moved on from `addListener` `removeListener` pattern to `disposable` one. The new implementation assumed that the listeners array for one event would not change when they were called, which caused some of the listeners to be ignored if the ones defined before them were removed before the end of the iteration. 

This caused problems with `waitForAppReady` promisees not being resolved which caused debbuger not attaching and the problem with Reloading the ide. 

### How Has This Been Tested: 

I run the following reproduction steps on `expo-53` test app:
- run app 
- cause bundle error 
- click on realod button a few times 
- fix the bundle error 
- reload 
- use "Reboot IDE" option 



