### PR TITLE
fix: saving initial launch configuration when it's detected

### DIFF
--- a/packages/vscode-extension/src/panels/AppRootConfigController.ts
+++ b/packages/vscode-extension/src/panels/AppRootConfigController.ts
@@ -1,72 +1,15 @@
 import path from "path";
 import { workspace } from "vscode";
-import { ApplicationRoot, AppRootConfig } from "../common/AppRootConfig";
-import { extensionContext, findAppRootCandidates } from "../utilities/extensionContext";
+import { AppRootConfig } from "../common/AppRootConfig";
 import { findXcodeProject, findXcodeScheme } from "../utilities/xcode";
 import { Logger } from "../Logger";
 import { getIosSourceDir } from "../builders/buildIOS";
 import { readEasConfig } from "../utilities/eas";
 import { EasBuildConfig } from "../common/EasConfig";
-import { requireNoCache } from "../utilities/requireNoCache";
-
-const CUSTOM_APPLICATION_ROOTS_KEY = "custom_application_roots_key";
+import { getAvailableApplicationRoots } from "../utilities/getAvailableApplicationRoots";
 
 function toAbsolutePath(appRoot: string): string {
   return path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
-}
-
-function readApplicationRootFromStaticConfig(appRootPath: string, configAbsolutePath: string) {
-  const appRootConfig = requireNoCache(configAbsolutePath);
-  if (appRootConfig) {
-    return {
-      path: appRootPath,
-      name: appRootConfig.name ?? appRootConfig.expo?.name ?? path.basename(appRootPath),
-      displayName: appRootConfig.displayName,
-    };
-  }
-  throw new Error("Could not read config file.");
-}
-
-function readApplicationRoot(appRootPath: string): ApplicationRoot {
-  const appRootAbsolutePath = toAbsolutePath(appRootPath);
-  try {
-    return readApplicationRootFromStaticConfig(appRootPath, appRootAbsolutePath + "/app.json");
-  } catch {}
-  try {
-    return readApplicationRootFromStaticConfig(
-      appRootPath,
-      appRootAbsolutePath + "/app.config.json"
-    );
-  } catch {}
-  try {
-    const appPackageJson = requireNoCache(appRootAbsolutePath + "/package.json");
-    return {
-      path: appRootPath,
-      name: appPackageJson.name ?? path.basename(appRootPath),
-    };
-  } catch {}
-  return {
-    path: appRootPath,
-    name: path.basename(appRootPath),
-  };
-}
-
-export function getAvailableApplicationRoots() {
-  const workspacePath = workspace.workspaceFolders![0].uri.fsPath;
-  const applicationRootsCandidates = findAppRootCandidates().map((candidate) => {
-    return "./" + path.relative(workspacePath, candidate);
-  });
-  const customApplicationRoots =
-    extensionContext.workspaceState.get<string[] | undefined>(CUSTOM_APPLICATION_ROOTS_KEY) ?? [];
-
-  const applicationRoots = [...applicationRootsCandidates, ...customApplicationRoots];
-
-  if (!applicationRoots) {
-    Logger.debug(`Could not find any application roots.`);
-    return [];
-  }
-
-  return applicationRoots.map(readApplicationRoot);
 }
 
 export class AppRootConfigController implements AppRootConfig {

--- a/packages/vscode-extension/src/panels/AppRootConfigController.ts
+++ b/packages/vscode-extension/src/panels/AppRootConfigController.ts
@@ -51,23 +51,27 @@ function readApplicationRoot(appRootPath: string): ApplicationRoot {
   };
 }
 
