### PR TITLE
fix multitouch anchor moving if shift is depressed while unfocused

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -75,7 +75,6 @@ function Preview({
   const wrapperDivRef = useRef<HTMLDivElement>(null);
   const [isPressing, setIsPressing] = useState(false);
   const [isMultiTouching, setIsMultiTouching] = useState(false);
-  const [isPanning, setIsPanning] = useState(false);
   const [touchPoint, setTouchPoint] = useState<Point>({ x: 0.5, y: 0.5 });
   const [anchorPoint, setAnchorPoint] = useState<Point>({ x: 0.5, y: 0.5 });
   const previewRef = useRef<HTMLImageElement>(null);
@@ -209,7 +208,7 @@ function Preview({
       sendInspect(e, "Move", false);
     } else if (isMultiTouching) {
       setTouchPoint(getTouchPosition(e));
-      if (isPanning) {
+      if (e.shiftKey) {
         moveAnchorPoint(e);
       }
       if (isPressing) {
@@ -355,7 +354,6 @@ function Preview({
 
     function onBlurChange() {
       if (!document.hasFocus()) {
-        setIsPanning(false);
         setIsMultiTouching(false);
         setIsPressing(false);
       }
@@ -407,8 +405,6 @@ function Preview({
           linux: e.code === "ControlLeft" || e.code === "ControlRight",
         });
 
-        const isPanningKey = e.code === "ShiftLeft" || e.code === "ShiftRight";
-
         if (isMultiTouchKey && isKeydown) {
           setAnchorPoint({
             x: 0.5,
@@ -422,10 +418,6 @@ function Preview({
           sendMultiTouch(touchPoint, "Up");
           setIsPressing(false);
           setIsMultiTouching(false);
-        }
-
-        if (isPanningKey) {
-          setIsPanning(isKeydown);
         }
 
         dispatchKeyPress(e);


### PR DESCRIPTION
Fixes #1319 
The issue was caused by Shift being pressed while Radon had focus (being a part of keyboard shortcuts for DevTools and video recording), but depressed once focus switched away from Radon, causing the `isPanning` state to be stuck set to `true` until the shift key was pressed again.

### How Has This Been Tested: 
- open an app in radon ide
- start multitouch by holding Alt/Option
- open the vscode command palette by pressing Ctrl/Cmd + Shift + P
- close the command palette and move the mouse
- the multitouch anchor should stay in place instead of moving as if the Shift key was held