### PR TITLE
feat: automatically reconnect debugger when application is closed and reopened

### DIFF
--- a/packages/vscode-extension/src/connect/ConnectSession.ts
+++ b/packages/vscode-extension/src/connect/ConnectSession.ts
@@ -22,7 +22,9 @@ class DebugSessionInspectorBridge extends BaseInspectorBridge {
   }
 
   protected send(message: unknown) {
-    this.debugSession.dispatchRadonAgentMessage(message);
+    this.debugSession.evaluateExpression({
+      expression: `globalThis.__radon_dispatch(${JSON.stringify(message)});`,
+    });
   }
 }
 

--- a/packages/vscode-extension/src/connect/ConnectSession.ts
+++ b/packages/vscode-extension/src/connect/ConnectSession.ts
@@ -1,7 +1,8 @@
-import { DebugSession } from "../debugging/DebugSession";
-import { Metro } from "../project/metro";
 import { Disposable } from "vscode";
+import { DebugSession, DebugSessionImpl } from "../debugging/DebugSession";
+import { Metro } from "../project/metro";
 import { BaseInspectorBridge } from "../project/bridge";
+import { disposeAll } from "../utilities/disposables";
 
 export interface ConnectSessionDelegate {
   onSessionTerminated: () => void;
@@ -20,13 +21,14 @@ class DebugSessionInspectorBridge extends BaseInspectorBridge {
     }
   }
 
-  protected send(message: any) {
+  protected send(message: unknown) {
     this.debugSession.dispatchRadonAgentMessage(message);
   }
 }
 
 export default class ConnectSession implements Disposable {
-  private debugSession: DebugSession;
+  private debugSession: DebugSession & Disposable;
+  private debugEventsSubscription: Disposable;
   public readonly inspectorBridge: DebugSessionInspectorBridge;
 
   public get port() {
@@ -37,20 +39,11 @@ export default class ConnectSession implements Disposable {
     private readonly metro: Metro,
     private readonly delegate: ConnectSessionDelegate
   ) {
-    this.debugSession = new DebugSession(
-      {
-        onDebugSessionTerminated: () => {
-          this.delegate.onSessionTerminated();
-        },
-        onBindingCalled: (event: any) => {
-          this.inspectorBridge.onBindingCalled(event);
-        },
-      },
-      {
-        suppressDebugToolbar: false,
-        displayName: "Radon Connect Debugger",
-      }
-    );
+    this.debugSession = new DebugSessionImpl({
+      suppressDebugToolbar: false,
+      displayName: "Radon Connect Debugger",
+    });
+    this.debugEventsSubscription = this.registerDebugSessionListeners();
     this.inspectorBridge = new DebugSessionInspectorBridge(this.debugSession);
   }
 
@@ -70,7 +63,22 @@ export default class ConnectSession implements Disposable {
     return success;
   }
 
+  private registerDebugSessionListeners(): Disposable {
+    const subscriptions = [
+      this.debugSession.onDebugSessionTerminated(() => {
+        this.delegate.onSessionTerminated();
+      }),
+      this.debugSession.onBindingCalled((event: unknown) => {
+        this.inspectorBridge.onBindingCalled(event);
+      }),
+    ];
+    return new Disposable(() => {
+      disposeAll(subscriptions);
+    });
+  }
+
   dispose() {
     this.debugSession.dispose();
+    this.debugEventsSubscription.dispose();
   }
 }

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -338,22 +338,13 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
     this.sendResponse(response);
   }
 