+export function getAvailableApplicationRoots() {
+  const workspacePath = workspace.workspaceFolders![0].uri.fsPath;
+  const applicationRootsCandidates = findAppRootCandidates().map((candidate) => {
+    return "./" + path.relative(workspacePath, candidate);
+  });
+  const customApplicationRoots =
+    extensionContext.workspaceState.get<string[] | undefined>(CUSTOM_APPLICATION_ROOTS_KEY) ?? [];
+
+  const applicationRoots = [...applicationRootsCandidates, ...customApplicationRoots];
+
+  if (!applicationRoots) {
+    Logger.debug(`Could not find any application roots.`);
+    return [];
+  }
+
+  return applicationRoots.map(readApplicationRoot);
+}
+
 export class AppRootConfigController implements AppRootConfig {
   async getAvailableApplicationRoots() {
-    const workspacePath = workspace.workspaceFolders![0].uri.fsPath;
-    const applicationRootsCandidates = findAppRootCandidates().map((candidate) => {
-      return "./" + path.relative(workspacePath, candidate);
-    });
-    const customApplicationRoots =
-      extensionContext.workspaceState.get<string[] | undefined>(CUSTOM_APPLICATION_ROOTS_KEY) ?? [];
-
-    const applicationRoots = [...applicationRootsCandidates, ...customApplicationRoots];
-
-    if (!applicationRoots) {
-      Logger.debug(`Could not find any application roots.`);
-      return [];
-    }
-
-    return applicationRoots.map(readApplicationRoot);
+    return getAvailableApplicationRoots();
   }
 
   async getAvailableXcodeSchemes(appRoot: string) {

--- a/packages/vscode-extension/src/project/launchConfigurationsManager.ts
+++ b/packages/vscode-extension/src/project/launchConfigurationsManager.ts
@@ -17,6 +17,7 @@ import {
 import { Logger } from "../Logger";
 import { extensionContext, findAppRootCandidates } from "../utilities/extensionContext";
 import { getLaunchConfigurations, LaunchRadonConfig } from "../utilities/launchConfiguration";
+import { getAvailableApplicationRoots } from "../panels/AppRootConfigController";
 const INITIAL_LAUNCH_CONFIGURATION_KEY = "initialLaunchConfiguration";
 
 function findDefaultAppRoot(showWarning = false) {
@@ -131,6 +132,18 @@ export class LaunchConfigurationsManager implements Disposable {
     const savedLaunchConfig = workspaceState.get<LaunchConfiguration | undefined>(
       INITIAL_LAUNCH_CONFIGURATION_KEY
     );
+
+    if (savedLaunchConfig?.kind === LaunchConfigurationKind.Detected) {
+      const availableAppRoots = getAvailableApplicationRoots();
+      if (
+        availableAppRoots.some(
+          (availableAppRoot) => availableAppRoot.path === savedLaunchConfig.appRoot
+        )
+      ) {
+        return savedLaunchConfig;
+      }
+    }
+
     if (
       savedLaunchConfig &&
       this._launchConfigurations.find((config) => _.isEqual(config, savedLaunchConfig))

--- a/packages/vscode-extension/src/project/launchConfigurationsManager.ts
+++ b/packages/vscode-extension/src/project/launchConfigurationsManager.ts
@@ -17,7 +17,7 @@ import {
 import { Logger } from "../Logger";
 import { extensionContext, findAppRootCandidates } from "../utilities/extensionContext";
 import { getLaunchConfigurations, LaunchRadonConfig } from "../utilities/launchConfiguration";
-import { getAvailableApplicationRoots } from "../panels/AppRootConfigController";
+import { getAvailableApplicationRoots } from "../utilities/getAvailableApplicationRoots";
 const INITIAL_LAUNCH_CONFIGURATION_KEY = "initialLaunchConfiguration";
 
 function findDefaultAppRoot(showWarning = false) {
@@ -145,6 +145,7 @@ export class LaunchConfigurationsManager implements Disposable {
     }
 
     if (
+      savedLaunchConfig?.kind === LaunchConfigurationKind.Custom &&
       savedLaunchConfig &&
       this._launchConfigurations.find((config) => _.isEqual(config, savedLaunchConfig))
     ) {

--- a/packages/vscode-extension/src/utilities/getAvailableApplicationRoots.ts
+++ b/packages/vscode-extension/src/utilities/getAvailableApplicationRoots.ts
@@ -1,0 +1,66 @@
+import path from "path";
+import { workspace } from "vscode";
+import { extensionContext, findAppRootCandidates } from "./extensionContext";
+import { Logger } from "../Logger";
+import { requireNoCache } from "./requireNoCache";
+import { ApplicationRoot } from "../common/AppRootConfig";
+
+const CUSTOM_APPLICATION_ROOTS_KEY = "custom_application_roots_key";
+
+function toAbsolutePath(appRoot: string): string {
+  return path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
+}
+
+function readApplicationRootFromStaticConfig(appRootPath: string, configAbsolutePath: string) {
+  const appRootConfig = requireNoCache(configAbsolutePath);
+  if (appRootConfig) {
+    return {
+      path: appRootPath,
+      name: appRootConfig.name ?? appRootConfig.expo?.name ?? path.basename(appRootPath),
+      displayName: appRootConfig.displayName,
+    };
+  }
+  throw new Error("Could not read config file.");
+}
+
+function readApplicationRoot(appRootPath: string): ApplicationRoot {
+  const appRootAbsolutePath = toAbsolutePath(appRootPath);
+  try {
+    return readApplicationRootFromStaticConfig(appRootPath, appRootAbsolutePath + "/app.json");
+  } catch {}
+  try {
+    return readApplicationRootFromStaticConfig(
+      appRootPath,
+      appRootAbsolutePath + "/app.config.json"
+    );
+  } catch {}
+  try {
+    const appPackageJson = requireNoCache(appRootAbsolutePath + "/package.json");
+    return {
+      path: appRootPath,
+      name: appPackageJson.name ?? path.basename(appRootPath),
+    };
+  } catch {}
+  return {
+    path: appRootPath,
+    name: path.basename(appRootPath),
+  };
+}
+
+export function getAvailableApplicationRoots() {
+  const workspacePath = workspace.workspaceFolders![0].uri.fsPath;
+  const applicationRootsCandidates = findAppRootCandidates().map((candidate) => {
+    return "./" + path.relative(workspacePath, candidate);
+  });
+  const customApplicationRoots =
+    extensionContext.workspaceState.get<string[] | undefined>(CUSTOM_APPLICATION_ROOTS_KEY) ?? [];
+
+  const applicationRoots = [...applicationRootsCandidates, ...customApplicationRoots];
+
+  if (!applicationRoots) {
+    Logger.debug(`Could not find any application roots.`);
+    return [];
+  }
+
+  return applicationRoots.map(readApplicationRoot);
+}


### PR DESCRIPTION
This PR fixes an issue with detected launch configuration never being used as initial launch configuration. 
This was caused by the initial config detector always checking if the saved configuration is still present in the custom configurations list even if the configuration wan never part of that list. 

To fix that we first check if the configurations kind is `Detected` and if it is and the selected appRoot still exists we select it.

### How Has This Been Tested: 

- run `radon-ide-test-apps` directory 
- select one of the detected configs 
- turn of vscode 
- turn it back on and check if the above config is the new initial config

### How Has This Change Been Documented:

Internal fix


