### PR TITLE
Fix panellsOpen context storing incorrect values

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -67,6 +67,11 @@ export function deactivate(context: ExtensionContext): undefined {
 }
 
 export async function activate(context: ExtensionContext) {
+  // We reset RNIDE.panelIsOpen context to false on activation
+  // to avoid situations when "Open IDE Panel" button is not shown
+  // after improper deactivation of the extension.
+  commands.executeCommand("setContext", "RNIDE.panelIsOpen", false);
+
   context.subscriptions.push(
     window.registerWebviewPanelSerializer(TabPanel.viewType, new TabPanelSerializer())
   );


### PR DESCRIPTION
This PR fixes an issue with `RNIDE.panellsOpen` context value still being set to `true` after extensions were restarted. 

This caused "open IDE panel" command to be not shown to the user after restarting extensions

### How Has This Been Tested: 

 - Build a packege out of the code on this branch 
 - install it 
 - open a test app 
 - disable the extension and restart all extensions 
 - enable extension 

before the changes "open IDE Panel" was not showing up in the UI. 


