### PR TITLE
Make BuildCache independent from `LaunchConfig`, batch fingerprint calculations when workspace doesn't change

### DIFF
--- a/packages/vscode-extension/src/builders/customBuild.ts
+++ b/packages/vscode-extension/src/builders/customBuild.ts
@@ -66,14 +66,6 @@ export async function runExternalBuild(
   return binaryPath;
 }
 
-export async function runfingerprintCommand(externalCommand: string, env: Env, cwd: string) {
-  const output = await runExternalScript(externalCommand, env, cwd);
-  if (!output) {
-    return undefined;
-  }
-  return output.lastLine;
-}
-
 async function runExternalScript(
   externalCommand: string,
   env: Env,

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -13,12 +13,12 @@ interface BuildConfigCommon {
   platform: DevicePlatform;
   env?: Record<string, string>;
   forceCleanBuild: boolean;
+  fingerprintCommand?: string;
 }
 
 export type CustomBuildConfig = {
   type: BuildType.Custom;
   buildCommand: string;
-  fingerprintCommand?: string;
 } & BuildConfigCommon;
 
 export type ExpoGoBuildConfig = {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -5,7 +5,6 @@ import { LaunchConfigController } from "../panels/LaunchConfigController";
 import { disposeAll } from "../utilities/disposables";
 import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
-import { FingerprintProvider } from "./FingerprintProvider";
 
 function createBuildManager(dependencyManager: DependencyManager, buildCache: BuildCache) {
   return new BatchingBuildManager(new BuildManagerImpl(dependencyManager, buildCache));
@@ -14,16 +13,16 @@ function createBuildManager(dependencyManager: DependencyManager, buildCache: Bu
 export class ApplicationContext implements Disposable {
   public dependencyManager: DependencyManager;
   public launchConfig: LaunchConfigController;
-  public buildCache: BuildCache;
   public buildManager: BuildManager;
-  public fingerprintProvider: FingerprintProvider = new FingerprintProvider();
   private disposables: Disposable[] = [];
 
-  constructor(public appRootFolder: string) {
+  constructor(
+    public appRootFolder: string,
+    public readonly buildCache: BuildCache
+  ) {
     this.dependencyManager = new DependencyManager(appRootFolder);
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
-    this.buildCache = new BuildCache(this.fingerprintProvider);
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
@@ -43,7 +42,6 @@ export class ApplicationContext implements Disposable {
     disposeAll(this.disposables);
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
-    this.buildCache = new BuildCache(this.fingerprintProvider);
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
@@ -52,6 +50,5 @@ export class ApplicationContext implements Disposable {
 
   public dispose() {
     disposeAll(this.disposables);
-    this.fingerprintProvider.dispose();
   }
 }

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -25,7 +25,7 @@ export class ApplicationContext implements Disposable {
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
-    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager, this.buildCache);
+    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager);
   }
 
   public async updateAppRootFolder(newAppRoot: string) {
@@ -45,7 +45,7 @@ export class ApplicationContext implements Disposable {
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
-    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager, this.buildCache);
+    this.disposables.push(this.launchConfig, this.dependencyManager, buildManager);
   }
 
   public dispose() {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -5,6 +5,7 @@ import { LaunchConfigController } from "../panels/LaunchConfigController";
 import { disposeAll } from "../utilities/disposables";
 import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
+import { FingerprintProvider } from "./FingerprintProvider";
 
 function createBuildManager(dependencyManager: DependencyManager, buildCache: BuildCache) {
   return new BatchingBuildManager(new BuildManagerImpl(dependencyManager, buildCache));
@@ -15,13 +16,14 @@ export class ApplicationContext implements Disposable {
   public launchConfig: LaunchConfigController;
   public buildCache: BuildCache;
   public buildManager: BuildManager;
+  public fingerprintProvider: FingerprintProvider = new FingerprintProvider();
   private disposables: Disposable[] = [];
 
   constructor(public appRootFolder: string) {
     this.dependencyManager = new DependencyManager(appRootFolder);
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
-    this.buildCache = new BuildCache();
+    this.buildCache = new BuildCache(this.fingerprintProvider);
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
@@ -41,7 +43,7 @@ export class ApplicationContext implements Disposable {
     disposeAll(this.disposables);
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
-    this.buildCache = new BuildCache();
+    this.buildCache = new BuildCache(this.fingerprintProvider);
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
@@ -50,5 +52,6 @@ export class ApplicationContext implements Disposable {
 
   public dispose() {
     disposeAll(this.disposables);
+    this.fingerprintProvider.dispose();
   }
 }

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -21,7 +21,7 @@ export class ApplicationContext implements Disposable {
     this.dependencyManager = new DependencyManager(appRootFolder);
 
     this.launchConfig = new LaunchConfigController(appRootFolder);
-    this.buildCache = new BuildCache(appRootFolder);
+    this.buildCache = new BuildCache();
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 
@@ -41,7 +41,7 @@ export class ApplicationContext implements Disposable {
     disposeAll(this.disposables);
 
     this.launchConfig = new LaunchConfigController(newAppRoot);
-    this.buildCache = new BuildCache(newAppRoot);
+    this.buildCache = new BuildCache();
     const buildManager = createBuildManager(this.dependencyManager, this.buildCache);
     this.buildManager = buildManager;
 

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -28,7 +28,7 @@ const MAX_ALLOWED_IOS_DEVICES = 3;
 const MAX_ALLOWED_ANDROID_DEVICES = 1;
 
 export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerInterface {
-  private deviceSessions: Map<DeviceId, DeviceSession> = new Map();
+  public readonly deviceSessions: Map<DeviceId, DeviceSession> = new Map();
   private activeSessionId: DeviceId | undefined;
   private findingDevice: boolean = false;
   private previousDevices: DeviceInfo[] = [];

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -28,7 +28,7 @@ const MAX_ALLOWED_IOS_DEVICES = 3;
 const MAX_ALLOWED_ANDROID_DEVICES = 1;
 
 export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerInterface {
-  public readonly deviceSessions: Map<DeviceId, DeviceSession> = new Map();
+  private deviceSessions: Map<DeviceId, DeviceSession> = new Map();
   private activeSessionId: DeviceId | undefined;
   private findingDevice: boolean = false;
   private previousDevices: DeviceInfo[] = [];

--- a/packages/vscode-extension/src/project/FingerprintProvider.ts
+++ b/packages/vscode-extension/src/project/FingerprintProvider.ts
@@ -72,11 +72,12 @@ export class FingerprintProvider implements Disposable {
     this.workspaceWatcher = watchProjectFiles(this.onProjectFilesChanged);
   }
 
-  public async calculateFingerprint(options: FingerprintOptions): Promise<Fingerprint> {
+  public calculateFingerprint(options: FingerprintOptions): Promise<Fingerprint> {
     const cacheKey = this.makeCacheKey(options);
-    if (this.fingerprintCache.has(cacheKey)) {
+    const cachedFingerprintPromise = this.fingerprintCache.get(cacheKey);
+    if (cachedFingerprintPromise) {
       Logger.debug("Using cached fingerprint");
-      return this.fingerprintCache.get(this.makeCacheKey(options))!;
+      return cachedFingerprintPromise;
     }
     Logger.debug("Calculating fingerprint");
     const { appRoot } = options;
@@ -99,7 +100,7 @@ export class FingerprintProvider implements Disposable {
       }
     });
 
-    return await fingerprintPromise;
+    return fingerprintPromise;
   }
 
   private makeCacheKey(options: FingerprintOptions): string {

--- a/packages/vscode-extension/src/project/FingerprintProvider.ts
+++ b/packages/vscode-extension/src/project/FingerprintProvider.ts
@@ -1,0 +1,116 @@
+import path from "path";
+import { Disposable } from "vscode";
+import { createFingerprintAsync } from "@expo/fingerprint";
+import { watchProjectFiles } from "../utilities/watchProjectFiles";
+import { Logger } from "../Logger";
+import { command } from "../utilities/subprocess";
+
+type Fingerprint = string;
+
+export interface FingerprintOptions {
+  appRoot: string;
+  env?: Record<string, string>;
+  fingerprintCommand?: string;
+}
+
+type CustomFingerprintOptions = FingerprintOptions & {
+  fingerprintCommand: string;
+};
+
+const IGNORE_PATHS = [
+  path.join("android", ".gradle/**/*"),
+  path.join("android", "build/**/*"),
+  path.join("android", "app", "build/**/*"),
+  path.join("ios", "build/**/*"),
+  path.join("ios", "DerivedData/**/*"),
+  "**/node_modules/**/android/.cxx/**/*",
+  "**/node_modules/**/.gradle/**/*",
+  "**/node_modules/**/android/build/intermediates/cxx/**/*",
+];
+
+export async function runFingerprintCommand(
+  options: CustomFingerprintOptions
+): Promise<Fingerprint | undefined> {
+  try {
+    const { appRoot, env, fingerprintCommand } = options;
+    const output = await command(fingerprintCommand, {
+      env,
+      cwd: appRoot,
+    });
+    if (!output) {
+      return undefined;
+    }
+    const lastLine = output.stdout
+      .split("\n")
+      // find last non-empty line
+      .findLast((line) => line.trim().length > 0)
+      ?.trim();
+    return lastLine || undefined;
+  } catch (error) {
+    Logger.error("Error running custom fingerprint command:", error);
+    return undefined;
+  }
+}
+
+async function calculateCustomFingerprint(options: CustomFingerprintOptions): Promise<Fingerprint> {
+  Logger.debug(`Using custom fingerprint script '${options.fingerprintCommand}'`);
+  const fingerprint = await runFingerprintCommand(options);
+
+  if (!fingerprint) {
+    throw new Error("Failed to generate application fingerprint using custom script.");
+  }
+
+  Logger.debug("Application fingerprint", fingerprint);
+  return fingerprint;
+}
+
+export class FingerprintProvider implements Disposable {
+  private workspaceWatcher: Disposable;
+  private fingerprintCache: Map<string, Promise<Fingerprint>> = new Map();
+
+  constructor() {
+    this.workspaceWatcher = watchProjectFiles(this.onProjectFilesChanged);
+  }
+
+  public async calculateFingerprint(options: FingerprintOptions): Promise<Fingerprint> {
+    const cacheKey = this.makeCacheKey(options);
+    if (this.fingerprintCache.has(cacheKey)) {
+      Logger.debug("Using cached fingerprint");
+      return this.fingerprintCache.get(this.makeCacheKey(options))!;
+    }
+    Logger.debug("Calculating fingerprint");
+    const { appRoot } = options;
+
+    let fingerprintPromise: Promise<Fingerprint>;
+    if (options.fingerprintCommand !== undefined) {
+      Logger.debug("Using custom fingerprint command");
+      fingerprintPromise = calculateCustomFingerprint(options as CustomFingerprintOptions);
+    } else {
+      fingerprintPromise = createFingerprintAsync(appRoot, {
+        ignorePaths: IGNORE_PATHS,
+      }).then((fingerprint) => fingerprint.hash);
+    }
+
+    this.fingerprintCache.set(cacheKey, fingerprintPromise);
+    fingerprintPromise.catch(() => {
+      // NOTE: on error, we remove the promise from the cache so that further calls will retry
+      if (this.fingerprintCache.get(cacheKey) === fingerprintPromise) {
+        this.fingerprintCache.delete(cacheKey);
+      }
+    });
+
+    return await fingerprintPromise;
+  }
+
+  private makeCacheKey(options: FingerprintOptions): string {
+    return `${options.appRoot}:${options.fingerprintCommand || ""}`;
+  }
+
+  private onProjectFilesChanged = () => {
+    this.fingerprintCache.clear();
+  };
+
+  dispose() {
+    this.workspaceWatcher.dispose();
+  }
+}

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -521,9 +521,17 @@ export class DeviceSession
       platform: this.device.platform,
     });
 
+    const launchConfig = getLaunchConfiguration();
+    const platformKey = this.device.platform === DevicePlatform.IOS ? "ios" : "android";
+    const fingerprintOptions = {
+      appRoot: this.applicationContext.appRootFolder,
+      env: launchConfig.env,
+      fingerprintCommand: launchConfig.customBuild?.[platformKey]?.fingerprintCommand,
+    };
+
     this.resetStartingState();
     try {
-      if (await this.buildCache.isCacheStale(this.device.platform)) {
+      if (await this.buildCache.isCacheStale(this.device.platform, fingerprintOptions)) {
         await this.restart({ forceClean: false, cleanCache: false });
         return;
       }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -531,7 +531,14 @@ export class DeviceSession
 
     this.resetStartingState();
     try {
-      if (await this.buildCache.isCacheStale(this.device.platform, fingerprintOptions)) {
+      const currentFingerprint = await this.buildCache.calculateFingerprint(fingerprintOptions);
+      if (
+        await this.buildCache.isCacheStale(
+          currentFingerprint,
+          this.device.platform,
+          this.applicationContext.appRootFolder
+        )
+      ) {
         await this.restart({ forceClean: false, cleanCache: false });
         return;
       }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -39,6 +39,8 @@ import { findAndSetupNewAppRootFolder } from "../utilities/findAndSetupNewAppRoo
 import { getLaunchConfiguration } from "../utilities/launchConfiguration";
 import { DeviceSessionsManager, DeviceSessionsManagerDelegate } from "./DeviceSessionsManager";
 import { DEVICE_SETTINGS_DEFAULT, DEVICE_SETTINGS_KEY } from "../devices/DeviceBase";
+import { FingerprintProvider } from "./FingerprintProvider";
+import { BuildCache } from "../builders/BuildCache";
 
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 const DEEP_LINKS_HISTORY_KEY = "deep_links_history";
@@ -66,7 +68,9 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     private readonly utils: UtilsInterface
   ) {
     const appRoot = findAndSetupNewAppRootFolder();
-    this.applicationContext = new ApplicationContext(appRoot);
+    const fingerprintProvider = new FingerprintProvider();
+    const buildCache = new BuildCache(fingerprintProvider);
+    this.applicationContext = new ApplicationContext(appRoot, buildCache);
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
       this.deviceManager,
@@ -81,6 +85,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       previewZoom: undefined,
     };
 
+    this.disposables.push(fingerprintProvider);
     this.disposables.push(refreshTokenPeriodically());
     this.disposables.push(
       watchLicenseTokenChange(async () => {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -127,11 +127,16 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       );
       const platformKey: "ios" | "android" = platform === DevicePlatform.IOS ? "ios" : "android";
       if (hasCachedBuild) {
-        const isCacheStale = await this.applicationContext.buildCache.isCacheStale(platform, {
+        const fingerprint = await this.applicationContext.buildCache.calculateFingerprint({
           appRoot: this.appRootFolder,
           env: launchConfig.env,
           fingerprintCommand: launchConfig.customBuild?.[platformKey]?.fingerprintCommand,
         });
+        const isCacheStale = await this.applicationContext.buildCache.isCacheStale(
+          fingerprint,
+          platform,
+          this.appRootFolder
+        );
 
         if (isCacheStale) {
           sessions


### PR DESCRIPTION
Makes the `BuildCache` class independent from `LaunchConfig`.
- calls to `BuildCache`'s methods now require passing either `appRoot` or `FingerprintOptions` which include the options previously retrieved from `LaunchConfig`.
- the "build cache stale" listener has been moved from `BuildCache` to `DeviceSession`. 
- fingerprint calculations are now batched, so that when multiple callers try to get the fingerprint while no changes to the project where made, they will get the result of the same calculation

Motivation:
- batch and cache fingerprint calculations to save time on unnecessary computations
- make `BuildCache` independent from `launchConfig` to allow for having multiple launch configs in the future

### How Has This Been Tested: 
- launch the app
- verify it grabs the build from cache
- change something that impacts the fingerprint
- verify the "native changes" alert appears
- verify that when custom fingerprint is configured, it is used


