### PR TITLE
fix multiple AppRoots alert showing when only a single AppRoot is detected

### DIFF
--- a/packages/vscode-extension/src/project/launchConfigurationsManager.ts
+++ b/packages/vscode-extension/src/project/launchConfigurationsManager.ts
@@ -13,7 +13,7 @@ function findDefaultAppRoot(showWarning = false) {
   const defaultAppRoot = appRoots.length > 0 ? appRoots[0] : undefined;
   const defaultAppRootRelative =
     defaultAppRoot && "./" + path.relative(workspacePath, defaultAppRoot);
-  if (appRoots.length > 0 && showWarning) {
+  if (appRoots.length > 1 && showWarning) {
     vscode.window
       .showWarningMessage(
         "Multiple application roots found in workspace, but no 'appRoot' specified in launch configuration. Using the first found application root: " +


### PR DESCRIPTION
fix multiple AppRoots alert showing when only a single AppRoot is detected

### How Has This Been Tested: 
- open the RN-80 test app
- the "Multiple application roots found in workspace" alert should not appear