### PR TITLE
stop device session before removing the device

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -301,6 +301,7 @@ export class DeviceSession
   build in vscode dispose system ignores async keyword and works synchronously.
   */
   public async dispose() {
+    this.cancelToken?.cancel();
     await this.deactivate();
     await this.debugSession?.dispose();
     this.disposableBuild?.dispose();

--- a/packages/vscode-extension/src/webview/components/DeviceRemovalConfirmation.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceRemovalConfirmation.tsx
@@ -14,7 +14,7 @@ function DeviceRemovalConfirmation({
 }) {
   const [loading, setLoading] = useState(false);
 
-  const { deviceManager } = useDevices();
+  const { deviceManager, deviceSessionsManager } = useDevices();
 
   const { showHeader } = useModal();
   useEffect(() => {
@@ -45,6 +45,7 @@ function DeviceRemovalConfirmation({
           onClick={async () => {
             setLoading(true);
             try {
+              await deviceSessionsManager.terminateSession(deviceInfo.id);
               await deviceManager.removeDevice(deviceInfo);
             } finally {
               onClose();


### PR DESCRIPTION
- Stops the device session when removing a device through the UI.
- cancels ongoing actions when `dispose` is called on `DeviceSession`

It should fix errors being reported by tools (`adb`, `simctl` etc.) called by the `DeviceSession` when a running device is removed.

### How Has This Been Tested: 
- open Radon
- start app on iPhone simulator
- wait for the "Installing..." step
- remove the selected device
- don't get an error