### PR TITLE
Restore last used launch config on IDE start

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -48,32 +48,10 @@ import { LaunchConfiguration, LaunchConfigurationOptions } from "../common/Launc
 
 const PREVIEW_ZOOM_KEY = "preview_zoom";
 const DEEP_LINKS_HISTORY_KEY = "deep_links_history";
-const INITIAL_LAUNCH_CONFIGURATION_KEY = "initialLaunchConfiguration";
 
 const DEEP_LINKS_HISTORY_LIMIT = 50;
 
 const MAX_RECORDING_TIME_SEC = 10 * 60; // 10 minutes
-
-function getInitialLaunchConfig(launchConfigsManager: LaunchConfigurationsManager) {
-  const workspaceState = extensionContext.workspaceState;
-  const savedLaunchConfig = workspaceState.get<LaunchConfiguration | undefined>(
-    INITIAL_LAUNCH_CONFIGURATION_KEY
-  );
-  if (
-    savedLaunchConfig &&
-    launchConfigsManager.launchConfigurations.find((config) => _.isEqual(config, savedLaunchConfig))
-  ) {
-    // If the saved launch config is still valid, return it
-    return savedLaunchConfig;
-  }
-  // Otherwise, return the first launch config or a default one
-  return launchConfigsManager.initialLaunchConfiguration;
-}
-
-function saveInitialLaunchConfig(launchConfig: LaunchConfiguration) {
-  const workspaceState = extensionContext.workspaceState;
-  workspaceState.update(INITIAL_LAUNCH_CONFIGURATION_KEY, launchConfig);
-}
 
 export class Project implements Disposable, ProjectInterface, DeviceSessionsManagerDelegate {
   private launchConfigsManager = new LaunchConfigurationsManager();
@@ -98,7 +76,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   ) {
     const fingerprintProvider = new FingerprintProvider();
     const buildCache = new BuildCache(fingerprintProvider);
-    const initialLaunchConfig = getInitialLaunchConfig(this.launchConfigsManager);
+    const initialLaunchConfig = this.launchConfigsManager.initialLaunchConfiguration;
     this.applicationContext = new ApplicationContext(initialLaunchConfig, buildCache);
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
@@ -167,7 +145,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       this
     );
     oldDeviceSessionsManager.dispose();
-    saveInitialLaunchConfig(launchConfig);
+    this.launchConfigsManager.saveInitialLaunchConfig(launchConfig);
     this.updateProjectState({
       appRootPath: this.relativeAppRootPath,
       selectedLaunchConfiguration: launchConfig,


### PR DESCRIPTION
Restores the last used launch configuration on start.
The implementation checks if the last used config is still configured, and if not, falls back to the first config on the list.

### How Has This Been Tested: 
- open a workspace
- add two (or more) launch configs
- select any custom config
- close and reopen the IDE
- the same config should be selected


