### PR TITLE
Fix local MCP server not being reloaded on license token change

### DIFF
--- a/packages/vscode-extension/src/ai/mcp/index.ts
+++ b/packages/vscode-extension/src/ai/mcp/index.ts
@@ -72,7 +72,6 @@ function isDirectLoadingAvailable() {
 }
 
 export default function registerRadonAi() {
-  // The `registerRadonAi` is async, but never awaited, to prevent slowing down Radon IDE startup.
   if (isDirectLoadingAvailable()) {
     directLoadRadonAI();
   } else {


### PR DESCRIPTION
Local MCP was intended to be restarted on every change of the license token.
This behaviour ensures that the paid MCP tools are loaded as soon as a valid license is available. 

With direct-injection mode (vscode `1.101+`), this behaviour was bugged, and the server never restarted 
due to the server-starting promise being only executed once before being cached.

This PR: 
- Fixes said bug
- Adds a missing `Disposable` (`watchLicenseTokenChange`) to the `extensionContext.subscriptions` array
- Prevents AI registration from blocking IDE initialisation
- Applies a more uniform naming scheme in the `ai/mcp/index.ts`.

### How Has This Been Tested: 

- On each token reload, a new `port` is being used, and the server now sends appropriate web requests to the backend.
