### PR TITLE
docs: update compatibility table for React Native versions

### DIFF
--- a/packages/docs/docs/getting-started/compatibility.md
+++ b/packages/docs/docs/getting-started/compatibility.md
@@ -40,9 +40,9 @@ Radon IDE supports projects bootstrapped with the [React Native Community CLI](h
 
 <div className="compatibility">
 
-| 0.72  | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   |
-| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <No/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| 0.72  | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   |
+| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <No/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 
 </div>
 


### PR DESCRIPTION
Radon IDE 1.8 added support for React Native 0.80. This PR updates the compatibility table to reflect this change.

![image](https://github.com/user-attachments/assets/8b485330-d2fd-4759-8d44-7bba83d028f9)
