### PR TITLE
feat: load environment variables from project`s dotenv files

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/preset-react": "^7.26.3",
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/compat": "^1.2.8",
+        "@expo/env": "^1.0.7",
         "@expo/fingerprint": "^0.11.11",
         "@expo/package-manager": "^1.7.2",
         "@modelcontextprotocol/sdk": "^1.12.3",
@@ -16141,6 +16142,30 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@expo/env": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-1.0.7.tgz",
+      "integrity": "sha512-qSTEnwvuYJ3umapO9XJtrb1fAqiPlmUUg78N0IZXXGwQRt+bkp0OBls+Y5Mxw/Owj8waAM0Z3huKKskRADR5ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^2.0.0"
+      }
+    },
+    "node_modules/@expo/env/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@expo/fingerprint": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.11.tgz",
@@ -22726,6 +22751,35 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -900,6 +900,7 @@
     "@babel/preset-react": "^7.26.3",
     "@babel/preset-typescript": "^7.27.1",
     "@eslint/compat": "^1.2.8",
+    "@expo/env": "^1.0.7",
     "@expo/fingerprint": "^0.11.11",
     "@expo/package-manager": "^1.7.2",
     "@modelcontextprotocol/sdk": "^1.12.3",

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -25,15 +25,19 @@ export interface CacheKey {
   env: Record<string, string>;
 }
 
-function stringifyCacheKey({ platform, appRoot, env }: CacheKey) {
-  const keyPrefix =
-    platform === DevicePlatform.Android ? ANDROID_BUILD_CACHE_KEY : IOS_BUILD_CACHE_KEY;
-
+function hashEnvironment(env: Record<string, string>) {
   const envHash = crypto.createHash("md5");
   const envEntries = Object.entries(env).sort(([k], [k2]) => k.localeCompare(k2));
   envEntries.map(([k, v]) => `${k}=${v}`).forEach((entry) => envHash.update(entry));
-  const envHashString = envHash.digest("hex");
-  return `${keyPrefix}:${appRoot}:${envHashString}`;
+  return envHash.digest("hex");
+}
+
+function stringifyCacheKey({ platform, appRoot, env }: CacheKey) {
+  const keyPrefix =
+    platform === DevicePlatform.Android ? ANDROID_BUILD_CACHE_KEY : IOS_BUILD_CACHE_KEY;
+  const envHash = hashEnvironment(env);
+
+  return `${keyPrefix}:${appRoot}:${envHash}`;
 }
 
 export class BuildCache {

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import assert from "assert";
+import crypto from "crypto";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { DevicePlatform } from "../common/DeviceManager";
@@ -27,9 +28,12 @@ export interface CacheKey {
 function stringifyCacheKey({ platform, appRoot, env }: CacheKey) {
   const keyPrefix =
     platform === DevicePlatform.Android ? ANDROID_BUILD_CACHE_KEY : IOS_BUILD_CACHE_KEY;
+
+  const envHash = crypto.createHash("md5");
   const envEntries = Object.entries(env).sort(([k], [k2]) => k.localeCompare(k2));
-  const envStrings = envEntries.map(([k, v]) => `${k}=${v}`);
-  return `${keyPrefix}:${appRoot}:${JSON.stringify(envStrings)}`;
+  envEntries.map(([k, v]) => `${k}=${v}`).forEach((entry) => envHash.update(entry));
+  const envHashString = envHash.digest("hex");
+  return `${keyPrefix}:${appRoot}:${envHashString}`;
 }
 
 export class BuildCache {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -47,11 +47,12 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
   const absoluteAppRoot = path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
 
   const configuredEnv = configuration.env || {};
-  const env = resolveEnvironment(absoluteAppRoot, configuredEnv);
 
   return {
     ...configuration,
-    env,
+    get env() {
+      return resolveEnvironment(absoluteAppRoot, configuredEnv);
+    },
     absoluteAppRoot,
     preview: {
       waitForAppLaunch: configuration.preview?.waitForAppLaunch ?? true,


### PR DESCRIPTION
Loads the environment variables for the application root using `@expo/env` and appends it to the system and configured environment that is passed to the other parts of the extension.
Also changes the build cache key to use a hash of the environment, instead of the full stringified env.

Closes #1350 

### How Has This Been Tested: 
- check that adding a `.env` file in the app root folder results in the variables being added to the `ApplicationContext.launchConfig` object
- check that `.env` contents don't override values set in the system or custom launch config
- check that switching app roots doesn't carry over the variables loaded from the previously chosen approot



