### PR TITLE
refactor: remove BuildManager's dependency on DependencyManager

### DIFF
--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -49,7 +49,11 @@ describe("BatchingBuildManager", () => {
     describe(`for ${platform}`, () => {
       it("should call the wrapped build manager's buildApp method", async () => {
         const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
-        const options = { progressListener, cancelToken: new CancelToken() };
+        const options = {
+          progressListener,
+          cancelToken: new CancelToken(),
+          buildOutputChannel: {} as any,
+        };
 
         buildAppMock.resolves(BUILD_RESULT);
         const result = await batchingBuildManager.buildApp(BUILD_CONFIG, options);

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -75,6 +75,7 @@ export class BatchingBuildManager implements BuildManager, Disposable {
         progressListener: (newProgress) => {
           buildInProgress.onProgress(newProgress);
         },
+        buildOutputChannel: options.buildOutputChannel,
       }),
       cancelTokenForBuild
     );

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -1,18 +1,16 @@
 import assert from "assert";
 import _ from "lodash";
+import { OutputChannel } from "vscode";
 import { BuildCache } from "./BuildCache";
 import { AndroidBuildResult, buildAndroid } from "./buildAndroid";
 import { IOSBuildResult, buildIos } from "./buildIOS";
 import { DevicePlatform } from "../common/DeviceManager";
-import { DependencyManager } from "../dependency/DependencyManager";
 import { CancelError, CancelToken } from "../utilities/cancelToken";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { Logger } from "../Logger";
 import { BuildConfig, BuildType } from "../common/BuildConfig";
 import { isExpoGoProject } from "./expoGo";
 import { LaunchConfiguration } from "../common/LaunchConfig";
-import { OutputChannelRegistry } from "../project/OutputChannelRegistry";
-import { Output } from "../common/OutputChannel";
 
 export type BuildResult = IOSBuildResult | AndroidBuildResult;
 
@@ -21,6 +19,7 @@ export interface BuildManager {
 }
 
 export type BuildOptions = {
+  buildOutputChannel: OutputChannel;
   progressListener: (newProgress: number) => void;
   cancelToken: CancelToken;
 };
@@ -181,27 +180,13 @@ export async function inferBuildType(
 }
 
 export class BuildManagerImpl implements BuildManager {
-  constructor(
-    private readonly dependencyManager: DependencyManager,
-    private readonly buildCache: BuildCache,
-    private readonly outputChannelRegistry: OutputChannelRegistry
-  ) {}
-
-  /**
-   * Returns true if some native build dependencies have change and we should perform
-   * a native build despite the fact the fingerprint indicates we don't need to.
-   * This is currently only used for the scenario when we detect that pods need
-   * to be reinstalled for iOS.
-   */
-  private async checkBuildDependenciesChanged(platform: DevicePlatform): Promise<boolean> {
-    if (platform === DevicePlatform.IOS) {
-      return !(await this.dependencyManager.checkPodsInstallationStatus());
-    }
-    return false;
+  constructor(private readonly buildCache: BuildCache) {
+    // Note: in future implementations decoupled from device session we
+    // should make this logic platform independent
   }
 
   public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {
-    const { progressListener, cancelToken } = options;
+    const { progressListener, cancelToken, buildOutputChannel } = options;
     const { forceCleanBuild, platform, type: buildType, appRoot } = buildConfig;
     const fingerprintOptions = {
       appRoot: buildConfig.appRoot,
@@ -221,10 +206,7 @@ export class BuildManagerImpl implements BuildManager {
 
     const currentFingerprint = await this.buildCache.calculateFingerprint(fingerprintOptions);
 
-    // Native build dependencies when changed, should invalidate cached build (even if the fingerprint is the same)
-    const buildDependenciesChanged = await this.checkBuildDependenciesChanged(platform);
-
-    if (forceCleanBuild || buildDependenciesChanged) {
+    if (forceCleanBuild) {
       // we reset the cache when force clean build is requested as the newly
       // started build may end up being cancelled
       Logger.debug(
@@ -250,50 +232,20 @@ export class BuildManagerImpl implements BuildManager {
     let buildFingerprint = currentFingerprint;
     try {
       if (platform === DevicePlatform.Android) {
-        const buildOutputChannel = this.outputChannelRegistry.getOrCreateOutputChannel(
-          Output.BuildAndroid
-        );
         buildOutputChannel.clear();
 
         assert(
           buildConfig.platform === DevicePlatform.Android,
-          "Expected build config platform to be iOS"
+          "Expected build config platform to be Android"
         );
         buildResult = await buildAndroid(
           buildConfig as BuildConfig & { platform: DevicePlatform.Android },
           cancelToken,
           buildOutputChannel,
-          progressListener,
-          this.dependencyManager
+          progressListener
         );
       } else {
-        const buildOutputChannel = this.outputChannelRegistry.getOrCreateOutputChannel(
-          Output.BuildIos
-        );
         buildOutputChannel.clear();
-        const installPodsIfNeeded = async () => {
-          let installPods = forceCleanBuild;
-          if (installPods) {
-            Logger.info("Clean build requested: installing pods");
-          } else {
-            const podsInstalled = await this.dependencyManager.checkPodsInstallationStatus();
-            if (!podsInstalled) {
-              Logger.info("Pods installation is missing or outdated. Installing Pods.");
-              installPods = true;
-            }
-          }
-          if (installPods) {
-            getTelemetryReporter().sendTelemetryEvent("build:install-pods", { platform });
-            await this.dependencyManager.installPods(buildOutputChannel, cancelToken);
-            const installed = await this.dependencyManager.checkPodsInstallationStatus();
-            if (!installed) {
-              throw new Error("Pods could not be installed automatically.");
-            }
-            // Installing pods may impact the fingerprint as new pods may be created under the project directory.
-            // For this reason we need to recalculate the fingerprint after installing pods.
-            buildFingerprint = await this.buildCache.calculateFingerprint(fingerprintOptions);
-          }
-        };
 
         assert(
           buildConfig.platform === DevicePlatform.IOS,
@@ -303,9 +255,7 @@ export class BuildManagerImpl implements BuildManager {
           buildConfig as BuildConfig & { platform: DevicePlatform.IOS },
           cancelToken,
           buildOutputChannel,
-          progressListener,
-          this.dependencyManager,
-          installPodsIfNeeded
+          progressListener
         );
       }
     } catch (e) {

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -15,7 +15,6 @@ import { DevicePlatform } from "../common/DeviceManager";
 import { getReactNativeVersion } from "../utilities/reactNative";
 import { runExternalBuild } from "./customBuild";
 import { fetchEasBuild, performLocalEasBuild } from "./eas";
-import { DependencyManager } from "../dependency/DependencyManager";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { AndroidBuildConfig, AndroidLocalBuildConfig, BuildType } from "../common/BuildConfig";
 
@@ -83,8 +82,7 @@ export async function buildAndroid(
   buildConfig: AndroidBuildConfig,
   cancelToken: CancelToken,
   outputChannel: OutputChannel,
-  progressListener: (newProgress: number) => void,
-  dependencyManager: DependencyManager
+  progressListener: (newProgress: number) => void
 ): Promise<AndroidBuildResult> {
   const { appRoot, env, type: buildType } = buildConfig;
 
@@ -157,12 +155,6 @@ export async function buildAndroid(
       return { apkPath, packageName: EXPO_GO_PACKAGE_NAME, platform: DevicePlatform.Android };
     }
     case BuildType.Local: {
-      if (!(await dependencyManager.checkAndroidDirectoryExits())) {
-        throw new Error(
-          'Your project does not have "android" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure an external build source using launch configuration.'
-        );
-      }
-
       return await buildLocal(buildConfig, cancelToken, outputChannel, progressListener);
     }
   }

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -5,16 +5,9 @@ import { disposeAll } from "../utilities/disposables";
 import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
 import { LaunchConfiguration } from "../common/LaunchConfig";
-import { OutputChannelRegistry } from "./OutputChannelRegistry";
 
-function createBuildManager(
-  dependencyManager: DependencyManager,
-  buildCache: BuildCache,
-  outputChannelRegistry: OutputChannelRegistry
-) {
-  return new BatchingBuildManager(
-    new BuildManagerImpl(dependencyManager, buildCache, outputChannelRegistry)
-  );
+function createBuildManager(buildCache: BuildCache) {
+  return new BatchingBuildManager(new BuildManagerImpl(buildCache));
 }
 
 export class ApplicationContext implements Disposable {
@@ -24,15 +17,10 @@ export class ApplicationContext implements Disposable {
 
   constructor(
     public launchConfig: LaunchConfiguration,
-    public readonly buildCache: BuildCache,
-    private readonly outputChannelRegistry: OutputChannelRegistry
+    public readonly buildCache: BuildCache
   ) {
     this.dependencyManager = new DependencyManager(this.launchConfig);
-    const buildManager = createBuildManager(
-      this.dependencyManager,
-      this.buildCache,
-      this.outputChannelRegistry
-    );
+    const buildManager = createBuildManager(this.buildCache);
     this.buildManager = buildManager;
 
     this.disposables.push(this.dependencyManager, buildManager);
@@ -54,11 +42,7 @@ export class ApplicationContext implements Disposable {
 
   public async updateAppRootFolder() {
     disposeAll(this.disposables);
-    const buildManager = createBuildManager(
-      this.dependencyManager,
-      this.buildCache,
-      this.outputChannelRegistry
-    );
+    const buildManager = createBuildManager(this.buildCache);
     this.buildManager = buildManager;
     this.disposables.push(this.dependencyManager, buildManager);
   }

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -16,6 +16,7 @@ import {
 import { disposeAll } from "../utilities/disposables";
 import { DeviceId, DeviceSessionsManagerState } from "../common/Project";
 import { Connector } from "../connect/Connector";
+import { OutputChannelRegistry } from "./OutputChannelRegistry";
 
 const LAST_SELECTED_DEVICE_KEY = "last_selected_device";
 const SWITCH_DEVICE_THROTTLE_MS = 300;
@@ -37,7 +38,8 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
   constructor(
     private readonly applicationContext: ApplicationContext,
     private readonly deviceManager: DeviceManager,
-    private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate
+    private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate,
+    private readonly outputChannelRegistry: OutputChannelRegistry
   ) {
     this.deviceManager.addListener("deviceRemoved", this.removeDeviceListener);
     this.deviceManager.addListener("devicesChanged", this.devicesChangedListener);
@@ -117,15 +119,20 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     }
     Logger.debug("Selected device is ready");
 
-    const newDeviceSession = new DeviceSession(this.applicationContext, device, {
-      onStateChange: (state) => {
-        if (!this.deviceSessions.has(state.deviceInfo.id)) {
-          // NOTE: the device is being removed, we shouldn't report state updates
-          return;
-        }
-        this.deviceSessionManagerDelegate.onDeviceSessionsManagerStateChange(this.state);
+    const newDeviceSession = new DeviceSession(
+      this.applicationContext,
+      device,
+      {
+        onStateChange: (state) => {
+          if (!this.deviceSessions.has(state.deviceInfo.id)) {
+            // NOTE: the device is being removed, we shouldn't report state updates
+            return;
+          }
+          this.deviceSessionManagerDelegate.onDeviceSessionsManagerStateChange(this.state);
+        },
       },
-    });
+      this.outputChannelRegistry
+    );
 
     this.deviceSessionManagerDelegate.onDeviceSessionsManagerStateChange(this.state);
     this.deviceSessions.set(deviceInfo.id, newDeviceSession);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -4,11 +4,11 @@ import assert from "assert";
 import _ from "lodash";
 import {
   commands,
+  window,
   DebugSessionCustomEvent,
   Disposable,
   extensions,
   Uri,
-  window,
   workspace,
 } from "vscode";
 import { MetroLauncher, MetroDelegate } from "./metro";
@@ -49,6 +49,9 @@ import { focusSource } from "../utilities/focusSource";
 import { ApplicationContext } from "./ApplicationContext";
 import { BuildCache } from "../builders/BuildCache";
 import { watchProjectFiles } from "../utilities/watchProjectFiles";
+import { BuildConfig, BuildType } from "../common/BuildConfig";
+import { OutputChannelRegistry } from "./OutputChannelRegistry";
+import { Output } from "../common/OutputChannel";
 
 const MAX_URL_HISTORY_SIZE = 20;
 const CACHE_STALE_THROTTLE_MS = 10 * 1000; // 10 seconds
@@ -124,7 +127,8 @@ export class DeviceSession
   constructor(
     private readonly applicationContext: ApplicationContext,
     private readonly device: DeviceBase,
-    private readonly deviceSessionDelegate: DeviceSessionDelegate
+    private readonly deviceSessionDelegate: DeviceSessionDelegate,
+    private readonly outputChannelRegistry: OutputChannelRegistry
   ) {
     this.devtools = this.makeDevtools();
     this.metro = new MetroLauncher(this.devtools, this);
@@ -202,12 +206,11 @@ export class DeviceSession
     const appRoot = this.applicationContext.appRootFolder;
     const launchConfig = this.applicationContext.launchConfig;
     const hasCachedBuild = this.applicationContext.buildCache.hasCachedBuild({
-      platform: this.device.platform,
+      platform: this.platform,
       appRoot,
       env: launchConfig.env,
     });
-    const platformKey: "ios" | "android" =
-      this.device.platform === DevicePlatform.IOS ? "ios" : "android";
+    const platformKey: "ios" | "android" = this.platform === DevicePlatform.IOS ? "ios" : "android";
     const fingerprintCommand = launchConfig.customBuild?.[platformKey]?.fingerprintCommand;
     if (hasCachedBuild) {
       const fingerprint = await this.applicationContext.buildCache.calculateFingerprint({
@@ -216,7 +219,7 @@ export class DeviceSession
         fingerprintCommand,
       });
       const isCacheStale = await this.applicationContext.buildCache.isCacheStale(fingerprint, {
-        platform: this.device.platform,
+        platform: this.platform,
         appRoot,
         env: launchConfig.env,
       });
@@ -402,7 +405,7 @@ export class DeviceSession
       this.resetStartingState();
 
       getTelemetryReporter().sendTelemetryEvent("url-bar:reload-requested", {
-        platform: this.device.platform,
+        platform: this.platform,
         method: type,
       });
       const result = await this.performReloadActionInternal(type);
@@ -423,7 +426,7 @@ export class DeviceSession
           kind: "build",
           message: e.message,
           buildType: e.buildType,
-          platform: this.device.platform,
+          platform: this.platform,
         };
         this.emitStateChange();
       }
@@ -550,11 +553,11 @@ export class DeviceSession
 
   private async autoReload() {
     getTelemetryReporter().sendTelemetryEvent("url-bar:restart-requested", {
-      platform: this.device.platform,
+      platform: this.platform,
     });
 
     const launchConfig = this.applicationContext.launchConfig;
-    const platformKey = this.device.platform === DevicePlatform.IOS ? "ios" : "android";
+    const platformKey = this.platform === DevicePlatform.IOS ? "ios" : "android";
     const fingerprintOptions = {
       appRoot: this.applicationContext.appRootFolder,
       env: launchConfig.env,
@@ -566,7 +569,7 @@ export class DeviceSession
       const currentFingerprint = await this.buildCache.calculateFingerprint(fingerprintOptions);
       if (
         await this.buildCache.isCacheStale(currentFingerprint, {
-          platform: this.device.platform,
+          platform: this.platform,
           appRoot: this.applicationContext.appRootFolder,
           env: launchConfig.env,
         })
@@ -650,7 +653,7 @@ export class DeviceSession
   private async launchApp(cancelToken: CancelToken) {
     const launchRequestTime = Date.now();
     getTelemetryReporter().sendTelemetryEvent("app:launch:requested", {
-      platform: this.device.platform,
+      platform: this.platform,
     });
     const launchConfig = this.applicationContext.launchConfig;
 
@@ -659,7 +662,7 @@ export class DeviceSession
     // bundle instead.
     const shouldWaitForAppLaunch = launchConfig.preview.waitForAppLaunch;
     const launchArguments =
-      (this.device.platform === DevicePlatform.IOS && launchConfig.ios?.launchArguments) || [];
+      (this.platform === DevicePlatform.IOS && launchConfig.ios?.launchArguments) || [];
     const waitForAppReady = shouldWaitForAppLaunch ? this.devtools.appReady() : Promise.resolve();
 
     this.updateStartupMessage(StartupMessage.Launching);
@@ -678,7 +681,7 @@ export class DeviceSession
           previewURL
         );
         getTelemetryReporter().sendTelemetryEvent("app:launch:waiting-stuck", {
-          platform: this.device.platform,
+          platform: this.platform,
         });
       }, 30000);
       waitForAppReady.then(() => clearTimeout(reportWaitingStuck));
@@ -705,7 +708,7 @@ export class DeviceSession
     Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");
     getTelemetryReporter().sendTelemetryEvent(
       "app:launch:completed",
-      { platform: this.device.platform },
+      { platform: this.platform },
       { durationSec: launchDurationSec }
     );
 
@@ -722,18 +725,92 @@ export class DeviceSession
     }
   }
 
+  /**
+   * Returns true if some native build dependencies have change and we should perform
+   * a native build despite the fact the fingerprint indicates we don't need to.
+   * This is currently only used for the scenario when we detect that pods need
+   * to be reinstalled for iOS.
+   */
+  private async checkBuildDependenciesChanged(platform: DevicePlatform): Promise<boolean> {
+    const dependencyManager = this.applicationContext.dependencyManager;
+    if (platform === DevicePlatform.IOS) {
+      return !(await dependencyManager.checkPodsInstallationStatus());
+    }
+    return false;
+  }
+
+  private async ensureDependenciesForBuild(buildConfig: BuildConfig, cancelToken: CancelToken) {
+    const dependencyManager = this.applicationContext.dependencyManager;
+
+    if (buildConfig.type === BuildType.Local) {
+      if (buildConfig.platform === DevicePlatform.Android) {
+        if (!(await dependencyManager.checkAndroidDirectoryExits())) {
+          throw new Error(
+            'Your project does not have "android" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure an external build source using launch configuration.'
+          );
+        }
+      }
+      if (buildConfig.platform === DevicePlatform.IOS) {
+        if (!(await dependencyManager.checkIOSDirectoryExists())) {
+          throw new Error(
+            'Your project does not have "ios" directory. If this is an Expo project, you may need to run `expo prebuild` to generate missing files, or configure an external build source using launch configuration.'
+          );
+        }
+        await this.installPodsIfNeeded(buildConfig, cancelToken);
+      }
+    }
+  }
+
+  private async installPodsIfNeeded(
+    { forceCleanBuild, platform }: BuildConfig,
+    cancelToken: CancelToken
+  ) {
+    const dependencyManager = this.applicationContext.dependencyManager;
+    let installPods = forceCleanBuild;
+    if (forceCleanBuild) {
+      Logger.info("Clean build requested: installing pods");
+    } else {
+      const podsInstalled = await dependencyManager.checkPodsInstallationStatus();
+      if (!podsInstalled) {
+        Logger.info("Pods installation is missing or outdated. Installing Pods.");
+        installPods = true;
+      }
+    }
+    if (installPods) {
+      getTelemetryReporter().sendTelemetryEvent("build:install-pods", { platform });
+      const podInstallOutput = this.outputChannelRegistry.getOrCreateOutputChannel(Output.BuildIos);
+      podInstallOutput.clear();
+      await dependencyManager.installPods(podInstallOutput, cancelToken);
+      const installed = await dependencyManager.checkPodsInstallationStatus();
+      if (!installed) {
+        throw new Error(
+          "Pods could not be installed in your project. Check the build logs for details."
+        );
+      }
+    }
+  }
+
   private async buildApp({ clean, cancelToken }: { clean: boolean; cancelToken: CancelToken }) {
     const buildStartTime = Date.now();
     this.updateStartupMessage(StartupMessage.Building);
     const launchConfiguration = this.applicationContext.launchConfig;
-    const buildType = await inferBuildType(this.device.platform, launchConfiguration);
+    const buildType = await inferBuildType(this.platform, launchConfiguration);
+
+    // Native build dependencies when changed, should invalidate cached build (even if the fingerprint is the same)
+    const buildDependenciesChanged = await this.checkBuildDependenciesChanged(this.platform);
+
     const buildConfig = createBuildConfig(
-      this.device.platform,
-      clean,
+      this.platform,
+      clean || buildDependenciesChanged,
       launchConfiguration,
       buildType
     );
+
+    await this.ensureDependenciesForBuild(buildConfig, cancelToken);
     this.hasStaleBuildCache = false;
+    const buildOutputChannel = this.outputChannelRegistry.getOrCreateOutputChannel(
+      this.platform === DevicePlatform.IOS ? Output.BuildIos : Output.BuildAndroid
+    );
     this.maybeBuildResult = await this.buildManager.buildApp(buildConfig, {
       progressListener: throttle((stageProgress: number) => {
         if (this.startupMessage === StartupMessage.Building) {
@@ -742,13 +819,14 @@ export class DeviceSession
         }
       }, 100),
       cancelToken,
+      buildOutputChannel,
     });
     const buildDurationSec = (Date.now() - buildStartTime) / 1000;
     Logger.info("Build completed in", buildDurationSec.toFixed(2), "sec.");
     getTelemetryReporter().sendTelemetryEvent(
       "build:completed",
       {
-        platform: this.device.platform,
+        platform: this.platform,
       },
       { durationSec: buildDurationSec }
     );
@@ -846,7 +924,7 @@ export class DeviceSession
           kind: "build",
           message: e.message,
           buildType: e.buildType,
-          platform: this.device.platform,
+          platform: this.platform,
         };
       } else {
         this.status = "fatalError";
@@ -854,7 +932,7 @@ export class DeviceSession
           kind: "build",
           message: (e as Error).message,
           buildType: null,
-          platform: this.device.platform,
+          platform: this.platform,
         };
       }
       throw e;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -88,15 +88,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     const initialLaunchConfig = initialLaunchConfigOptions
       ? launchConfigurationFromOptions(initialLaunchConfigOptions)
       : this.launchConfigsManager.initialLaunchConfiguration;
-    this.applicationContext = new ApplicationContext(
-      initialLaunchConfig,
-      buildCache,
-      this.outputChannelRegistry
-    );
+    this.applicationContext = new ApplicationContext(initialLaunchConfig, buildCache);
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
       this.deviceManager,
-      this
+      this,
+      this.outputChannelRegistry
     );
 
     const connector = Connector.getInstance();
@@ -181,7 +178,8 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.applicationContext,
       this.deviceManager,
-      this
+      this,
+      this.outputChannelRegistry
     );
     oldDeviceSessionsManager.dispose();
     this.maybeStartInitialDeviceSession();


### PR DESCRIPTION
Moves installing / checking of dependencies out of `BuildManager`, removing the dependency on `DependencyManager`
### How Has This Been Tested: 
- open app in Radon
- verify it still builds
- check that removing `ios` or `android` folder in a standard build causes errors
- check that pods are installed if not present


