### PR TITLE
Refactor BuildManager

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -19,10 +19,6 @@ const FINGERPRINT_THROTTLE_MS = 10 * 1000; // 10 seconds
 
 export type BuildResult = IOSBuildResult | AndroidBuildResult;
 
-export interface DisposableBuild<R> extends Disposable {
-  readonly build: Promise<R>;
-}
-
 export interface BuildManagerDelegate {
   onCacheStale: (platform: DevicePlatform) => void;
 }

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -12,6 +12,7 @@ interface BuildConfigCommon {
   appRoot: string;
   platform: DevicePlatform;
   env?: Record<string, string>;
+  forceCleanBuild: boolean;
 }
 
 export type CustomBuildConfig = {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -3,11 +3,13 @@ import { BuildCache } from "../builders/BuildCache";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { LaunchConfigController } from "../panels/LaunchConfigController";
 import { disposeAll } from "../utilities/disposables";
+import { BuildManager } from "../builders/BuildManager";
 
 export class ApplicationContext implements Disposable {
   public dependencyManager: DependencyManager;
   public launchConfig: LaunchConfigController;
   public buildCache: BuildCache;
+  public buildManager: BuildManager;
   private disposables: Disposable[] = [];
 
   constructor(public appRootFolder: string) {
@@ -15,8 +17,14 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
     this.buildCache = new BuildCache(appRootFolder);
+    this.buildManager = new BuildManager(this.dependencyManager, this.buildCache);
 
-    this.disposables.push(this.launchConfig, this.dependencyManager);
+    this.disposables.push(
+      this.launchConfig,
+      this.dependencyManager,
+      this.buildManager,
+      this.buildCache
+    );
   }
 
   public async updateAppRootFolder(newAppRoot: string) {
@@ -33,7 +41,13 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
     this.buildCache = new BuildCache(newAppRoot);
-    this.disposables.push(this.launchConfig, this.dependencyManager);
+    this.buildManager = new BuildManager(this.dependencyManager, this.buildCache);
+    this.disposables.push(
+      this.launchConfig,
+      this.dependencyManager,
+      this.buildManager,
+      this.buildCache
+    );
   }
 
   public dispose() {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -304,7 +304,6 @@ export class DeviceSession
     this.cancelToken?.cancel();
     await this.deactivate();
     await this.debugSession?.dispose();
-    this.disposableBuild?.dispose();
     this.device?.dispose();
     this.metro?.dispose();
     this.devtools?.dispose();
@@ -651,7 +650,7 @@ export class DeviceSession
   }) {
     const buildStartTime = Date.now();
     this.updateStartupMessage(StartupMessage.Building);
-    this.disposableBuild = this.buildManager.startBuild(this.device.deviceInfo, {
+    this.maybeBuildResult = await this.buildManager.startBuild(this.device.deviceInfo, {
       appRoot,
       clean,
       progressListener: throttle((stageProgress: number) => {
@@ -662,7 +661,6 @@ export class DeviceSession
       }, 100),
       cancelToken,
     });
-    this.maybeBuildResult = await this.disposableBuild.build;
     const buildDurationSec = (Date.now() - buildStartTime) / 1000;
     Logger.info("Build completed in", buildDurationSec.toFixed(2), "sec.");
     getTelemetryReporter().sendTelemetryEvent(

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -128,10 +128,7 @@ export class DeviceSession
     this.toolsManager = new ToolsManager(this.inspectorBridge, this);
 
     this.buildCache = this.applicationContext.buildCache;
-    this.buildManager = new BuildManager(
-      applicationContext.dependencyManager,
-      applicationContext.buildCache
-    );
+    this.buildManager = this.applicationContext.buildManager;
     this.debugSession = new DebugSession(this, {
       useParentDebugSession: true,
     });

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -21,7 +21,6 @@ import {
   BuildManagerDelegate,
   BuildResult,
   createBuildConfig,
-  DisposableBuild,
   inferBuildType,
 } from "../builders/BuildManager";
 import {
@@ -79,7 +78,6 @@ export class DeviceSession
   private maybeBuildResult: BuildResult | undefined;
   private devtools: Devtools;
   private debugSession: DebugSession;
-  private disposableBuild: DisposableBuild<BuildResult> | undefined;
   private buildManager: BuildManager;
   private cancelToken: CancelToken | undefined;
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -20,7 +20,9 @@ import {
   BuildManager,
   BuildManagerDelegate,
   BuildResult,
+  createBuildConfig,
   DisposableBuild,
+  inferBuildType,
 } from "../builders/BuildManager";
 import {
   AppPermissionType,
@@ -650,9 +652,16 @@ export class DeviceSession
   }) {
     const buildStartTime = Date.now();
     this.updateStartupMessage(StartupMessage.Building);
-    this.maybeBuildResult = await this.buildManager.startBuild(this.device.deviceInfo, {
+    const launchConfiguration = getLaunchConfiguration();
+    const buildType = await inferBuildType(appRoot, this.device.platform, launchConfiguration);
+    const buildConfig = createBuildConfig(
       appRoot,
+      this.device.platform,
       clean,
+      launchConfiguration,
+      buildType
+    );
+    this.maybeBuildResult = await this.buildManager.buildApp(buildConfig, {
       progressListener: throttle((stageProgress: number) => {
         if (this.startupMessage === StartupMessage.Building) {
           this.stageProgress = stageProgress;


### PR DESCRIPTION
Refactors `BuildManager`:
- makes `BuildManager` accept a `BuildConfig` rather than reading the launch config
- gets rid of `DisposableBuild` interface in favor of using `CancelToken` to cancel builds
- moves the "cache stale" event that `DeviceSession` listens to from `BuildManager` to `BuildCache`
- lifts the `BuildManager` out of `DeviceSession` to `ApplicationContext`

Motivation:
- move some responsibilities out of `BuildManager` (watching the workspace for cache staleness, generating build configs from launch config, reading launch configs)
- passing `BuildConfig` to `BuildManager` will make it easier to handle multiple `LaunchConfig`s in the future
- lifting `BuildManager` out of `DeviceSession` will make it possible to share builds-in-progress between compatible devices
- simply cleaning up

### How Has This Been Tested: 
- open app in Radon
- check it builds for Android and iOS
- check that build cache works
- check that changing the native code invalidates the cache and displays the error alert
- check that switching approots works

