### PR TITLE
Prevent error panel from opening in production builds 

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -50,8 +50,8 @@ function handleUncaughtErrors(context: ExtensionContext) {
       return;
     }
     Logger.error("Uncaught exception", error);
-    Logger.openOutputPanel();
     if (context.extensionMode === ExtensionMode.Development) {
+      Logger.openOutputPanel();
       window.showErrorMessage("Internal extension error.", "Dismiss");
     }
   });


### PR DESCRIPTION
Current `uncaughtError` handling captures errors, which are unrelated to `Radon IDE`.
As a result, errors coming from unrelated extensions like `gitlens` or `copilot` are causing `Radon IDE` output panel to open, despite no errors being encountered by `Radon IDE` itself.

This PR prevents the panel from opening automatically on production builds of `Radon IDE`. 

Fixes #1292

### How Has This Been Tested: 

- Have `copilot` extension installed (this extension consistently throws `uncaughtError` on my and @robertherber's setups)
- The `Radon IDE` output panel no longer automatically opens on IDE startup due to errors in `gitlens` and `copilot`.
 