### PR TITLE
feat: disable biometric authorizations buttons when not enrolled

### DIFF
--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -355,18 +355,21 @@ function CommandItem({
   commandName,
   label,
   icon,
+  disabled = false,
 }: {
   project: ProjectInterface;
   commandName: string;
   label: string;
   icon: string;
+  disabled?: boolean;
 }) {
   return (
     <DropdownMenu.Item
       className="dropdown-menu-item"
       onSelect={() => {
         project.runCommand(commandName);
-      }}>
+      }}
+      disabled={disabled}>
       <span className="dropdown-menu-item-wraper">
         <span className={`codicon codicon-${icon}`} />
         <div className="dropdown-menu-item-content">
@@ -410,12 +413,14 @@ const BiometricsItem = () => {
             commandName="RNIDE.performBiometricAuthorization"
             label="Matching ID"
             icon="layout-sidebar-left"
+            disabled={!deviceSettings.hasEnrolledBiometrics}
           />
           <CommandItem
             project={project}
             commandName="RNIDE.performFailedBiometricAuthorization"
             label="Non-Matching ID"
             icon="layout-sidebar-left"
+            disabled={!deviceSettings.hasEnrolledBiometrics}
           />
         </DropdownMenu.SubContent>
       </DropdownMenu.Portal>


### PR DESCRIPTION
<img width="586" height="363" alt="image" src="https://github.com/user-attachments/assets/0e5ca19e-a65f-4555-bfdc-39b0e7bdded4" />

Fixes #1208 

### How Has This Been Tested: 
- open app in Radon on iOS
- toggle enrolled option in device settings
- verify the options enable/disable accordingly
