### PR TITLE
fix: cocoapods diagnostics not working when `bundle` is used

### DIFF
--- a/packages/vscode-extension/src/dependency/DependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/DependencyManager.ts
@@ -50,10 +50,14 @@ export class DependencyManager implements Disposable, DependencyManagerInterface
       this.packageManagerInternal = undefined;
     }
     this.launchConfiguration = newLaunchConfiguration;
+    const oldPods = this.pods;
+    this.pods = new Pods(newRoot, newLaunchConfiguration.env);
+    oldPods.dispose(); // dispose the old pods instance to clean up resources
   }
 
   public dispose() {
     this.eventEmitter.removeAllListeners();
+    this.pods.dispose();
   }
 
   public async addListener(listener: DependencyListener) {

--- a/packages/vscode-extension/src/utilities/pods.ts
+++ b/packages/vscode-extension/src/utilities/pods.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { OutputChannel } from "vscode";
+import { OutputChannel, Disposable } from "vscode";
 import { command, lineReader } from "./subprocess";
 import { CancelToken } from "./cancelToken";
 import { getIosSourceDir } from "../builders/buildIOS";
@@ -13,7 +13,7 @@ import { getIosSourceDir } from "../builders/buildIOS";
  * a given application root directory. It ensures that only one pod installation
  * process runs at a time and supports cancellation of ongoing installations.
  */
-export class Pods {
+export class Pods implements Disposable {
   private podsInstallationProcess:
     | {
         podsPromise: Promise<void>;
@@ -154,5 +154,10 @@ export class Pods {
     } catch (_) {
       return false;
     }
+  }
+
+  public dispose(): void {
+    this.podsInstallationProcess?.cancelToken.cancel();
+    this.podsInstallationProcess = undefined;
   }
 }


### PR DESCRIPTION
- fixes cocoapods diagnostics not working when the `bundle` utility is used in the project
- fixes cocoapods diagnostics not using the envs set in the launch config
- moves code calling the pods command out of `DependencyManager` to a helper `pods` module

### How Has This Been Tested: 
- run test-apps/react-native-80 app
- check diagnostics are correct
- remove pods and check that installing pods automatically still works
