### PR TITLE
docs: add cookie consent banner

### DIFF
--- a/packages/docs/src/theme/Navbar/index.js
+++ b/packages/docs/src/theme/Navbar/index.js
@@ -6,10 +6,18 @@ import Head from "@docusaurus/Head";
 
 const isProduction = process.env.NODE_ENV === "production";
 
-function RedditPixel() {
+// Scripts component to include additional scripts in <head>
+// Note: Google Tag Manager is handled by Docusaurus preset, so we don't need to include it here.
+function Scripts() {
   if (isProduction) {
     return (
       <Head>
+        {/* CookieScript */}
+        <script
+          type="text/javascript"
+          charset="UTF-8"
+          src="//cdn.cookie-script.com/s/b0724133a2e949a319ce96eb3f7febf6.js"></script>
+        {/* Reddit Pixel */}
         <script src={useBaseUrl("/js/reddit-pixel.js")}></script>
       </Head>
     );
@@ -29,7 +37,7 @@ export default function NavbarWrapper(props) {
         heroImages={heroImages}
         {...props}
       />
-      <RedditPixel />
+      <Scripts />
       <Analytics />
     </>
   );


### PR DESCRIPTION
This PR adds a cookie consent banner handled by CookieScript - a cookie management system which we already using on the app.js and rtc.on websites. 

The cookie banner will be placed on the bottom-right corner and look accordingly:
<img width="513" alt="image" src="https://github.com/user-attachments/assets/07561eeb-20d9-47cc-b27b-5d6089359e9f" />

It's possible to adjust the banner styles & content from the CookieScript dashboard.

When you close the banner it's still visible with a cookie icon but it's not disturbing
<img width="243" alt="image" src="https://github.com/user-attachments/assets/9aaad2f1-743f-484b-ba9e-45196d4e74d6" />

