### PR TITLE
Update timeout for troubleshooting options

### DIFF
--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -86,9 +86,14 @@ function PreviewLoader({
   useEffect(() => {
     setIsLoadingSlowly(false);
 
-    // we show the slow loading message after 12 seconds for each phase,
-    // but for the native build phase we show it after 5 seconds.
+    // we show the slow loading message after:
+    // - 5 seconds native build phase for  12 seconds for each phase,
+    // - 17 seconds for waiting for app to load phase (loads slowly on android devices after clean build)
+    // - 12 seconds for other phases
     let timeoutMs = 12_000;
+    if(startupMessage === StartupMessage.WaitingForAppToLoad){
+      timeoutMs = 17_000;
+    }
     if (startupMessage === StartupMessage.Building) {
       timeoutMs = 5_000;
     }

--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -91,7 +91,7 @@ function PreviewLoader({
     // - 17 seconds for waiting for app to load phase (loads slowly on android devices after clean build)
     // - 12 seconds for other phases
     let timeoutMs = 12_000;
-    if(startupMessage === StartupMessage.WaitingForAppToLoad){
+    if (startupMessage === StartupMessage.WaitingForAppToLoad) {
       timeoutMs = 17_000;
     }
     if (startupMessage === StartupMessage.Building) {


### PR DESCRIPTION
** Description **

When the projects builds for the first time, especially in the case of Android devices, the troubleshooting options during loading appear right before the app successfully launches. Described in Issue #1374.

This PR  increases the time needed for troubleshooting options to appear to 17 seconds during WaitingForAppToLoad phase in PreviewLoader.

<img width="789" height="338" alt="Screenshot 2025-07-30 at 08 27 36" src="https://github.com/user-attachments/assets/abc2d2a4-a9ef-4da2-aaa9-7f78c75cf067" />



### How Has This Been Tested: 

Internal change - tested by running the IDE