### PR TITLE
Prevent running the same build concurrently

### DIFF
--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -30,10 +30,16 @@ describe("BatchingBuildManager", () => {
     };
   });
 
-  it("shoud focus the build output of the wrapped build manager", () => {
+  it("should focus the build output of the wrapped build manager", () => {
     const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
     batchingBuildManager.focusBuildOutput();
     assert(buildManagerMock.focusBuildOutput.calledOnce);
+  });
+
+  it("should dispose the wrapped build manager", () => {
+    const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+    batchingBuildManager.dispose();
+    assert(buildManagerMock.dispose.calledOnce);
   });
 
   for (const platform of Object.values(DevicePlatform)) {

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -1,0 +1,166 @@
+import assert from "assert";
+import Sinon from "sinon";
+import { describe, beforeEach, it } from "mocha";
+
+import { BatchingBuildManager } from "./BatchingBuildManager";
+import { BuildManagerInterface } from "./BuildManager";
+import { DevicePlatform } from "../common/DeviceManager";
+import { BuildConfig, BuildType } from "../common/BuildConfig";
+import { CancelToken } from "./cancelToken";
+
+describe("BatchingBuildManager", () => {
+  let buildManagerMock: BuildManagerInterface;
+  let buildAppMock: Sinon.SinonStub;
+  const APP_ROOT = "appRoot";
+  const APP_ROOT_2 = "appRoot_2";
+  const BUILD_RESULT = "build result";
+  const progressListener = () => {};
+
+  beforeEach(() => {
+    // setup build manager mock
+    buildAppMock = Sinon.stub();
+    buildManagerMock = {
+      buildApp: buildAppMock,
+      focusBuildOutput: Sinon.stub(),
+      dispose: Sinon.stub(),
+    };
+  });
+
+  for (const platform of Object.values(DevicePlatform)) {
+    const BUILD_CONFIG = {
+      appRoot: APP_ROOT,
+      type: BuildType.Local,
+      platform,
+    } as BuildConfig;
+    const BUILD_CONFIG_2 = {
+      appRoot: APP_ROOT_2,
+      type: BuildType.Local,
+      platform,
+    } as BuildConfig;
+
+    describe(`for ${platform}`, () => {
+      it("should call the wrapped build manager's buildApp method", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const options = { progressListener, cancelToken: new CancelToken() };
+
+        buildAppMock.resolves(BUILD_RESULT);
+        const result = await batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        assert.strictEqual(result, BUILD_RESULT);
+        assert(buildAppMock.calledOnceWith(BUILD_CONFIG));
+      });
+
+      it("should only call the wrapped build manager's buildApp method once for the same configuration", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const options = { progressListener, cancelToken: new CancelToken() };
+
+        const { promise, resolve } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // First call
+        const result1 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        // Second call with the same configuration
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        resolve(BUILD_RESULT);
+
+        assert.strictEqual(await result1, BUILD_RESULT);
+        assert.strictEqual(await result2, BUILD_RESULT);
+
+        assert(buildAppMock.calledOnce);
+      });
+
+      it("should call the wrapped build manager's buildApp for each different config", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const options = { progressListener: () => {}, cancelToken: new CancelToken() };
+
+        const { promise, resolve } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // First call
+        const result1 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        // Second call with the same configuration
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG_2, options);
+
+        resolve(BUILD_RESULT);
+
+        assert.strictEqual(await result1, BUILD_RESULT);
+        assert.strictEqual(await result2, BUILD_RESULT);
+
+        assert(buildAppMock.calledTwice);
+        assert(buildAppMock.calledWith(BUILD_CONFIG));
+        assert(buildAppMock.calledWith(BUILD_CONFIG_2));
+      });
+
+      it("should call the wrapped build manager a second time after the first build is completed", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const options = { progressListener, cancelToken: new CancelToken() };
+
+        const { promise, resolve } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // First call
+        const result1 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        // Resolve the first promise
+        resolve(BUILD_RESULT);
+
+        assert.strictEqual(await result1, BUILD_RESULT);
+
+        // Second call after the first is resolved
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+        assert.strictEqual(await result2, BUILD_RESULT);
+        assert(buildAppMock.calledTwice);
+        assert(buildAppMock.alwaysCalledWith(BUILD_CONFIG));
+      });
+
+      it("should cancel the build in progress when the passed cancel token is cancelled", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const cancelToken = new CancelToken();
+        const options = { progressListener, cancelToken };
+
+        const { promise } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // Start the build
+        batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        // Cancel the token
+        cancelToken.cancel();
+
+        const passedCancelToken = buildAppMock.getCall(0).args[1].cancelToken;
+        assert(
+          passedCancelToken.cancelled,
+          "The cancel token passed to the wrapped BuildManager should be marked as cancelled"
+        );
+      });
+
+      it("should not cancel the build in progress not all passed cancel tokens are cancelled", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const cancelToken = new CancelToken();
+
+        const { promise } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // Start the build
+        batchingBuildManager.buildApp(BUILD_CONFIG, { progressListener, cancelToken });
+        batchingBuildManager.buildApp(BUILD_CONFIG, {
+          progressListener,
+          cancelToken: new CancelToken(),
+        });
+
+        // Cancel the token
+        cancelToken.cancel();
+
+        assert(buildAppMock.calledOnce, "The wrapped BuildManager should be called only once");
+        const passedCancelToken = buildAppMock.getCall(0).args[1].cancelToken;
+        assert(
+          !passedCancelToken.cancelled,
+          "The cancel token passed to the wrapped BuildManager should be not marked as cancelled"
+        );
+      });
+    });
+  }
+});

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -5,7 +5,7 @@ import { describe, beforeEach, it } from "mocha";
 import { BatchingBuildManager } from "./BatchingBuildManager";
 import { DevicePlatform } from "../common/DeviceManager";
 import { BuildConfig, BuildType } from "../common/BuildConfig";
