### PR TITLE
fix: reload button disabled while starting

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -248,7 +248,7 @@ function PreviewView() {
       }}>
       <div className="button-group-top">
         <div className="button-group-top-left">
-          <UrlBar disabled={!navBarButtonsActive} />
+          <UrlBar disabled={!selectedDeviceSession} />
         </div>
         <div className="button-group-top-right">
           <ProfilingButton


### PR DESCRIPTION
Fixes the Reload button being disabled while starting the device / app. This was introduced in #1314 

### How Has This Been Tested: 
- open app in Radon
- verify you can restart the app while it's still building

