### PR TITLE
change next/previous device shortcuts to avoid collisions

### DIFF
--- a/packages/docs/docs/guides/keyboard-shortcuts.md
+++ b/packages/docs/docs/guides/keyboard-shortcuts.md
@@ -15,8 +15,8 @@ Radon IDE lets you perform some repetitive actions through keyboard shortcuts.
 | Perform biometric authorization        | Command + Shift + M   | Control + Shift + M  |
 | Perform failed biometric authorization | Option + Command + Shift + M   | Control + Alt + Shift + M |
 | Close IDE Panel with confirmation      | Command + W           | Control + W          |
-| Switch to next running device          | Command + Shift + \]  | Control + Shift + \] |
-| Switch to previous running device      | Command + Shift + \[  | Control + Shift + \[ |
+| Switch to next running device          | Command + Shift + \)  | Control + Shift + \) |
+| Switch to previous running device      | Command + Shift + \(  | Control + Shift + \( |
 
 ## Customize shortcuts
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -174,13 +174,13 @@
       },
       {
         "command": "RNIDE.nextRunningDevice",
-        "key": "ctrl+shift+]",
-        "mac": "cmd+shift+]"
+        "key": "ctrl+shift+0",
+        "mac": "cmd+shift+0"
       },
       {
         "command": "RNIDE.previousRunningDevice",
-        "key": "ctrl+shift+[",
-        "mac": "cmd+shift+["
+        "key": "ctrl+shift+9",
+        "mac": "cmd+shift+9"
       }
     ],
     "configuration": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -121,13 +121,13 @@
         "command": "RNIDE.nextRunningDevice",
         "title": "Switch to next running device",
         "category": "Radon IDE",
-        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && RNIDE.isPreviewFocused"
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
       },
       {
         "command": "RNIDE.previousRunningDevice",
         "title": "Switch to previous running device",
         "category": "Radon IDE",
-        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen && RNIDE.isPreviewFocused"
+        "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
       }
     ],
     "keybindings": [

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -82,10 +82,6 @@ export class WebviewController implements Disposable {
 
         if (message.command === "call") {
           this.handleRemoteCall(message);
-        } else if (message.command === "focusPreview") {
-          commands.executeCommand("setContext", "RNIDE.isPreviewFocused", true);
-        } else if (message.command === "blurPreview") {
-          commands.executeCommand("setContext", "RNIDE.isPreviewFocused", false);
         }
       },
       undefined,

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -29,7 +29,6 @@ import RecordingIcon from "../components/icons/RecordingIcon";
 import { ActivateLicenseView } from "./ActivateLicenseView";
 import ToolsDropdown from "../components/ToolsDropdown";
 import AppRootSelect from "../components/AppRootSelect";
-import { vscode } from "../utilities/vscode";
 
 function ActivateLicenseButton() {
   const { openModal } = useModal();
@@ -199,18 +198,7 @@ function PreviewView() {
     .padStart(2, "0")}`;
 
   return (
-    <div
-      className="panel-view"
-      onFocus={(e) => {
-        vscode.postMessage({
-          command: "focusPreview",
-        });
-      }}
-      onBlur={(e) => {
-        vscode.postMessage({
-          command: "blurPreview",
-        });
-      }}>
+    <div className="panel-view">
       <div className="button-group-top">
         <div className="button-group-top-left">
           <UrlBar disabled={hasNoDevices} />


### PR DESCRIPTION
Reverts #1257 and changes the next/previous device shortcuts to avoid collisions with default keybinds

### How Has This Been Tested: 
- check the new shortcuts work


