### PR TITLE
Add a fallback for simulator server image when no is provided

### DIFF
--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -76,7 +76,7 @@ export function generateWebviewContent(
       </head>
       <body data-use-code-theme="${useCodeTheme}">
         <div id="root"></div>
-        <script nonce="${nonce}">window.RNIDE_hostOS = "${Platform.OS}";</script>
+        <script nonce="${nonce}">window.RNIDE_hostOS = "${Platform.OS}";window.RNIDE_isDev = ${IS_DEV};</script>
         <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
       </body>
     </html>

--- a/packages/vscode-extension/src/webview/Preview/MjpegImg.tsx
+++ b/packages/vscode-extension/src/webview/Preview/MjpegImg.tsx
@@ -1,6 +1,13 @@
 import { useEffect, forwardRef, RefObject } from "react";
+import { IS_DEV } from "../providers/UtilsProvider";
 
-const NO_IMAGE_DATA = "data:,";
+const NO_IMAGE_DATA_PRODUCTION =
+  "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' fill='black'/></svg>";
+
+const NO_IMAGE_DATA_DEV =
+  "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' fill='gray'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='white' font-size='20'>No Image</text></svg>";
+
+const NO_IMAGE_DATA = IS_DEV ? NO_IMAGE_DATA_DEV : NO_IMAGE_DATA_PRODUCTION;
 
 const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
   (props, ref) => {
@@ -61,7 +68,14 @@ const MjpegImg = forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageE
       };
     }, [ref]);
 
-    return <img ref={ref} {...rest} />;
+    function handleError(e: React.SyntheticEvent<HTMLImageElement, Event>) {
+      const img = e.currentTarget;
+      if (img.src !== NO_IMAGE_DATA) {
+        img.src = NO_IMAGE_DATA;
+      }
+    }
+
+    return <img ref={ref} {...rest} onError={handleError} />;
   }
 );
 

--- a/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/UtilsProvider.tsx
@@ -7,8 +7,11 @@ declare global {
   interface Window {
     // set in generateWebviewContent()
     RNIDE_hostOS: "macos" | "windows" | "linux";
+    RNIDE_isDev: boolean;
   }
 }
+
+export const IS_DEV = window.RNIDE_isDev;
 
 export const Platform = {
   OS: window.RNIDE_hostOS,


### PR DESCRIPTION
This PR adds a fallback for when simulator server is killed but the webview still tries to read the stream. 

To do this in a way that will not disrupt our  ability to diagnose problems within the IDE we introduce new `IS_DEV` value passed down to the webview and conditionally render the visible (and annoying)  "NO IMAGE" warning if we are in the development mode. 

In production we replace the stream with a black screen to mask any imperfections in our state management and provide better user experience.

Dev: 

<img width="347" alt="Screenshot 2025-07-08 at 12 22 42" src="https://github.com/user-attachments/assets/cede927a-57ab-4104-98db-7dbd9d0ffb2b" />

Production: 

https://github.com/user-attachments/assets/e81cf7bd-a84e-4fc8-8820-7cf70e6da321

### How Has This Been Tested: 

- Run any test application and wait for the stream to be visible 
- find `simulator-server-macos` process in activity monitor and kill it 
- do it both for prod and dev environment.

### How Has This Change Been Documented:

Not applicable



