### PR TITLE
remove the legacy "react-native-ide" launch config

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -678,20 +678,7 @@
               }
             }
           }
-        },
-        "initialConfigurations": [
-          {
-            "type": "react-native-ide",
-            "request": "launch",
-            "name": "Radon IDE panel",
-            "ios": {
-              "configuration": "Debug"
-            },
-            "android": {
-              "buildType": "debug"
-            }
-          }
-        ]
+        }
       }
     ],
     "walkthroughs": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -599,7 +599,7 @@
       {
         "type": "react-native-ide",
         "label": "Radon IDE",
-        "deprecated": "true",
+        "deprecated": "Use `radon-ide` instead",
         "languages": [
           "javascript",
           "typescript",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -612,7 +612,7 @@
             "properties": {
               "appRoot": {
                 "type": "string",
-                "description": "Location of the React Native application root folder relative to the workspace. This is used for monorepo type setups when the workspace root is not the root of the React Native project. The IDE extension tries to locate the React Native application root automatically, but in case it failes to do so (i.e. there are multiple applications defined in the workspace), you can use this setting to override the location."
+                "description": "Location of the React Native application root folder relative to the workspace. This is used for monorepo type setups when the workspace root is not the root of the React Native project. The IDE extension tries to locate the React Native application root automatically, but in case it fails to do so (i.e. there are multiple applications defined in the workspace), you can use this setting to override the location."
               },
               "isExpo": {
                 "type": "boolean",
@@ -629,6 +629,88 @@
               "expoStartArgs": {
                 "type": "array",
                 "description": "Extra arguments to pass to Expo start command."
+              },
+              "customBuild": {
+                "type": "object",
+                "description": "Configuration for using custom scripts for building and fingerprinting the app.",
+                "properties": {
+                  "ios": {
+                    "type": "object",
+                    "description": "Configuration for iOS.",
+                    "properties": {
+                      "buildCommand": {
+                        "type": "string",
+                        "description": "Script used to build the app. It should build the app in debug mode and print path to the built app as a last line of its standard output."
+                      },
+                      "fingerprintCommand": {
+                        "type": "string",
+                        "description": "Script used to fingerprint the app. It should print workspace hash as a last line of its standard output."
+                      }
+                    }
+                  },
+                  "android": {
+                    "type": "object",
+                    "description": "Configuration for Android.",
+                    "properties": {
+                      "buildCommand": {
+                        "type": "string",
+                        "description": "Script used to build the app. It should build the app in debug mode and print path to the built app as a last line of its standard output."
+                      },
+                      "fingerprintCommand": {
+                        "type": "string",
+                        "description": "Script used to fingerprint the app. It should print workspace hash as a last line of its standard output."
+                      }
+                    }
+                  }
+                }
+              },
+              "eas": {
+                "type": "object",
+                "description": "Configuration for EAS build service",
+                "properties": {
+                  "android": {
+                    "type": "object",
+                    "description": "Configuration for EAS build service for Android",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "description": "Profile used to build the app in EAS. Built app should be in debug version."
+                      },
+                      "buildUUID": {
+                        "type": "string",
+                        "description": "UUID of the EAS build used in `eas build:view` command. If unspecified, will use a build with matching fingerprint if available."
+                      },
+                      "local": {
+                        "type": "boolean",
+                        "description": "When set, builds the app locally using EAS CLI."
+                      }
+                    },
+                    "required": [
+                      "profile"
+                    ]
+                  },
+                  "ios": {
+                    "type": "object",
+                    "description": "Configuration for EAS build service for iOS",
+                    "properties": {
+                      "profile": {
+                        "type": "string",
+                        "description": "Profile used to build the app in EAS. Built app should be in debug version and have '\"ios.simulator\": true' option set."
+                      },
+                      "buildUUID": {
+                        "type": "string",
+                        "description": "UUID of the EAS build used in `eas build:view` command. If unspecified, will use a build with matching fingerprint if available."
+                      },
+                      "local": {
+                        "type": "boolean",
+                        "description": "When set, builds the app locally using EAS CLI."
+                      }
+                    },
+                    "required": [
+                      "profile"
+                    ]
+                  }
+                }
               },
               "ios": {
                 "description": "Provides a way to customize Xcode builds for iOS",


### PR DESCRIPTION
Removes the duplicate "Radon IDE" entry from the vscode debuggers suggestions.
Updates the deprecation message for `react-native-ide` debugger type.
Updates the configuration attributes for `react-native-ide` debugger type to match `radon-ide`

### How Has This Been Tested: 
- open a project without a `launch.json` file
- go to "Run and Debug" menu
- press "Start debugging"
- the drop-down with available debuggers should include a single "Radon IDE" entry