### PR TITLE
Add warning when the currently selected custom config is removed

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.test.ts
@@ -4,7 +4,12 @@ import { describe, afterEach, beforeEach, it } from "mocha";
 
 import { BuildType } from "../common/BuildConfig";
 import { DevicePlatform } from "../common/DeviceManager";
-import { CustomBuild, EasConfig, LaunchConfiguration } from "../common/LaunchConfig";
+import {
+  CustomBuild,
+  EasConfig,
+  LaunchConfiguration,
+  LaunchConfigurationKind,
+} from "../common/LaunchConfig";
 import { createBuildConfig, inferBuildType } from "./BuildManager";
 import * as ExpoGo from "./expoGo";
 
@@ -35,6 +40,7 @@ function toPlatformConfig<T>(
 }
 
 const COMMON_CONFIG: LaunchConfiguration = {
+  kind: LaunchConfigurationKind.Detected,
   appRoot: APP_ROOT,
   absoluteAppRoot: APP_ROOT_ABSOLUTE,
   env: {},

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -54,7 +54,13 @@ export interface AndroidLaunchConfiguration {
   productFlavor?: string;
 }
 
+export enum LaunchConfigurationKind {
+  Custom = "Custom",
+  Detected = "Detected",
+}
+
 export type LaunchConfiguration = LaunchConfigurationOptions & {
+  kind: LaunchConfigurationKind;
   absoluteAppRoot: string;
   appRoot: string;
   env: Record<string, string>;

--- a/packages/vscode-extension/src/project/launchConfigurationsManager.ts
+++ b/packages/vscode-extension/src/project/launchConfigurationsManager.ts
@@ -41,7 +41,8 @@ export function launchConfigurationFromOptions(
 
 function launchConfigFromOptionsWithDefaultAppRoot(
   options: LaunchConfigurationOptions,
-  defaultAppRoot: string | undefined
+  defaultAppRoot: string | undefined,
+  launchConfigurationKind: LaunchConfigurationKind = LaunchConfigurationKind.Custom
 ): LaunchConfiguration {
   if ((options.appRoot ?? defaultAppRoot) === undefined) {
     const maybeName =
@@ -54,7 +55,7 @@ function launchConfigFromOptionsWithDefaultAppRoot(
   const appRoot = (options.appRoot ?? defaultAppRoot) as string;
   const absoluteAppRoot = path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
   return {
-    kind: LaunchConfigurationKind.Custom,
+    kind: launchConfigurationKind,
     appRoot,
     absoluteAppRoot,
     env: {},
@@ -110,8 +111,9 @@ export class LaunchConfigurationsManager implements Disposable {
       return this._launchConfigurations[0];
     }
     return launchConfigFromOptionsWithDefaultAppRoot(
-      { kind: LaunchConfigurationKind.Detected } as LaunchConfigurationOptions,
-      findDefaultAppRoot(true)
+      {},
+      findDefaultAppRoot(true),
+      LaunchConfigurationKind.Detected
     );
   }
 

--- a/packages/vscode-extension/src/project/launchConfigurationsManager.ts
+++ b/packages/vscode-extension/src/project/launchConfigurationsManager.ts
@@ -2,7 +2,11 @@ import path from "path";
 import { ConfigurationChangeEvent, Disposable, EventEmitter, workspace } from "vscode";
 import vscode from "vscode";
 import _ from "lodash";
-import { LaunchConfiguration, LaunchConfigurationOptions } from "../common/LaunchConfig";
+import {
+  LaunchConfiguration,
+  LaunchConfigurationKind,
+  LaunchConfigurationOptions,
+} from "../common/LaunchConfig";
 import { Logger } from "../Logger";
 import { findAppRootCandidates } from "../utilities/extensionContext";
 import { getLaunchConfigurations } from "../utilities/launchConfiguration";
@@ -50,6 +54,7 @@ function launchConfigFromOptionsWithDefaultAppRoot(
   const appRoot = (options.appRoot ?? defaultAppRoot) as string;
   const absoluteAppRoot = path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
   return {
+    kind: LaunchConfigurationKind.Custom,
     appRoot,
     absoluteAppRoot,
     env: {},
@@ -104,7 +109,10 @@ export class LaunchConfigurationsManager implements Disposable {
     if (this._launchConfigurations.length > 0) {
       return this._launchConfigurations[0];
     }
-    return launchConfigFromOptionsWithDefaultAppRoot({}, findDefaultAppRoot(true));
+    return launchConfigFromOptionsWithDefaultAppRoot(
+      { kind: LaunchConfigurationKind.Detected } as LaunchConfigurationOptions,
+      findDefaultAppRoot(true)
+    );
   }
 
   public async createOrUpdateLaunchConfiguration(

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -2,13 +2,19 @@ import * as Select from "@radix-ui/react-select";
 import "./AppRootSelect.css";
 import "./shared/Dropdown.css";
 import _ from "lodash";
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useEffect } from "react";
 import { useProject } from "../providers/ProjectProvider";
-import { LaunchConfiguration, LaunchConfigurationOptions } from "../../common/LaunchConfig";
+import {
+  LaunchConfiguration,
+  LaunchConfigurationKind,
+  LaunchConfigurationOptions,
+} from "../../common/LaunchConfig";
 import RichSelectItem from "./shared/RichSelectItem";
 import { useModal } from "../providers/ModalProvider";
 import LaunchConfigurationView from "../views/LaunchConfigurationView";
 import { useApplicationRoots } from "../providers/ApplicationRootsProvider";
+import IconButton from "./shared/IconButton";
+import { useAlert } from "../providers/AlertProvider";
 
 const SelectItem = React.forwardRef<HTMLDivElement, PropsWithChildren<Select.SelectItemProps>>(
   ({ children, ...props }, forwardedRef) => (
@@ -103,6 +109,35 @@ function renderCustomLaunchConfigurations(
   );
 }
 
+function useUnknownConfigurationAlert(shouldOpen: boolean) {
+  const { openAlert, closeAlert, isOpen } = useAlert();
+
+  const alertId = "unknown-launch-configuration-alert";
+
+  useEffect(() => {
+    if (shouldOpen && !isOpen(alertId)) {
+      openAlert({
+        id: alertId,
+        title: "Unknown launch configuration",
+        description:
+          "The selected launch configration is no longer specified in the launch.json file. " +
+          "Radon IDE will continue to use the last selected configuration, but you may want to select a different one.",
+        priority: 1,
+        actions: (
+          <IconButton
+            type="secondary"
+            onClick={() => closeAlert(alertId)}
+            tooltip={{ label: "Close notification", side: "bottom" }}>
+            <span className="codicon codicon-close" />
+          </IconButton>
+        ),
+      });
+    } else if (!shouldOpen && isOpen(alertId)) {
+      closeAlert(alertId);
+    }
+  }, [shouldOpen]);
+}
+
 function AppRootSelect() {
   const applicationRoots = useApplicationRoots();
   const { projectState, project } = useProject();
@@ -121,6 +156,7 @@ function AppRootSelect() {
   const detectedConfigurations: LaunchConfigurationOptions[] = applicationRoots.map(
     ({ path, displayName, name }) => {
       return {
+        kind: LaunchConfigurationKind.Detected,
         appRoot: path,
         name: displayName || name,
       };
@@ -149,26 +185,28 @@ function AppRootSelect() {
   const value = selectedConfigName ?? selectedAppRootName;
 
   const selectedValue = (() => {
-    if (selectedConfiguration) {
+    if (selectedConfiguration.kind === LaunchConfigurationKind.Custom) {
       const index = customConfigurations.findIndex((config) =>
         _.isEqual(config, selectedConfiguration)
       );
-      if (index !== -1) {
-        return `custom:${index}`;
-      }
+      return index !== -1 ? `custom:${index}` : "unknown";
+    } else {
+      const index = detectedConfigurations.findIndex(
+        (config) => config.appRoot === selectedAppRootPath
+      );
+      return index !== -1 ? `detected:${index}` : "unknown";
     }
-    const index = detectedConfigurations.findIndex(
-      (config) => config.appRoot === selectedAppRootPath
-    );
-    return index !== -1 ? `detected:${index}` : undefined;
   })();
+
+  useUnknownConfigurationAlert(selectedValue === "unknown");
+
+  const configurationsCount = detectedConfigurations.length + customConfigurations.length;
+  const placeholder = configurationsCount === 0 ? "No applications found" : "Select application";
 
   return (
     <Select.Root onValueChange={handleAppRootChange} value={selectedValue}>
-      <Select.Trigger
-        className="approot-select-trigger"
-        disabled={detectedConfigurations.length + customConfigurations.length === 0}>
-        <Select.Value placeholder="No applications found">
+      <Select.Trigger className="approot-select-trigger" disabled={configurationsCount === 0}>
+        <Select.Value placeholder={placeholder}>
           <div className="approot-select-value">
             <span className="codicon codicon-folder-opened" />
             <span className="approot-select-value-text">{value}</span>
@@ -187,9 +225,7 @@ function AppRootSelect() {
           <Select.Viewport className="approot-select-viewport">
             {renderDetectedLaunchConfigurations(detectedConfigurations, selectedValue)}
             {renderCustomLaunchConfigurations(customConfigurations, selectedValue, onEditConfig)}
-            {detectedConfigurations.length + customConfigurations.length > 0 && (
-              <Select.Separator className="approot-select-separator" />
-            )}
+            {configurationsCount > 0 && <Select.Separator className="approot-select-separator" />}
             <SelectItem value="manage">
               <span className="codicon codicon-add" />
               <span> Add custom launch config</span>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -178,11 +178,6 @@ function AppRootSelect() {
     project.selectLaunchConfiguration(launchConfiguration);
   };
 
-  const selectedAppRootName =
-    selectedAppRoot?.displayName ?? selectedAppRoot?.name ?? selectedAppRootPath;
-  const selectedConfigName = displayNameForConfig(selectedConfiguration);
-  const value = selectedConfigName ?? selectedAppRootName;
-
   const selectedValue = (() => {
     if (selectedConfiguration.kind === LaunchConfigurationKind.Custom) {
       const index = customConfigurations.findIndex((config) =>
@@ -201,6 +196,10 @@ function AppRootSelect() {
 
   const configurationsCount = detectedConfigurations.length + customConfigurations.length;
   const placeholder = configurationsCount === 0 ? "No applications found" : "Select application";
+  const selectedAppRootName =
+    selectedAppRoot?.displayName ?? selectedAppRoot?.name ?? selectedAppRootPath;
+  const selectedConfigName = displayNameForConfig(selectedConfiguration);
+  const value = selectedConfigName ?? selectedAppRootName ?? placeholder;
 
   return (
     <Select.Root onValueChange={handleAppRootChange} value={selectedValue}>

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -120,7 +120,7 @@ function useUnknownConfigurationAlert(shouldOpen: boolean) {
         id: alertId,
         title: "Unknown launch configuration",
         description:
-          "The selected launch configration is no longer specified in the workspace's launch.json file. " +
+          "The selected launch configration was deleted or modified in the workspace's launch.json file. " +
           "Radon IDE will continue to use the last selected configuration, but you may want to select a different one.",
         actions: (
           <IconButton

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -120,7 +120,7 @@ function useUnknownConfigurationAlert(shouldOpen: boolean) {
         id: alertId,
         title: "Unknown launch configuration",
         description:
-          "The selected launch configration is no longer specified in the launch.json file. " +
+          "The selected launch configration is no longer specified in the workspace's launch.json file. " +
           "Radon IDE will continue to use the last selected configuration, but you may want to select a different one.",
         actions: (
           <IconButton

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -122,7 +122,6 @@ function useUnknownConfigurationAlert(shouldOpen: boolean) {
         description:
           "The selected launch configration is no longer specified in the launch.json file. " +
           "Radon IDE will continue to use the last selected configuration, but you may want to select a different one.",
-        priority: 1,
         actions: (
           <IconButton
             type="secondary"

--- a/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ProjectProvider.tsx
@@ -16,6 +16,7 @@ import {
   ProjectInterface,
   ProjectState,
 } from "../../common/Project";
+import { LaunchConfigurationKind } from "../../common/LaunchConfig";
 
 const project = makeProxy<ProjectInterface>("Project");
 
@@ -37,6 +38,7 @@ const defaultProjectState: ProjectState = {
   initialized: false,
   customLaunchConfigurations: [],
   selectedLaunchConfiguration: {
+    kind: LaunchConfigurationKind.Detected,
     appRoot: "./",
     absoluteAppRoot: "/",
     env: {},


### PR DESCRIPTION
Displays an alert when the currently selected custom config is removed from the `launch.json` file, either because the file is edited by hand, or through the "Delete" option in the UI.

![image](https://github.com/user-attachments/assets/0e89ee9f-7cd5-4969-8a53-359b67cc6fc5)

### How Has This Been Tested: 
- add a custom launch configuration and select it
- verify that removing it in various ways makes the alert appear:
  - remove it via UI (launch config select -> gear icon -> "Delete" button in modal)
  - remove it from the `launch.json` file manually
  - change it in the `launch.json` file manually
- verify the alert can be dismissed with the "close" button