### PR TITLE
fix: `DependencyManager` disposed incorrectly on launch config change

### DIFF
--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -31,20 +31,9 @@ export class ApplicationContext implements Disposable {
   }
 
   public async updateLaunchConfig(launchConfig: LaunchConfiguration) {
-    const oldAppRoot = this.appRootFolder;
     this.launchConfig = launchConfig;
     this.dependencyManager.setLaunchConfiguration(launchConfig);
     await this.dependencyManager.runAllDependencyChecks();
-    if (this.appRootFolder !== oldAppRoot) {
-      this.updateAppRootFolder();
-    }
-  }
-
-  public async updateAppRootFolder() {
-    disposeAll(this.disposables);
-    const buildManager = createBuildManager(this.buildCache);
-    this.buildManager = buildManager;
-    this.disposables.push(this.dependencyManager, buildManager);
   }
 
   public dispose() {


### PR DESCRIPTION
- Fixes `DependencyManager` being incorrectly `dispose`d when the application root in the selected launch config changes
- `BuildManager` is now retained when app root changes.

### How Has This Been Tested: 
- open monorepo in Radon
- check "Run diagnostics" matches the chosen app root
- change app root
- check "Run diagnostics" matches the chosen app root
