### PR TITLE
fix: enable radon connect button trigger incorrect action

### DIFF
--- a/packages/vscode-extension/src/common/utils.ts
+++ b/packages/vscode-extension/src/common/utils.ts
@@ -22,6 +22,8 @@ export interface UtilsInterface {
 
   movePanelTo(location: IDEPanelMoveTarget): Promise<void>;
 
+  enableRadonConnect(): Promise<void>;
+
   showDismissableError(errorMessage: string): Promise<void>;
 
   openExternalUrl(uriString: string): Promise<void>;

--- a/packages/vscode-extension/src/utilities/utils.ts
+++ b/packages/vscode-extension/src/utilities/utils.ts
@@ -132,6 +132,10 @@ export class Utils implements UtilsInterface {
     commands.executeCommand("RNIDE.showPanel", location);
   }
 
+  public async enableRadonConnect() {
+    commands.executeCommand("RNIDE.enableRadonConnect");
+  }
+
   public async showDismissableError(errorMessage: string) {
     window.showErrorMessage(errorMessage, "Dismiss");
   }

--- a/packages/vscode-extension/src/webview/views/NoDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/NoDeviceView.tsx
@@ -82,6 +82,10 @@ export default function NoDeviceView({ hasNoDevices }: { hasNoDevices: boolean }
     openModal("Manage devices", <ManageDevicesView />);
   }
 
+  function enableRadonConnect() {
+    utils.enableRadonConnect();
+  }
+
   async function createAndroidDevice() {
     if (errors?.emulator) {
       utils.showDismissableError(errors?.emulator.message);
@@ -169,7 +173,7 @@ export default function NoDeviceView({ hasNoDevices }: { hasNoDevices: boolean }
         Create new device
       </Button>
       <h2 className="devices-not-found-title">Bring your own device or simulator</h2>
-      <Button onClick={openCreateNewDeviceModal}>
+      <Button onClick={enableRadonConnect}>
         <span className="codicon codicon-debug-disconnect" />
         Enable Radon Connect
       </Button>


### PR DESCRIPTION
This PR fixes an issue with "enable radon connect" button on the home screen triggering create device modal 

Before: 

https://github.com/user-attachments/assets/ab2e62c5-bcc3-4af6-8bd4-b95ab21cc805

After: 

https://github.com/user-attachments/assets/d3aeec16-9b03-4cee-841c-905da33a47e6


### How Has This Been Tested: 

-run external metro proces and navigate to "No device view" then try out the "Enable radon connect"  button 