-  private async ping() {
+  private async evaluateExpression(args: any) {
     if (!this.cdpSession) {
-      Logger.warn("[DebugAdapter] [ping] The CDPSession was not initialized yet");
+      Logger.warn("[DebugAdapter] [injectDebuggerCommand] The CDPSession was not initialized yet");
       return;
     }
-    try {
-      const res = await this.cdpSession.sendCDPMessage("Runtime.evaluate", {
-        expression: "('ping')",
-      });
-      if (res.result.value === "ping") {
-        return true;
-      }
-    } catch (_) {
-      /** debugSession is waiting for an event, if it won't get any it will fail after timeout, so we don't need to do anything here */
-    }
-    return false;
+    const res = await this.cdpSession?.sendCDPMessage("Runtime.evaluate", args);
+    return res.result;
   }
 
   protected async customRequest(
@@ -378,8 +369,8 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
           this.sendEvent(new Event("RNIDE_profilingCPUStopped", { filePath }));
         }
         break;
-      case "RNIDE_ping":
-        response.body.result = await this.ping();
+      case "RNIDE_evaluate":
+        response.body.result = await this.evaluateExpression(args);
         break;
       default:
         Logger.debug(`Custom req ${command} ${args}`);

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -1,4 +1,4 @@
-import { DebugSessionCustomEvent, Disposable, Event } from "vscode";
+import { Disposable } from "vscode";
 import { Cdp } from "vscode-cdp-proxy";
 import { Metro } from "../project/metro";
 import { CancelToken } from "../utilities/cancelToken";
@@ -76,28 +76,15 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
     await this.debugSession.dispose?.();
   }
 
