### PR TITLE
hotifx: don't serialize launch config `kind` field

### DIFF
--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -36,6 +36,7 @@ export function optionsForLaunchConfiguration(
   config: LaunchConfiguration
 ): LaunchConfigurationOptions {
   const options: LaunchConfigurationOptions & Partial<LaunchConfiguration> = { ...config };
+  delete options.kind;
   delete options.absoluteAppRoot;
   if (options.preview?.waitForAppLaunch) {
     delete options.preview;


### PR DESCRIPTION
Fixes the `kind` launch configuration field being serialized despite being meant for internal use

### How Has This Been Tested: 
- save a launch config through the UI
- verify the entry in `launch.json` does not have a `kind` field



