### PR TITLE
fix: Logger output channel is disposed when panel closes, DeviceSessionsManager is not disposed correctly

### DIFF
--- a/packages/vscode-extension/src/project/OutputChannelRegistry.ts
+++ b/packages/vscode-extension/src/project/OutputChannelRegistry.ts
@@ -19,6 +19,12 @@ export class OutputChannelRegistry implements Disposable {
   }
 
   dispose() {
-    this.channelByName.values().forEach((c) => c.dispose());
+    this.channelByName.entries().forEach(([k, c]) => {
+      // NOTE: we special-case the IDE output channel to keep it open
+      // even when the IDE is disposed.
+      if (k !== Output.Ide) {
+        c.dispose();
+      }
+    });
   }
 }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -364,7 +364,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   }
 
   public dispose() {
-    this.deviceSession?.dispose();
+    this.deviceSessionsManager.dispose();
     this.applicationContext.dispose();
     disposeAll(this.disposables);
   }


### PR DESCRIPTION
- fixes a bug where the output channel for Logger would be disposed with IDE, causing issues when the IDE panel is closed and reopened
- fixes a bug where the DeviceSessionsManager would not be cleaned up when the IDE is disposed

### How Has This Been Tested: 
- open the IDE panel
- close it
- reopen it
- the IDE should work