-  // Delegate DebugSession methods to the decorated object
-  public get onConsoleLog(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onConsoleLog;
-  }
-  public get onDebuggerPaused(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onDebuggerPaused;
-  }
-  public get onDebuggerResumed(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onDebuggerResumed;
-  }
-  public get onProfilingCPUStarted(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onProfilingCPUStarted;
-  }
-  public get onProfilingCPUStopped(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onProfilingCPUStopped;
-  }
-  public get onBindingCalled(): Event<DebugSessionCustomEvent> {
-    return this.debugSession.onBindingCalled;
-  }
-  public get onDebugSessionTerminated(): Event<void> {
-    return this.debugSession.onDebugSessionTerminated;
-  }
+  // #region DebugSession methods delegated to the decorated object
+  public onConsoleLog = this.debugSession.onConsoleLog;
+  public onDebuggerPaused = this.debugSession.onDebuggerPaused;
+  public onDebuggerResumed = this.debugSession.onDebuggerResumed;
+  public onProfilingCPUStarted = this.debugSession.onProfilingCPUStarted;
+  public onProfilingCPUStopped = this.debugSession.onProfilingCPUStopped;
+  public onBindingCalled = this.debugSession.onBindingCalled;
+  public onDebugSessionTerminated = this.debugSession.onDebugSessionTerminated;
+
   public async startParentDebugSession(): Promise<void> {
     return this.debugSession.startParentDebugSession();
   }

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -1,0 +1,128 @@
+import { DebugSessionCustomEvent, Disposable, Event } from "vscode";
+import { Cdp } from "vscode-cdp-proxy";
+import { Metro } from "../project/metro";
+import { CancelToken } from "../utilities/cancelToken";
+import { sleep } from "../utilities/retry";
+import { DebugSession, DebugSource, JSDebugConfiguration } from "./DebugSession";
+
+const PING_TIMEOUT = 1000;
+export class ReconnectingDebugSession implements DebugSession, Disposable {
+  private readonly sessionTerminatedSubscription: Disposable;
+  private cancelReconnect: CancelToken | undefined;
+
+  private isRunning: boolean = false;
+
+  constructor(
+    private readonly debugSession: DebugSession & Partial<Disposable>,
+    private readonly metro: Metro
+  ) {
+    this.sessionTerminatedSubscription = debugSession.onDebugSessionTerminated(() => {
+      if (this.isRunning && this.cancelReconnect === undefined) {
+        this.reconnect();
+      }
+    });
+  }
+
+  public async startJSDebugSession(configuration: JSDebugConfiguration) {
+    this.isRunning = true;
+    return this.debugSession.startJSDebugSession(configuration);
+  }
+
+  private async pingJsDebugSessionWithTimeout() {
+    const resultPromise = this.debugSession
+      .evaluateExpression({ expression: "('ping')" })
+      .then((response) => {
+        return response.result.value === "ping";
+      });
+    const timeout = sleep(PING_TIMEOUT).then(() => {
+      throw new Error("Ping timeout");
+    });
+    return Promise.race([resultPromise, timeout]).catch((_e) => false);
+  }
+
+  private async reconnect() {
+    this.cancelReconnect = new CancelToken();
+    while (this.isRunning && !this.cancelReconnect.cancelled) {
+      try {
+        const connected = await this.pingJsDebugSessionWithTimeout();
+        if (connected) {
+          // if we're connected to a responsive session, we can break
+          break;
+        }
+        const websocketAddress = await this.metro.getDebuggerURL(undefined, this.cancelReconnect);
+        if (!websocketAddress) {
+          throw new Error("No connected device listed");
+        }
+        await this.debugSession.startJSDebugSession({
+          websocketAddress,
+          displayDebuggerOverlay: false,
+          isUsingNewDebugger: this.metro.isUsingNewDebugger,
+          expoPreludeLineCount: this.metro.expoPreludeLineCount,
+          sourceMapPathOverrides: this.metro.sourceMapPathOverrides,
+        });
+      } catch (e) {
+        // we ignore the errors and retry
+      }
+    }
+    this.cancelReconnect = undefined;
+  }
+
+  async dispose() {
+    this.sessionTerminatedSubscription.dispose();
+    this.cancelReconnect?.cancel();
+    await this.debugSession.dispose?.();
+  }
+
+  // Delegate DebugSession methods to the decorated object
+  public get onConsoleLog(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onConsoleLog;
+  }
+  public get onDebuggerPaused(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onDebuggerPaused;
+  }
+  public get onDebuggerResumed(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onDebuggerResumed;
+  }
+  public get onProfilingCPUStarted(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onProfilingCPUStarted;
+  }
+  public get onProfilingCPUStopped(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onProfilingCPUStopped;
+  }
+  public get onBindingCalled(): Event<DebugSessionCustomEvent> {
+    return this.debugSession.onBindingCalled;
+  }
+  public get onDebugSessionTerminated(): Event<void> {
+    return this.debugSession.onDebugSessionTerminated;
+  }
+  public async startParentDebugSession(): Promise<void> {
+    return this.debugSession.startParentDebugSession();
+  }
+  public async restart(): Promise<void> {
+    return this.debugSession.restart();
+  }
+  public resumeDebugger(): void {
+    this.debugSession.resumeDebugger();
+  }
+  public stepOverDebugger(): void {
+    this.debugSession.stepOverDebugger();
+  }
+  public async startProfilingCPU(): Promise<void> {
+    return this.debugSession.startProfilingCPU();
+  }
+  public async stopProfilingCPU(): Promise<void> {
+    return this.debugSession.stopProfilingCPU();
+  }
+  public async appendDebugConsoleEntry(
+    message: string,
+    type: string,
+    source?: DebugSource
+  ): Promise<void> {
+    return this.debugSession.appendDebugConsoleEntry(message, type, source);
+  }
+  public async evaluateExpression(
+    params: Cdp.Runtime.EvaluateParams
+  ): Promise<Cdp.Runtime.EvaluateResult> {
+    return this.debugSession.evaluateExpression(params);
+  }
+}

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -331,7 +331,8 @@ export class DeviceSession implements Disposable, MetroDelegate, ToolsDelegate {
         displayName: this.device.deviceInfo.displayName,
         useParentDebugSession: true,
       }),
-      this.metro
+      this.metro,
+      this.devtools
     );
   }
 

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -38,7 +38,7 @@ import {
   FatalErrorDescriptor,
   BundleErrorDescriptor,
 } from "../common/Project";
