### PR TITLE
improve themeing in launch configuration modal

### DIFF
--- a/packages/vscode-extension/src/webview/styles/theme.css
+++ b/packages/vscode-extension/src/webview/styles/theme.css
@@ -611,6 +611,7 @@ body[data-use-code-theme="true"] {
   --swm-scrollbar-thumb: var(--vscode-scrollbarSlider-background);
   --swm-scrollbar-hover: var(--vscode-scrollbarSlider-hoverBackground);
   --swm-select-hover-background: var(--vscode-list-hoverBackground);
+  --swm-select-shadow: 0 1px 10px var(--vscode-widget-shadow);
   --swm-select-disabled: var(--vscode-disabledForeground);
   --swm-select-item-highlighted-background: var(--vscode-list-hoverBackground);
   --swm-select-border: var(--vscode-input-border);

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.css
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.css
@@ -62,4 +62,5 @@
   flex: 1;
   flex-direction: column;
   overflow: scroll;
+  scrollbar-color: var(--swm-scrollbar-thumb) var(--swm-popover-background);
 }


### PR DESCRIPTION
Improve how vscode themes are applied in the Launch Configuration modal 

Before:
![image](https://github.com/user-attachments/assets/196670da-c1a3-450c-b880-1c1aebb6a282)


After:
![image](https://github.com/user-attachments/assets/cb2fc8ad-f15e-4c5e-8b18-9d8186b77651)

### How Has This Been Tested: 
- open the launch configuration modal
- your eyes shouldn't bleed as much