### PR TITLE
fix: correct rotation icons style in DeviceSettingsDropdown

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -232,7 +232,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
                     onSelect={() => store$.workspaceConfiguration.deviceRotation.set(option.value)}>
                     <span
                       className={`codicon codicon-${option.icon}`}
-                      style={{ rotate: rotation }}
+                      style={{ rotate: option.rotation }}
                     />
                     {option.label}
                     {rotation === option.value && (


### PR DESCRIPTION
### Description ###

This PR fixes incorrect icon styling in DeviceSettingsDropdown - the "style" parameter now properly uses `option.rotation` instead of `rotation` inside `.map` method.


### How Has This Been Tested: 

Visual change, standard IDE setup:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device - check whether the icons are now properly rotated.

### How Has This Change Been Documented:

Bugfix, not applicable.