-import { DebugSession, DebugSource, ReconnectingDebugSession } from "../debugging/DebugSession";
+import { DebugSource, ReconnectingDebugSession } from "../debugging/DebugSession";
 import { throttle, throttleAsync } from "../utilities/throttle";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { CancelError, CancelToken } from "../utilities/cancelToken";
@@ -81,7 +81,7 @@ export class DeviceSession implements Disposable, MetroDelegate, ToolsDelegate {
   private inspectCallID = 7621;
   private maybeBuildResult: BuildResult | undefined;
   private devtools: Devtools;
-  private debugSession: DebugSession & Disposable;
+  private debugSession: ReconnectingDebugSession;
   private debugSessionEventSubscription: Disposable;
   private buildManager: BuildManager;
   private buildCache: BuildCache;

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -15,9 +15,11 @@ import { getOpenPort } from "../utilities/common";
 import { DebugSource } from "../debugging/DebugSession";
 import { openFileAtPosition } from "../utilities/openFileAtPosition";
 import { ResolvedLaunchConfig } from "./ApplicationContext";
+import { CancelToken } from "../utilities/cancelToken";
 
 const FAKE_EDITOR = "RADON_IDE_FAKE_EDITOR";
 const OPENING_IN_FAKE_EDITOR_REGEX = new RegExp(`Opening (.+) in ${FAKE_EDITOR}`);
+const WAIT_FOR_DEBUGGER_TIMEOUT_MS = 15_000;
 
 export interface MetroDelegate {
   onBundleProgress(bundleProgress: number): void;
@@ -265,13 +267,24 @@ export class Metro {
     return undefined;
   }
 
-  public async fetchWsTargets(): Promise<CDPTargetDescription[] | undefined> {
-    const WAIT_FOR_DEBUGGER_TIMEOUT_MS = 15_000;
-
+  public async fetchWsTargets(
+    timeoutMs: number | undefined = WAIT_FOR_DEBUGGER_TIMEOUT_MS,
+    cancelToken: CancelToken = new CancelToken()
+  ): Promise<CDPTargetDescription[] | undefined> {
     let retryCount = 0;
     const startTime = Date.now();
 
-    while (Date.now() - startTime < WAIT_FOR_DEBUGGER_TIMEOUT_MS) {
+    function shouldContinue() {
+      if (timeoutMs !== undefined) {
+        if (Date.now() - startTime > timeoutMs) {
+          return false;
+        }
+      }
+
+      return !cancelToken.cancelled;
+    }
+
+    while (shouldContinue()) {
       retryCount++;
 
       try {
@@ -291,14 +304,19 @@ export class Metro {
         Logger.warn("[METRO] Fetching list of runtimes failed, retrying...");
       }
 
-      await sleep(progressiveRetryTimeout(retryCount));
+      await cancelToken.adapt(sleep(progressiveRetryTimeout(retryCount))).catch(() => {
+        // ignore the CancelError, we'll just break out of the loop after the condition is checked next time
+      });
     }
 
     return undefined;
   }
 
-  public async getDebuggerURL() {
-    const listJson = await this.fetchWsTargets();
+  public async getDebuggerURL(
+    timeoutMs: number | undefined = WAIT_FOR_DEBUGGER_TIMEOUT_MS,
+    cancelToken: CancelToken = new CancelToken()
+  ) {
+    const listJson = await this.fetchWsTargets(timeoutMs, cancelToken);
 
     if (listJson === undefined) {
       return undefined;


### PR DESCRIPTION
Closes #1368

### How Has This Been Tested: 
- open an app in Radon
- close the application through the device's App Switcher
- open the application from the device's system launcher
- check that the debugger connects automatically to the application

#### Check for potential regression -- Expo Go sometimes misbehaves on JS reload #985 
- open an app which uses Expo Go
- reload JS
- verify that the debugger still works correctly (e.g. by triggering a breakpoint)