### PR TITLE
fix: workspace state fast updates

### DIFF
--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -6,7 +6,6 @@ import { StateManager } from "../project/StateManager";
 import { disposeAll } from "../utilities/disposables";
 import { DeviceRotation } from "../common/Project";
 import { updatePartialWorkspaceConfig } from "../utilities/updatePartialWorkspaceConfig";
-import { Logger } from "../Logger";
 
 export class WorkspaceConfigController implements Disposable {
   private disposables: Disposable[] = [];

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { ConfigurationChangeEvent, workspace, Disposable } from "vscode";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { PanelLocation, WorkspaceConfiguration } from "../common/State";
@@ -5,9 +6,11 @@ import { StateManager } from "../project/StateManager";
 import { disposeAll } from "../utilities/disposables";
 import { DeviceRotation } from "../common/Project";
 import { updatePartialWorkspaceConfig } from "../utilities/updatePartialWorkspaceConfig";
+import { Logger } from "../Logger";
 
 export class WorkspaceConfigController implements Disposable {
   private disposables: Disposable[] = [];
+  private workspaceConfigurationUpdatesToIgnore: WorkspaceConfiguration[] = [];
 
   constructor(private stateManager: StateManager<WorkspaceConfiguration>) {
     const configuration = workspace.getConfiguration("RadonIDE");
@@ -27,7 +30,25 @@ export class WorkspaceConfigController implements Disposable {
 
       const config = workspace.getConfiguration("RadonIDE");
 
+      const currentWorkspaceConfig = {
+        panelLocation: config.get<PanelLocation>("panelLocation")!,
+        showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
+        stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
+        deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
+      };
+
       for (const partialStateEntry of partialStateEntries) {
+        const updatedConfig = {
+          [partialStateEntry[0]]: partialStateEntry[1],
+          ...currentWorkspaceConfig,
+        };
+
+        const shouldSkipUpdate = _.isEqual(updatedConfig, currentWorkspaceConfig);
+        if (shouldSkipUpdate) {
+          continue;
+        }
+
+        this.workspaceConfigurationUpdatesToIgnore.push(updatedConfig);
         await updatePartialWorkspaceConfig(config, partialStateEntry);
       }
     });
@@ -47,6 +68,15 @@ export class WorkspaceConfigController implements Disposable {
       stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
       deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
     };
+
+    const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>
+      _.isEqual(cfg, newConfig)
+    );
+    const shouldIgnoreUpdate = index !== -1;
+    if (shouldIgnoreUpdate) {
+      this.workspaceConfigurationUpdatesToIgnore.splice(index, 1);
+      return;
+    }
 
     const oldConfig = this.stateManager.getState();
 


### PR DESCRIPTION
This PR fixes how we perform the sync with workspace settings.  Before a consecutive fast updates would cause an infinite 
loop of synchronization between `workspaceConfiguration` and our state manager. 

This change checks if the update that comes back is the same as the one just set before updating it. 

Additionally after this change updates that take no effect are not send at all.

### How Has This Been Tested: 

- run radon and use `control` +`option` + 0/9 keybinding (rotate the device) in very short succession 
- before this update it would trigger infinite spiral of updates 

### How Has This Change Been Documented:

internal change



