### PR TITLE
Support device audio

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -100,6 +100,30 @@
         "enablement": "RNIDE.extensionIsActive"
       },
       {
+        "command": "RNIDE.deviceVolumeIncreaseButtonDown",
+        "title": "Trigger volume increase button down on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
+        "command": "RNIDE.deviceVolumeIncreaseButtonUp",
+        "title": "Trigger volume increase button up on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
+        "command": "RNIDE.deviceVolumeDecreaseButtonDown",
+        "title": "Trigger volume decrease button down on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
+        "command": "RNIDE.deviceVolumeDecreaseButtonUp",
+        "title": "Trigger volume decrease button up on the current device",
+        "category": "Radon IDE",
+        "enablement": "RNIDE.extensionIsActive"
+      },
+      {
         "command": "RNIDE.captureReplay",
         "title": "Capture Replay",
         "category": "Radon IDE",

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -135,7 +135,7 @@ export type ZoomLevelType = number | "Fit";
 
 export type AppPermissionType = "all" | "location" | "photos" | "contacts" | "calendar";
 
-export type DeviceButtonType = "home" | "back" | "appSwitch" | "volumeUp" | "volumeDown";
+export type DeviceButtonType = "home" | "back" | "appSwitch" | "volumeUp" | "volumeDown" | "power";
 
 // important: order of values in this enum matters
 export enum StartupMessage {

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -382,7 +382,6 @@ export class AndroidEmulatorDevice extends DeviceBase {
         "-avd",
         this.avdId,
         "-qt-hide-window",
-        "-no-audio",
         "-no-boot-anim",
         "-grpc-use-token",
         "-no-snapshot-save",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -196,6 +196,18 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand("RNIDE.deviceAppSwitchButtonPress", deviceAppSwitchButtonPress)
   );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceVolumeIncreaseButtonDown", deviceVolumeIncreaseButtonDown)
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceVolumeIncreaseButtonUp", deviceVolumeIncreaseButtonUp)
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceVolumeDecreaseButtonDown", deviceVolumeDecreaseButtonDown)
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.deviceVolumeDecreaseButtonUp", deviceVolumeDecreaseButtonUp)
+  );
   context.subscriptions.push(commands.registerCommand("RNIDE.openDevMenu", openDevMenu));
   context.subscriptions.push(commands.registerCommand("RNIDE.closePanel", closeIDEPanel));
   context.subscriptions.push(commands.registerCommand("RNIDE.openPanel", showIDEPanel));
@@ -382,6 +394,26 @@ async function deviceAppSwitchButtonPress() {
   const project = IDE.getInstanceIfExists()?.project;
   project?.dispatchButton("appSwitch", "Down");
   project?.dispatchButton("appSwitch", "Up");
+}
+
+async function deviceVolumeIncreaseButtonDown() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("volumeUp", "Down");
+}
+
+async function deviceVolumeIncreaseButtonUp() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("volumeUp", "Up");
+}
+
+async function deviceVolumeDecreaseButtonDown() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("volumeDown", "Down");
+}
+
+async function deviceVolumeDecreaseButtonUp() {
+  const project = IDE.getInstanceIfExists()?.project;
+  project?.dispatchButton("volumeDown", "Up");
 }
 
 async function captureReplay() {

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.css
@@ -48,3 +48,31 @@
   display: flex;
   align-items: center;
 }
+
+.volume-controls {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.volume-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--swm-default-text);
+  cursor: pointer;
+  padding: 4px;
+  font-size: 12px;
+  transition: all 0.1s ease;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.volume-button:hover {
+  background: var(--swm-dropdown-item-highlighted);
+}

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -149,6 +149,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             Location
           </DropdownMenu.Item>
           <LocalizationItem />
+          <VolumeItem />
           {selectedDeviceSession?.deviceInfo.platform === DevicePlatform.Android && <CameraItem />}
           <DropdownMenu.Sub>
             <DropdownMenu.SubTrigger className="dropdown-menu-item">
@@ -327,6 +328,59 @@ const CameraItem = () => {
       <span className="codicon codicon-device-camera" />
       Camera Settings
     </DropdownMenu.Item>
+  );
+};
+
+const VolumeItem = () => {
+  const { project } = useProject();
+
+  const handleVolumeIncreaseDown = () => {
+    project.runCommand("RNIDE.deviceVolumeIncreaseButtonDown");
+  };
+
+  const handleVolumeIncreaseUp = () => {
+    project.runCommand("RNIDE.deviceVolumeIncreaseButtonUp");
+  };
+
+  const handleVolumeDecreaseDown = () => {
+    project.runCommand("RNIDE.deviceVolumeDecreaseButtonDown");
+  };
+
+  const handleVolumeDecreaseUp = () => {
+    project.runCommand("RNIDE.deviceVolumeDecreaseButtonUp");
+  };
+
+  // Make sure buttons get unpressed on unmount
+  React.useEffect(() => {
+    return () => {
+      handleVolumeDecreaseUp();
+      handleVolumeIncreaseUp();
+    };
+  }, []);
+
+  return (
+    <div className="dropdown-menu-item">
+      <span className="codicon codicon-unmute" />
+      Volume
+      <div className="volume-controls">
+        <button
+          title="Volume Down"
+          className="volume-button"
+          onMouseDown={handleVolumeDecreaseDown}
+          onMouseUp={handleVolumeDecreaseUp}
+          onMouseLeave={handleVolumeDecreaseUp}>
+          <span className="codicon codicon-chevron-down" />
+        </button>
+        <button
+          title="Volume Up"
+          className="volume-button"
+          onMouseDown={handleVolumeIncreaseDown}
+          onMouseUp={handleVolumeIncreaseUp}
+          onMouseLeave={handleVolumeIncreaseUp}>
+          <span className="codicon codicon-chevron-up" />
+        </button>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
This PR updates the Simulator Server to handle volume up / volume down buttons on iOS Simulator and provides UI controls to control the volume.

https://github.com/user-attachments/assets/34f6da2d-1a59-4ae0-b212-0e3104689a7f

Notice that the audio is outputted by the underlying iOS Simulator/Android Emulator, so it won't be present on videos recorded by the Simulator Server.

### How Has This Been Tested: 

Simply run iOS Simulator/Android Emulator, ensure volume is non-zero and the sound will be outputted by your default speakers. You can hold mouse down to change the volume faster (similarly to holding a button on a real device).

### How Has This Change Been Documented:

TBD

