### PR TITLE
Setup initial device on webview side

### DIFF
--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -14,6 +14,8 @@ export type ReloadAction =
   | "restartProcess" // relaunch app
   | "reloadJs"; // refetch JS scripts from metro
 
+export const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
+
 export interface DeviceSessionsManagerInterface {
   reloadCurrentSession(type: ReloadAction): Promise<boolean>;
   startOrActivateSessionForDevice(

--- a/packages/vscode-extension/src/common/PersistentStore.ts
+++ b/packages/vscode-extension/src/common/PersistentStore.ts
@@ -1,0 +1,9 @@
+/**
+ * Interface representing a persistent key-value store.
+ *
+ * Provides asynchronous methods to update and retrieve values by key.
+ */
+export interface PersistentStore {
+  update<V>(key: string, value: V | undefined): Promise<void>;
+  get<V>(key: string): Promise<V | undefined>;
+}

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -117,7 +117,6 @@ export interface DeviceSessionsManagerState {
 }
 
 export type ProjectState = {
-  initialized: boolean;
   appRootPath: string | undefined;
   previewZoom: ZoomLevelType | undefined; // Preview specific. Consider extracting to different location if we store more preview state
 } & DeviceSessionsManagerState;

--- a/packages/vscode-extension/src/panels/WebviewController.ts
+++ b/packages/vscode-extension/src/panels/WebviewController.ts
@@ -5,6 +5,8 @@ import { IDE } from "../project/ide";
 import { disposeAll } from "../utilities/disposables";
 import { RENDER_OUTLINES_PLUGIN_ID } from "../common/RenderOutlines";
 import { PanelLocation } from "../common/WorkspaceConfig";
+import { extensionContext } from "../utilities/extensionContext";
+import { MementoStore } from "../project/MementoStore";
 
 type CallArgs = {
   callId: string;
@@ -37,6 +39,8 @@ export class WebviewController implements Disposable {
     // Set an event listener to listen for messages passed from the webview context
     this.setWebviewMessageListener(webview);
 
+    const workspaceStore = new MementoStore(extensionContext.workspaceState);
+
     this.callableObjectGetters = new Map([
       ["DeviceManager", () => this.ide.deviceManager as object],
       ["DependencyManager", () => this.ide.project.dependencyManager as object],
@@ -49,6 +53,7 @@ export class WebviewController implements Disposable {
         "RenderOutlines",
         () => this.ide.project.deviceSession!.getPlugin(RENDER_OUTLINES_PLUGIN_ID) as object,
       ],
+      ["WorkspaceStore", () => workspaceStore],
     ]);
 
     commands.executeCommand("setContext", "RNIDE.panelIsOpen", true);

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -10,17 +10,16 @@ import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
 import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 import {
   DeviceSessionsManagerInterface,
+  LAST_SELECTED_DEVICE_KEY,
   ReloadAction,
   SelectDeviceOptions,
 } from "../common/DeviceSessionsManager";
 import { disposeAll } from "../utilities/disposables";
 import { DeviceId, DeviceSessionsManagerState } from "../common/Project";
 
-const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const SWITCH_DEVICE_THROTTLE_MS = 300;
 
 export type DeviceSessionsManagerDelegate = {
-  onInitialized(): void;
   onDeviceSessionsManagerStateChange(state: DeviceSessionsManagerState): void;
 };
 
@@ -38,7 +37,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     private readonly deviceManager: DeviceManager,
     private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate
   ) {
-    this.findInitialDeviceAndStartSession();
+    // this.findInitialDeviceAndStartSession();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.addListener("devicesChanged", this.devicesChangedListener);
   }
@@ -123,7 +122,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     this.deviceSessions.set(deviceInfo.id, newDeviceSession);
     this.maybeWarnAboutRunningDevices();
     this.updateSelectedSession(newDeviceSession);
-    this.deviceSessionManagerDelegate.onInitialized();
 
     if (stopPreviousDevices) {
       await this.terminatePreviousSessions();
@@ -192,8 +190,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
       }
     } finally {
       this.findingDevice = false;
-      // even if no device can be selected mark project as initialized
-      this.deviceSessionManagerDelegate.onInitialized();
     }
   };
 

--- a/packages/vscode-extension/src/project/MementoStore.ts
+++ b/packages/vscode-extension/src/project/MementoStore.ts
@@ -1,0 +1,18 @@
+import { Memento } from "vscode";
+import { PersistentStore } from "../common/PersistentStore";
+
+/**
+ * A wrapper class for VS Code's {@link Memento} that implements the {@link PersistentStore} interface.
+ * Provides asynchronous methods to persist and retrieve data using a key-value store.
+ */
+export class MementoStore implements PersistentStore {
+  constructor(private memento: Memento) {}
+
+  async update<V>(key: string, value: V | undefined): Promise<void> {
+    this.memento.update(key, value);
+  }
+
+  async get<V>(key: string): Promise<V | undefined> {
+    return this.memento.get<V>(key);
+  }
+}

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -76,7 +76,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.projectState = {
       selectedSessionId: null,
       deviceSessions: {},
-      initialized: false,
       appRootPath: this.relativeAppRootPath,
       previewZoom: undefined,
     };
@@ -168,11 +167,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     oldDeviceSessionsManager.dispose();
     this.updateProjectState({
       appRootPath: this.relativeAppRootPath,
+      selectedSessionId: null,
+      deviceSessions: {},
     });
-  }
-
-  onInitialized(): void {
-    this.updateProjectState({ initialized: true });
   }
 
   private recordingTimeout: NodeJS.Timeout | undefined = undefined;

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -34,7 +34,6 @@ const defaultProjectState: ProjectState = {
   deviceSessions: {},
   previewZoom: undefined,
   appRootPath: "./",
-  initialized: false,
 };
 
 const defaultDeviceSettings: DeviceSettings = {

--- a/packages/vscode-extension/src/webview/utilities/WorkspaceStore.ts
+++ b/packages/vscode-extension/src/webview/utilities/WorkspaceStore.ts
@@ -1,0 +1,14 @@
+import { PersistentStore } from "../../common/PersistentStore";
+import { makeProxy } from "./rpc";
+
+/**
+ * A proxy instance of the persistent store for workspace-level data.
+ *
+ * This store provides access to persistent data scoped to the current workspace,
+ * allowing for reading and writing of settings or state that should be retained
+ * across sessions within the same workspace.
+ *
+ * @see PersistentStore
+ * @see makeProxy
+ */
+export const workspaceStore = makeProxy<PersistentStore>("WorkspaceStore");


### PR DESCRIPTION
Moves the code for selecting the initial device to the webview.

### How Has This Been Tested: 
- open an app in Radon
- a device should start automatically
- delete all devices and restart Radon
- the "no devices" screen should appear
- try switching approots, the device should restart correctly after switching

