### PR TITLE
Center the screen recording indicator

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.css
+++ b/packages/vscode-extension/src/webview/views/PreviewView.css
@@ -91,8 +91,13 @@
 .recording-rec-indicator {
   display: flex;
   align-items: center;
+  gap: 6px;
   font-size: 120%;
   font-family: "Courier new", fixed;
+}
+
+.recording-rec-indicator span {
+  margin-top: 2px;
 }
 
 .icon-red {


### PR DESCRIPTION
When writing a documentation for the screen recording feature my OCD couldn't ignore the non-centered screen recording indicator. This PR aim to fix the styles for the indicator.

Please test before merging. The Courier New font seems to render differently on different screens.

## Before

![Screenshot 2025-07-03 at 10 20 58](https://github.com/user-attachments/assets/097b071c-0d8a-4707-9ee1-95852d67df4e)

## After

![image 41](https://github.com/user-attachments/assets/87a64a5a-150e-41e7-ae34-ad34d319a7db)
