### PR TITLE
fix selecting device from Radon Connect

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -39,7 +39,6 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     private readonly deviceManager: DeviceManager,
     private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate
   ) {
-    this.findInitialDeviceAndStartSession();
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.addListener("devicesChanged", this.devicesChangedListener);
   }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -104,13 +104,13 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       },
     };
 
+    this.maybeStartInitialDeviceSession();
+
     this.disposables.push(
       connector.onConnectStateChanged((connectState) => {
         this.updateProjectState({ connectState });
         if (connectState.enabled) {
           this.deviceSessionsManager.terminateAllSessions();
-        } else {
-          this.deviceSessionsManager.findInitialDeviceAndStartSession();
         }
       })
     );
@@ -166,6 +166,8 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       this
     );
     oldDeviceSessionsManager.dispose();
+    this.maybeStartInitialDeviceSession();
+
     this.launchConfigsManager.saveInitialLaunchConfig(launchConfig);
     this.updateProjectState({
       appRootPath: this.relativeAppRootPath,
@@ -198,6 +200,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   get buildCache() {
     return this.applicationContext.buildCache;
+  }
+
+  private maybeStartInitialDeviceSession() {
+    if (!Connector.getInstance().isEnabled && !this.deviceSessionsManager.selectedDeviceSession) {
+      this.deviceSessionsManager.findInitialDeviceAndStartSession();
+    }
   }
 
   private get selectedDeviceSessionState(): DeviceSessionState | undefined {


### PR DESCRIPTION
After #1314 switching to an emulated device from Radon Connect causes the first device on the list to be started as well. 

https://github.com/user-attachments/assets/ccdd48ae-f5b8-4153-bd41-9093ea04e0ce

### How Has This Been Tested: 
- switch between Radon Connect and different emulated devices
- verify the correct device is used each time



