### PR TITLE
fix: element inspector not working with Fragments wrapping empty components on Paper

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -149,16 +149,16 @@ function getInspectorDataForCoordinates(mainContainerRef, x, y, requestStack, ca
         inspectorDataStack.map(
           (inspectorData) =>
             new Promise((res, rej) => {
+              const source = {
+                fileName: inspectorData.source.fileName,
+                line0Based: inspectorData.source.lineNumber - 1,
+                column0Based: inspectorData.source.columnNumber - 1,
+              };
               try {
                 inspectorData.measure((_x, _y, viewWidth, viewHeight, pageX, pageY) => {
-                  const source = inspectorData.source;
                   res({
                     componentName: inspectorData.name,
-                    source: {
-                      fileName: source.fileName,
-                      line0Based: source.lineNumber - 1,
-                      column0Based: source.columnNumber - 1,
-                    },
+                    source,
                     frame: {
                       x: pageX / screenWidth,
                       y: pageY / screenHeight,
@@ -168,7 +168,7 @@ function getInspectorDataForCoordinates(mainContainerRef, x, y, requestStack, ca
                   });
                 });
               } catch (e) {
-                rej(e);
+                res({ componentName: inspectorData.name, source });
               }
             })
         )
@@ -186,7 +186,6 @@ export function AppWrapper({ children, initialProps, fabric }) {
   const rootTag = useContext(RootTagContext);
   const [hasLayout, setHasLayout] = useState(false);
   const mainContainerRef = useRef();
-  const latestRouteListRef = useRef();
 
   const mountCallback = initialProps?.__RNIDE_onMount;
   useEffect(() => {

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -187,7 +187,7 @@ export type InspectStackData = {
 
 export type InspectData = {
   stack: InspectDataStackItem[] | undefined;
-  frame: Frame;
+  frame?: Frame;
 };
 
 export type TouchPoint = {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -192,7 +192,9 @@ function Preview({
           }
         }
       }
-      setInspectFrame(inspectData.frame);
+      if (inspectData.frame) {
+        setInspectFrame(inspectData.frame);
+      }
     });
   }
 


### PR DESCRIPTION
Fixes #980

### How Has This Been Tested: 
- open a project which uses the Paper (old) renderer in Radon
- render the C component:
```tsx
function C() {
  return (
    <React.Fragment>
      <B />
      <A />
    </React.Fragment>
  );
}

function A() {
  return <View style={{ height: 100, backgroundColor: "red" }} />;
}

function B() {
  return null;
}
```
- right click the red `View`
- element inspector should show the element stack with `<View>,  <A>, <C>` components

<img width="610" height="420" alt="image" src="https://github.com/user-attachments/assets/ee2baea9-094f-4c01-bc2a-9e45750b3753" />

