### PR TITLE
fix: attaching debugger on relaunch

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -739,7 +739,15 @@ export class DeviceSession implements Disposable, MetroDelegate, ToolsDelegate {
     Logger.debug("App and preview ready, moving on...");
     this.updateStartupMessage(StartupMessage.AttachingDebugger);
     if (this.isActive) {
-      await cancelToken.adapt(this.connectJSDebugger());
+      try {
+        await cancelToken.adapt(this.connectJSDebugger());
+      } catch (e) {
+        if (!(e instanceof CancelError)) {
+          throw e;
+        }
+        // when connecting to debugger is cancelled, we don't want to throw an error
+        // as that mean that the other process is already attaching the debugger
+      }
     }
 
     const launchDurationSec = (Date.now() - launchRequestTime) / 1000;


### PR DESCRIPTION
after #1373 the application would get stuck in "attaching debugger" state after using "restart app process" or "reinstall" options. It was happening because the new "reconnecting" functionality would cancel the launch proces attempt to connect to the debugger and that would cause the launch proces to never end. 

This fixes it in a crude way by just checking if  the attempt to connect to the debugger was in fact cancelled and not thrown more critical exception. 

The real fix would be to rework the debugger session to only start new session and cancel the previous try if the configuration has changed and even the probably instead of cancelling It should just become the new awaited session for the old start request.  

### How Has This Been Tested: 

use the reinstall functionality 

### How Has This Change Been Documented:

Internal change



