### PR TITLE
hotfix: unknown configuration alert shown during project initialization

### DIFF
--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -192,7 +192,7 @@ function AppRootSelect() {
     }
   })();
 
-  useUnknownConfigurationAlert(selectedValue === "unknown");
+  useUnknownConfigurationAlert(projectState.initialized && selectedValue === "unknown");
 
   const configurationsCount = detectedConfigurations.length + customConfigurations.length;
   const placeholder = configurationsCount === 0 ? "No applications found" : "Select application";


### PR DESCRIPTION
Fixes the "Unknown Launch Configuration" alert being briefly shown while the IDE starts.

### How Has This Been Tested: 
- start Radon with a custom config set up
- the alert should not appear while the IDE is initializing



