### PR TITLE
Add snippets when editing Radon IDE Launch Configurations

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -540,11 +540,31 @@
             "type": "radon-ide",
             "request": "launch",
             "name": "Radon IDE panel",
+            "env": {},
             "ios": {
               "configuration": "Debug"
             },
             "android": {
               "buildType": "debug"
+            }
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "Radon IDE: Application configuration",
+            "description": "A new configuration for launching a React Native application in Radon IDE.",
+            "body": {
+              "type": "radon-ide",
+              "request": "launch",
+              "name": "${1:Application name}",
+              "appRoot": "${2:./}",
+              "env": {},
+              "ios": {
+                "configuration": "Debug"
+              },
+              "android": {
+                "buildType": "debug"
+              }
             }
           }
         ]

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -574,6 +574,25 @@
                 "buildType": "debug"
               }
             }
+          },
+          {
+            "label": "Radon IDE: EAS configuration",
+            "description": "A new configuration for launching a React Native application in Radon IDE. Uses EAS build service.",
+            "body": {
+              "type": "radon-ide",
+              "request": "launch",
+              "name": "${1:Application name}",
+              "appRoot": "${2:./}",
+              "env": {},
+              "eas": {
+                "ios": {
+                  "profile": "${3:development}"
+                },
+                "android": {
+                  "profile": "${3:development}"
+                }
+              }
+            }
           }
         ]
       },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -461,6 +461,10 @@
                       "buildUUID": {
                         "type": "string",
                         "description": "UUID of the EAS build used in `eas build:view` command. If unspecified, will use a build with matching fingerprint if available."
+                      },
+                      "local": {
+                        "type": "boolean",
+                        "description": "When set, builds the app locally using EAS CLI."
                       }
                     },
                     "required": [
@@ -478,6 +482,10 @@
                       "buildUUID": {
                         "type": "string",
                         "description": "UUID of the EAS build used in `eas build:view` command. If unspecified, will use a build with matching fingerprint if available."
+                      },
+                      "local": {
+                        "type": "boolean",
+                        "description": "When set, builds the app locally using EAS CLI."
                       }
                     },
                     "required": [


### PR DESCRIPTION
- adds launch config snippets to help users add and edit `radon-ide` launch configurations
- adds the `env` attribute to the initial configuration generated for Radon
- 
### How Has This Been Tested: 

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### How Has This Change Been Documented:

If applicable (for UI changes or new features) provide a link to a PR that updates the relevant documentation pages.



