### PR TITLE
select launch config when started from vscode UI

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -325,10 +325,16 @@ export async function activate(context: ExtensionContext) {
 }
 
 class LaunchConfigDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
-  createDebugAdapterDescriptor(
+  async createDebugAdapterDescriptor(
     session: vscode.DebugSession
-  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    commands.executeCommand("RNIDE.openPanel");
+  ): Promise<vscode.DebugAdapterDescriptor> {
+    await commands.executeCommand("RNIDE.openPanel");
+    const ide = IDE.attach();
+    try {
+      ide.project.selectLaunchConfiguration(session.configuration);
+    } finally {
+      ide.detach();
+    }
     // we can't return undefined or throw here because then VSCode displays an ugly error dialog
     // so we return a dummy adapter that calls echo command and exists immediately
     return new DebugAdapterExecutable("echo", ["noop"]);


### PR DESCRIPTION
When opening Radon via the launch action in the "Run and Debug" menu, selects the run launch configuration in Radon automatically.

### How Has This Been Tested: 
- open vscode window (with Radon closed)
- configure multiple launch configurations
- "Run and Debug" menu
- select a config from the dropdown and press "Start debugging"
- Radon should open with the chosen configuration selected
- select a different config and press "Start debugging"
- Radon should switch to the chosen configuration

