### PR TITLE
add: option to disable radon ai

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -235,7 +235,7 @@
           "type": "boolean",
           "scope": "window",
           "default": true,
-          "description": "Enables the Radon AI functionality in the extension. Note: A restart is required for this setting to take effect."
+          "description": "Enables the Radon AI functionality in the extension. Note: A full restart of the IDE is required for this setting to take effect."
         }
       }
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -230,6 +230,12 @@
           "scope": "window",
           "default": false,
           "description": "When set, switching between devices will shut down the previous device instead of leaving it running in the background."
+        },
+        "RadonIDE.enableRadonAI": {
+          "type": "boolean",
+          "scope": "window",
+          "default": true,
+          "description": "Enables the Radon AI functionality in the extension. Note: A restart is required for this setting to take effect."
         }
       }
     },

--- a/packages/vscode-extension/src/ai/chat/index.ts
+++ b/packages/vscode-extension/src/ai/chat/index.ts
@@ -50,7 +50,7 @@ async function processChatResponse(
   return [];
 }
 
-export function registerRadonChat(context: vscode.ExtensionContext) {
+export function registerRadonChat(context: vscode.ExtensionContext, enableRadonAI: boolean) {
   const chatHandler: vscode.ChatRequestHandler = async (
     request,
     chatContext,
@@ -60,6 +60,15 @@ export function registerRadonChat(context: vscode.ExtensionContext) {
     stream.progress("Thinking...");
     Logger.info(CHAT_LOG, "Chat requested");
     getTelemetryReporter().sendTelemetryEvent("radon-chat:requested");
+
+    if (!enableRadonAI) {
+      const msg =
+        "You have disabled radon AI. You can enable it using 'Radon IDE: Enable Radon AI' setting in your editor.";
+      Logger.warn(CHAT_LOG, msg);
+      getTelemetryReporter().sendTelemetryEvent("radon-chat:radon-ai-disabled", { error: msg });
+      stream.markdown(msg);
+      return { metadata: { command: "" } };
+    }
 
     const jwt = await getLicenseToken();
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -311,11 +311,16 @@ export async function activate(context: ExtensionContext) {
     })
   );
 
-  // Initializes MCP part of Radon AI
-  context.subscriptions.push(registerRadonAi());
+  const configuration = workspace.getConfiguration("RadonIDE");
+  const enableRadonAI = configuration.get<boolean>("enableRadonAI");
+
+  if (enableRadonAI) {
+    // Initializes MCP part of Radon AI
+    context.subscriptions.push(registerRadonAi());
+  }
 
   // You can configure the chat in package.json under the `chatParticipants` key
-  registerRadonChat(context);
+  registerRadonChat(context, !!enableRadonAI);
 
   const shouldExtensionActivate = findAppRootFolder() !== undefined;
 


### PR DESCRIPTION
This PR adds an option to disable radon ai functionality.

### How Has This Been Tested: 

- run any repository 
- check if chat participant is working 
- disable radon ai 
- reload window 
- check the chat participant response 

### How was this documented:

the documentation is updated in #1357