-import { CancelToken } from "./cancelToken";
+import { CancelToken } from "../utilities/cancelToken";
 
 describe("BatchingBuildManager", () => {
   let buildAppMock = Sinon.stub();

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -3,14 +3,17 @@ import Sinon from "sinon";
 import { describe, beforeEach, it } from "mocha";
 
 import { BatchingBuildManager } from "./BatchingBuildManager";
-import { BuildManagerInterface } from "./BuildManager";
 import { DevicePlatform } from "../common/DeviceManager";
 import { BuildConfig, BuildType } from "../common/BuildConfig";
 import { CancelToken } from "./cancelToken";
 
 describe("BatchingBuildManager", () => {
-  let buildManagerMock: BuildManagerInterface;
-  let buildAppMock: Sinon.SinonStub;
+  let buildAppMock = Sinon.stub();
+  let buildManagerMock = {
+    buildApp: buildAppMock,
+    focusBuildOutput: Sinon.stub(),
+    dispose: Sinon.stub(),
+  };
   const APP_ROOT = "appRoot";
   const APP_ROOT_2 = "appRoot_2";
   const BUILD_RESULT = "build result";
@@ -25,6 +28,12 @@ describe("BatchingBuildManager", () => {
       focusBuildOutput: Sinon.stub(),
       dispose: Sinon.stub(),
     };
+  });
+
+  it("shoud focus the build output of the wrapped build manager", () => {
+    const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+    batchingBuildManager.focusBuildOutput();
+    assert(buildManagerMock.focusBuildOutput.calledOnce);
   });
 
   for (const platform of Object.values(DevicePlatform)) {

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -43,7 +43,7 @@ class BuildInProgress {
 export class BatchingBuildManager implements BuildManager, Disposable {
   private buildsInProgress: Map<string, BuildInProgress> = new Map();
 
-  constructor(private readonly wrappedBuildManager: BuildManager) {}
+  constructor(private readonly wrappedBuildManager: BuildManager & Partial<Disposable>) {}
 
   private makeBuildKey(buildConfig: BuildConfig) {
     return `${buildConfig.platform}:${buildConfig.type}:${buildConfig.appRoot}`;
@@ -101,6 +101,6 @@ export class BatchingBuildManager implements BuildManager, Disposable {
       build.cancelToken.cancel();
     }
     this.buildsInProgress.clear();
-    this.wrappedBuildManager.dispose();
+    this.wrappedBuildManager.dispose?.();
   }
 }

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -1,7 +1,7 @@
 import { Disposable } from "vscode";
 import { BuildConfig } from "../common/BuildConfig";
 import { Logger } from "../Logger";
-import { BuildManagerInterface, BuildOptions, BuildResult } from "./BuildManager";
+import { BuildManager, BuildOptions, BuildResult } from "./BuildManager";
 import { CancelToken } from "./cancelToken";
 
 class BuildInProgress {
@@ -40,10 +40,10 @@ class BuildInProgress {
  * for the same build configuration. It ensures that only one build is in progress for a given configuration
  * at a time, and reuses the existing build promise if another request comes in for the same configuration.
  */
-export class BatchingBuildManager implements BuildManagerInterface, Disposable {
+export class BatchingBuildManager implements BuildManager, Disposable {
   private buildsInProgress: Map<string, BuildInProgress> = new Map();
 
-  constructor(private readonly wrappedBuildManager: BuildManagerInterface) {}
+  constructor(private readonly wrappedBuildManager: BuildManager) {}
 
   private makeBuildKey(buildConfig: BuildConfig) {
     return `${buildConfig.platform}:${buildConfig.type}:${buildConfig.appRoot}`;

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -56,8 +56,10 @@ export class BatchingBuildManager implements BuildManagerInterface, Disposable {
   public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {
     const { progressListener, cancelToken } = options;
     const buildKey = this.makeBuildKey(buildConfig);
+    const { forceCleanBuild } = buildConfig;
 
-    if (this.buildsInProgress.has(buildKey)) {
+    // NOTE: if forceCleanBuild is true, we always start a new build
+    if (!forceCleanBuild && this.buildsInProgress.has(buildKey)) {
       Logger.debug("Build already in progress for this configuration, reusing the promise.");
       const existingBuild = this.buildsInProgress.get(buildKey);
       if (existingBuild) {

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -2,7 +2,7 @@ import { Disposable } from "vscode";
 import { BuildConfig } from "../common/BuildConfig";
 import { Logger } from "../Logger";
 import { BuildManager, BuildOptions, BuildResult } from "./BuildManager";
-import { CancelToken } from "./cancelToken";
+import { CancelToken } from "../utilities/cancelToken";
 
 class BuildInProgress {
   private progressListeners: ((newProgress: number) => void)[] = [];

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Disposable } from "vscode";
 import { BuildConfig } from "../common/BuildConfig";
 import { Logger } from "../Logger";
@@ -19,7 +18,11 @@ class BuildInProgress {
   }
 
   public removeProgressListener(listener: (newProgress: number) => void) {
-    _.remove(this.progressListeners, (l) => l === listener);
+    const index = this.progressListeners.findIndex((l) => l === listener);
+    if (index === -1) {
+      return;
+    }
+    this.progressListeners.splice(index, 1);
     if (this.progressListeners.length <= 0) {
       this.cancelToken.cancel();
     }

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -1,0 +1,101 @@
+import _ from "lodash";
+import { Disposable } from "vscode";
+import { BuildConfig } from "../common/BuildConfig";
+import { Logger } from "../Logger";
+import { BuildManagerInterface, BuildOptions, BuildResult } from "./BuildManager";
+import { CancelToken } from "./cancelToken";
+
+class BuildInProgress {
+  private progressListeners: ((newProgress: number) => void)[] = [];
+
+  constructor(
+    public readonly buildConfig: BuildConfig,
+    public readonly promise: Promise<BuildResult>,
+    public readonly cancelToken: CancelToken
+  ) {}
+
+  public addProgressListener(listener: (newProgress: number) => void) {
+    this.progressListeners.push(listener);
+  }
+
+  public removeProgressListener(listener: (newProgress: number) => void) {
+    _.remove(this.progressListeners, (l) => l === listener);
+    if (this.progressListeners.length <= 0) {
+      this.cancelToken.cancel();
+    }
+  }
+
+  public onProgress(newProgress: number) {
+    for (const listener of this.progressListeners.slice()) {
+      listener(newProgress);
+    }
+  }
+}
+
+/**
+ * BatchingBuildManager is a wrapper around BuildManagerInterface that batches concurrent build requests
+ * for the same build configuration. It ensures that only one build is in progress for a given configuration
+ * at a time, and reuses the existing build promise if another request comes in for the same configuration.
+ */
+export class BatchingBuildManager implements BuildManagerInterface, Disposable {
+  private buildsInProgress: Map<string, BuildInProgress> = new Map();
+
+  constructor(private readonly wrappedBuildManager: BuildManagerInterface) {}
+
+  private makeBuildKey(buildConfig: BuildConfig) {
+    return `${buildConfig.platform}:${buildConfig.type}:${buildConfig.appRoot}`;
+  }
+
+  public focusBuildOutput(): void {
+    this.wrappedBuildManager.focusBuildOutput();
+  }
+
+  public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {
+    const { progressListener, cancelToken } = options;
+    const buildKey = this.makeBuildKey(buildConfig);
+
+    if (this.buildsInProgress.has(buildKey)) {
+      Logger.debug("Build already in progress for this configuration, reusing the promise.");
+      const existingBuild = this.buildsInProgress.get(buildKey);
+      if (existingBuild) {
+        existingBuild.addProgressListener(progressListener);
+        cancelToken.onCancel(() => {
+          existingBuild.removeProgressListener(progressListener);
+        });
+        return existingBuild.promise;
+      }
+    }
+
+    const cancelTokenForBuild = new CancelToken();
+    const buildInProgress = new BuildInProgress(
+      buildConfig,
+      this.wrappedBuildManager.buildApp(buildConfig, {
+        cancelToken: cancelTokenForBuild,
+        progressListener: (newProgress) => {
+          buildInProgress.onProgress(newProgress);
+        },
+      }),
+      cancelTokenForBuild
+    );
+    buildInProgress.addProgressListener(progressListener);
+    cancelToken.onCancel(() => {
+      buildInProgress.removeProgressListener(progressListener);
+    });
+    this.buildsInProgress.set(buildKey, buildInProgress);
+    try {
+      return await buildInProgress.promise;
+    } finally {
+      if (this.buildsInProgress.get(buildKey) === buildInProgress) {
+        this.buildsInProgress.delete(buildKey);
+      }
+    }
+  }
+
+  public dispose() {
+    for (const build of this.buildsInProgress.values()) {
+      build.cancelToken.cancel();
+    }
+    this.buildsInProgress.clear();
+    this.wrappedBuildManager.dispose();
+  }
+}

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -20,6 +20,41 @@ type BuildOptions = {
   cancelToken: CancelToken;
 };
 
+class BuildInProgress {
+  private counter = 1;
+  private progressListeners: ((newProgress: number) => void)[] = [];
+
+  constructor(
+    public readonly buildConfig: BuildConfig,
+    public readonly promise: Promise<BuildResult>,
+    private readonly cancelToken: CancelToken
+  ) {}
+
+  public increment() {
+    this.counter++;
+  }
+
+  public decrement() {
+    this.counter--;
+    if (this.counter <= 0) {
+      this.cancelToken.cancel();
+    }
+  }
+
+  public addProgressListener(listener: (newProgress: number) => void) {
+    this.progressListeners.push(listener);
+  }
+
+  public removeProgressListener(listener: (newProgress: number) => void) {
+    _.remove(this.progressListeners, (l) => l === listener);
+  }
+
+  public onProgress(newProgress: number) {
+    for (const listener of this.progressListeners.slice()) {
+      listener(newProgress);
+    }
+  }
+}
 export class BuildError extends Error {
   constructor(
     message: string,
@@ -196,6 +231,62 @@ export class BuildManager implements Disposable {
       return !(await this.dependencyManager.checkPodsInstallationStatus());
     }
     return false;
+  }
+
+  private buildsInProgress: Map<string, BuildInProgress> = new Map();
+
+  private makeBuildKey(buildConfig: BuildConfig) {
+    return `${buildConfig.platform}:${buildConfig.type}:${buildConfig.appRoot}`;
+  }
+
+  public async requestBuild(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {
+    const { progressListener, cancelToken } = options;
+    const buildKey = this.makeBuildKey(buildConfig);
+
+    if (this.buildsInProgress.has(buildKey)) {
+      Logger.debug("Build already in progress for this configuration, reusing the promise.");
+      const existingBuild = this.buildsInProgress.get(buildKey);
+      if (existingBuild) {
+        existingBuild.increment();
+        existingBuild.addProgressListener(progressListener);
+        cancelToken.onCancel(() => {
+          existingBuild.decrement();
+          existingBuild.removeProgressListener(progressListener);
+        });
+        return existingBuild.promise;
+      }
+    }
+
+    const cancelTokenForBuild = new CancelToken();
+    const buildInProgress = new BuildInProgress(
+      buildConfig,
+      this.buildApp(buildConfig, {
+        cancelToken: cancelTokenForBuild,
+        progressListener: (newProgress) => {
+          buildInProgress.onProgress(newProgress);
+        },
+      }),
+      cancelTokenForBuild
+    );
+    cancelTokenForBuild.onCancel(() => {
+      if (this.buildsInProgress.get(buildKey) === buildInProgress) {
+        Logger.debug("Build was canceled by the user.");
+        this.buildsInProgress.delete(buildKey);
+      }
+    });
+    buildInProgress.addProgressListener(progressListener);
+    cancelToken.onCancel(() => {
+      buildInProgress.decrement();
+      buildInProgress.removeProgressListener(progressListener);
+    });
+    this.buildsInProgress.set(buildKey, buildInProgress);
+    try {
+      return await buildInProgress.promise;
+    } finally {
+      if (this.buildsInProgress.get(buildKey) === buildInProgress) {
+        this.buildsInProgress.delete(buildKey);
+      }
+    }
   }
 
   public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -15,7 +15,7 @@ import { LaunchConfigurationOptions } from "../common/LaunchConfig";
 
 export type BuildResult = IOSBuildResult | AndroidBuildResult;
 
-export interface BuildManager extends Disposable {
+export interface BuildManager {
   buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult>;
   focusBuildOutput(): void;
 }

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -15,7 +15,7 @@ import { LaunchConfigurationOptions } from "../common/LaunchConfig";
 
 export type BuildResult = IOSBuildResult | AndroidBuildResult;
 
-export interface BuildManagerInterface extends Disposable {
+export interface BuildManager extends Disposable {
   buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult>;
   focusBuildOutput(): void;
 }
@@ -175,7 +175,7 @@ export async function inferBuildType(
   return BuildType.Local;
 }
 
-export class BuildManager implements Disposable, BuildManagerInterface {
+export class BuildManagerImpl implements Disposable, BuildManager {
   constructor(
     private readonly dependencyManager: DependencyManager,
     private readonly buildCache: BuildCache

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -3,13 +3,21 @@ import { BuildCache } from "../builders/BuildCache";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { LaunchConfigController } from "../panels/LaunchConfigController";
 import { disposeAll } from "../utilities/disposables";
-import { BuildManager } from "../builders/BuildManager";
+import { BuildManager, BuildManagerInterface } from "../builders/BuildManager";
+import { BatchingBuildManager } from "../builders/BatchingBuildManager";
+
+function createBuildManager(
+  dependencyManager: DependencyManager,
+  buildCache: BuildCache
+): BuildManagerInterface {
+  return new BatchingBuildManager(new BuildManager(dependencyManager, buildCache));
+}
 
 export class ApplicationContext implements Disposable {
   public dependencyManager: DependencyManager;
   public launchConfig: LaunchConfigController;
   public buildCache: BuildCache;
-  public buildManager: BuildManager;
+  public buildManager: BuildManagerInterface & Disposable;
   private disposables: Disposable[] = [];
 
   constructor(public appRootFolder: string) {
@@ -17,7 +25,7 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
     this.buildCache = new BuildCache(appRootFolder);
-    this.buildManager = new BuildManager(this.dependencyManager, this.buildCache);
+    this.buildManager = createBuildManager(this.dependencyManager, this.buildCache);
 
     this.disposables.push(
       this.launchConfig,
@@ -41,7 +49,7 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
     this.buildCache = new BuildCache(newAppRoot);
-    this.buildManager = new BuildManager(this.dependencyManager, this.buildCache);
+    this.buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.disposables.push(
       this.launchConfig,
       this.dependencyManager,

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -6,10 +6,7 @@ import { disposeAll } from "../utilities/disposables";
 import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
 
-function createBuildManager(
-  dependencyManager: DependencyManager,
-  buildCache: BuildCache
-): BuildManager {
+function createBuildManager(dependencyManager: DependencyManager, buildCache: BuildCache) {
   return new BatchingBuildManager(new BuildManagerImpl(dependencyManager, buildCache));
 }
 
@@ -25,14 +22,10 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
     this.buildCache = new BuildCache(appRootFolder);
-    this.buildManager = createBuildManager(this.dependencyManager, this.buildCache);
+    const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
+    this.buildManager = buildManager;
 
-    this.disposables.push(
-      this.launchConfig,
-      this.dependencyManager,
-      this.buildManager,
-      this.buildCache
-    );
+    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager, this.buildCache);
   }
 
   public async updateAppRootFolder(newAppRoot: string) {
@@ -49,13 +42,10 @@ export class ApplicationContext implements Disposable {
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
     this.buildCache = new BuildCache(newAppRoot);
-    this.buildManager = createBuildManager(this.dependencyManager, this.buildCache);
-    this.disposables.push(
-      this.launchConfig,
-      this.dependencyManager,
-      this.buildManager,
-      this.buildCache
-    );
+    const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
+    this.buildManager = buildManager;
+
+    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager, this.buildCache);
   }
 
   public dispose() {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -3,21 +3,21 @@ import { BuildCache } from "../builders/BuildCache";
 import { DependencyManager } from "../dependency/DependencyManager";
 import { LaunchConfigController } from "../panels/LaunchConfigController";
 import { disposeAll } from "../utilities/disposables";
-import { BuildManager, BuildManagerInterface } from "../builders/BuildManager";
+import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
 
 function createBuildManager(
   dependencyManager: DependencyManager,
   buildCache: BuildCache
-): BuildManagerInterface {
-  return new BatchingBuildManager(new BuildManager(dependencyManager, buildCache));
+): BuildManager {
+  return new BatchingBuildManager(new BuildManagerImpl(dependencyManager, buildCache));
 }
 
 export class ApplicationContext implements Disposable {
   public dependencyManager: DependencyManager;
   public launchConfig: LaunchConfigController;
   public buildCache: BuildCache;
-  public buildManager: BuildManagerInterface & Disposable;
+  public buildManager: BuildManager;
   private disposables: Disposable[] = [];
 
   constructor(public appRootFolder: string) {

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -17,7 +17,7 @@ import { DeviceBase } from "../devices/DeviceBase";
 import { Logger } from "../Logger";
 import {
   BuildError,
-  BuildManager,
+  BuildManagerInterface,
   BuildResult,
   createBuildConfig,
   inferBuildType,
@@ -78,7 +78,7 @@ export class DeviceSession
   private maybeBuildResult: BuildResult | undefined;
   private devtools: Devtools;
   private debugSession: DebugSession;
-  private buildManager: BuildManager;
+  private buildManager: BuildManagerInterface;
   private buildCache: BuildCache;
   private cancelToken: CancelToken | undefined;
   private cacheStaleSubscription: Disposable;
@@ -666,7 +666,7 @@ export class DeviceSession
       buildType
     );
     this.hasStaleBuildCache = false;
-    this.maybeBuildResult = await this.buildManager.requestBuild(buildConfig, {
+    this.maybeBuildResult = await this.buildManager.buildApp(buildConfig, {
       progressListener: throttle((stageProgress: number) => {
         if (this.startupMessage === StartupMessage.Building) {
           this.stageProgress = stageProgress;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -666,7 +666,7 @@ export class DeviceSession
       buildType
     );
     this.hasStaleBuildCache = false;
-    this.maybeBuildResult = await this.buildManager.buildApp(buildConfig, {
+    this.maybeBuildResult = await this.buildManager.requestBuild(buildConfig, {
       progressListener: throttle((stageProgress: number) => {
         if (this.startupMessage === StartupMessage.Building) {
           this.stageProgress = stageProgress;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -17,7 +17,7 @@ import { DeviceBase } from "../devices/DeviceBase";
 import { Logger } from "../Logger";
 import {
   BuildError,
-  BuildManagerInterface,
+  BuildManager,
   BuildResult,
   createBuildConfig,
   inferBuildType,
@@ -78,7 +78,7 @@ export class DeviceSession
   private maybeBuildResult: BuildResult | undefined;
   private devtools: Devtools;
   private debugSession: DebugSession;
-  private buildManager: BuildManagerInterface;
+  private buildManager: BuildManager;
   private buildCache: BuildCache;
   private cancelToken: CancelToken | undefined;
   private cacheStaleSubscription: Disposable;


### PR DESCRIPTION
After #1118 we encounter an issue where, if two devices (with the same platform) are launched at the same time, and we need to build the native application, both will start building at the same time. This causes issues (at least on iOS, running `xcodebuild` from the same project concurrently causes errors in one of the builds) as well as is simply wasteful (since the application build can be used for both devices anyway).

This PR introduces a "batching" mechanism, where if a device requests an application build while a compatible build is already running, it will use the result of that in-progress build instead.

### How Has This Been Tested: 
- open an app (which builds the native part locally) in Radon
- choose the "Clean rebuild" option to force a build
- start a second device with the same platform
- check that the build only runs once -- either by inspecting the Radon IDE output or adding breakpoints/logpoints in `BuildManager`
- check that stopping all of the devices also cancels the build



