### PR TITLE
feat: add "Restart Metro" reload action

### DIFF
--- a/packages/vscode-extension/src/common/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/common/DeviceSessionsManager.ts
@@ -7,6 +7,7 @@ export type SelectDeviceOptions = {
 
 export type ReloadAction =
   | "autoReload" // automatic reload mode
+  | "restartMetro"
   | "clearMetro" // clear metro cache, boot device, install app
   | "rebuild" // clean build, boot device, install app
   | "reboot" // reboots device, launch app
@@ -15,7 +16,7 @@ export type ReloadAction =
   | "reloadJs"; // refetch JS scripts from metro
 
 export interface DeviceSessionsManagerInterface {
-  reloadCurrentSession(type: ReloadAction): Promise<boolean>;
+  reloadCurrentSession(type: ReloadAction): Promise<void>;
   startOrActivateSessionForDevice(
     deviceInfo: DeviceInfo,
     selectDeviceOptions?: SelectDeviceOptions

--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -74,7 +74,7 @@ export class DeviceSessionsManager implements Disposable, DeviceSessionsManagerI
     const deviceSession = this.selectedDeviceSession;
     if (!deviceSession) {
       window.showErrorMessage("Failed to reload, no active device found.", "Dismiss");
-      return false;
+      return;
     }
     return await deviceSession.performReloadAction(type);
   }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -515,7 +515,7 @@ export class DeviceSession implements Disposable, MetroDelegate, ToolsDelegate {
     });
 
     await cancelToken.adapt(this.restartDebugger());
-    if (!this.buildResult) {
+    if (!this.maybeBuildResult) {
       await this.buildApp({ clean: false, cancelToken });
     }
     await cancelToken.adapt(this.installApp({ reinstall: false }));
@@ -749,6 +749,7 @@ export class DeviceSession implements Disposable, MetroDelegate, ToolsDelegate {
   private async buildApp({ clean, cancelToken }: { clean: boolean; cancelToken: CancelToken }) {
     const buildStartTime = Date.now();
     this.updateStartupMessage(StartupMessage.Building);
+    this.maybeBuildResult = undefined;
     const launchConfiguration = this.applicationContext.launchConfig;
     const buildType = await inferBuildType(this.platform, launchConfiguration);
 

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -19,7 +19,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
         "Reload JS": () => deviceSessionsManager.reloadCurrentSession("reloadJs"),
         "Restart app process": () => deviceSessionsManager.reloadCurrentSession("restartProcess"),
         "Reinstall app": () => deviceSessionsManager.reloadCurrentSession("reinstall"),
-        "Restart Metro": () => deviceSessionsManager.reloadCurrentSession("restartMetro"),
+        "Restart Metro server": () => deviceSessionsManager.reloadCurrentSession("restartMetro"),
         "Clear Metro cache": () => deviceSessionsManager.reloadCurrentSession("clearMetro"),
         "Reboot IDE": () => deviceSessionsManager.reloadCurrentSession("reboot"),
         "Clean rebuild": () => deviceSessionsManager.reloadCurrentSession("rebuild"),

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -19,6 +19,7 @@ function ReloadButton({ disabled }: { disabled: boolean }) {
         "Reload JS": () => deviceSessionsManager.reloadCurrentSession("reloadJs"),
         "Restart app process": () => deviceSessionsManager.reloadCurrentSession("restartProcess"),
         "Reinstall app": () => deviceSessionsManager.reloadCurrentSession("reinstall"),
+        "Restart Metro": () => deviceSessionsManager.reloadCurrentSession("restartMetro"),
         "Clear Metro cache": () => deviceSessionsManager.reloadCurrentSession("clearMetro"),
         "Reboot IDE": () => deviceSessionsManager.reloadCurrentSession("reboot"),
         "Clean rebuild": () => deviceSessionsManager.reloadCurrentSession("rebuild"),


### PR DESCRIPTION
- Adds a "Restart Metro server" reload action to the restart dropdown
- No longer restarts the whole device for metro restart actions

Closes #1369 

### How Has This Been Tested: 
- open `expo-52-prebuilt` test app
- check that both "Restart Metro" and "Clear Metro cache" options work
- check that Redux / React Query devtools work after restarting metro this way


