### PR TITLE
Fix new Android emulators getting stuck in "booting" state

### DIFF
--- a/packages/vscode-extension/src/utilities/retry.ts
+++ b/packages/vscode-extension/src/utilities/retry.ts
@@ -1,3 +1,5 @@
+import { CancelError, CancelToken } from "./cancelToken";
+
 type RetryFn<T> = (retryNumber: number, retriesLeft: number) => Promise<T>;
 
 export async function retry<T>(fn: RetryFn<T>, retries = 5, interval = 1000): Promise<T> {
@@ -22,4 +24,36 @@ export const progressiveRetryTimeout = (retryNumber: number) =>
 
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type Cancellable = Parameters<CancelToken["adapt"]>[0];
+/**
+ * Executes a given asynchronous function with retry logic, supporting cancellation.
+ *
+ * @param fn - A function that returns a `Cancellable` operation to be executed.
+ * @param retries - The number of times to retry the operation upon failure.
+ * @param cancelToken - A `CancelToken` used to signal cancellation and adapt promises.
+ * @throws {CancelError} Throws if the operation is cancelled.
+ * @throws {Error} Throws if the operation fails after all retries.
+ */
+export async function cancellableRetry(
+  fn: () => Cancellable,
+  cancelToken: CancelToken,
+  retries: number = 5,
+  interval: number = 1000
+) {
+  while (!cancelToken.cancelled && retries-- > 0) {
+    try {
+      await cancelToken.adapt(fn());
+      return;
+    } catch (error) {
+      if (error instanceof CancelError) {
+        throw error; // rethrow the cancel error to be handled by the caller
+      }
+      if (retries === 0) {
+        throw error;
+      }
+      await cancelToken.adapt(sleep(interval));
+    }
+  }
 }


### PR DESCRIPTION
When trying to call `adb` on a newly created Android emulator, it sometimes fails with "device not found" error.
This can cause Radon to be stuck in the "Booting device" state until the device is restarted by the user, due to an `adb` call made in `waitForEmulatorOnline`.
This PR tries to work around the issue by retrying the command until a timeout is reached.
It also throws an error if the `waitForEmulatorOnline` call fails, instead of getting stuck in "Booting Device".

### How Has This Been Tested: 
- create a new Android device and select it immediately
- wait for the device to start
- on main branch, the preview will be stuck at "Booting device" and you can see
```
[error] Error: Command failed with exit code 255: adb -s emulator-5556 wait-for-device shell while [[ -z $(getprop sys.boot_completed) ]]; do sleep 0.5; done; input keyevent 82
    at makeError (/Users/jwajgelt/Developer/radon/radon-ide/packages/vscode-extension/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/Users/jwajgelt/Developer/radon/radon-ide/packages/vscode-extension/node_modules/execa/index.js:118:26)
    at processTicksAndRejections (node:internal/process/task_queues:105:5) Unhandled promise rejection
```
in the logs