### PR TITLE
fix: fix touch-area overflow issues

### DIFF
--- a/packages/vscode-extension/src/webview/Preview/Device/Device.tsx
+++ b/packages/vscode-extension/src/webview/Preview/Device/Device.tsx
@@ -40,8 +40,6 @@ type DeviceCSSProperties = React.CSSProperties & {
   "--phone-touch-area-left"?: string;
   "--phone-touch-area-screen-height"?: string;
   "--phone-touch-area-screen-width"?: string;
-  "--phone-touch-area-screen-top"?: string;
-  "--phone-touch-area-screen-left"?: string;
   "--frame-rotation"?: string;
 };
 
@@ -131,32 +129,6 @@ function getLandscapeDimensions(
   };
 }
 
-function getPortraitTouchAreaDimensions() {
-  return {
-    phoneTouchAreaWidth: "calc(var(--phone-screen-width) + 14px)",
-    phoneTouchAreaHeight: "var(--phone-screen-height)",
-    phoneTouchAreaTop: "var(--phone-top)",
-    phoneTouchAreaLeft: "calc(var(--phone-left) - 7px)",
-    phoneTouchAreaScreenHeight: "100%",
-    phoneTouchAreaScreenWidth: "calc(100% - 14px)",
-    phoneTouchAreaScreenTop: "0",
-    phoneTouchAreaScreenLeft: "7px",
-  };
-}
-
-function getLandscapeTouchAreaDimensions() {
-  return {
-    phoneTouchAreaWidth: "var(--phone-screen-width)",
-    phoneTouchAreaHeight: "calc(var(--phone-screen-height) + 14px)",
-    phoneTouchAreaTop: "calc(var(--phone-top) - 7px)",
-    phoneTouchAreaLeft: "var(--phone-left)",
-    phoneTouchAreaScreenHeight: "calc(100% - 14px)",
-    phoneTouchAreaScreenWidth: "100%",
-    phoneTouchAreaScreenTop: "7px",
-    phoneTouchAreaScreenLeft: "0",
-  };
-}
-
 function getDeviceLayoutConfig(
   frame: DevicePropertiesFrame,
   rotation: DeviceRotation,
@@ -190,9 +162,6 @@ export default function Device({ device, zoomLevel, children, wrapperDivRef }: D
     const phoneDimensions = layoutConfig.isLandscape
       ? getLandscapeDimensions(layoutConfig, device, frame, zoomLevel)
       : getPortraitDimensions(layoutConfig, device, frame, zoomLevel);
-    const touchAreaDimensions = layoutConfig.isLandscape
-      ? getLandscapeTouchAreaDimensions()
-      : getPortraitTouchAreaDimensions();
 
     const frameRotation = shouldRotateFrame(rotation) ? "180deg" : "0deg";
 
@@ -212,14 +181,6 @@ export default function Device({ device, zoomLevel, children, wrapperDivRef }: D
       "--phone-left": phoneDimensions.phoneLeft,
       "--phone-mask-image": phoneDimensions.phoneMaskImage,
       "--phone-frame-image": phoneDimensions.phoneFrameImage,
-      "--phone-touch-area-width": touchAreaDimensions.phoneTouchAreaWidth,
-      "--phone-touch-area-height": touchAreaDimensions.phoneTouchAreaHeight,
-      "--phone-touch-area-top": touchAreaDimensions.phoneTouchAreaTop,
-      "--phone-touch-area-left": touchAreaDimensions.phoneTouchAreaLeft,
-      "--phone-touch-area-screen-height": touchAreaDimensions.phoneTouchAreaScreenHeight,
-      "--phone-touch-area-screen-width": touchAreaDimensions.phoneTouchAreaScreenWidth,
-      "--phone-touch-area-screen-top": touchAreaDimensions.phoneTouchAreaScreenTop,
-      "--phone-touch-area-screen-left": touchAreaDimensions.phoneTouchAreaScreenLeft,
       "--frame-rotation": frameRotation,
     };
   }, [device, frame, rotation, zoomLevel, wrapperDivRef]);

--- a/packages/vscode-extension/src/webview/components/Preview.css
+++ b/packages/vscode-extension/src/webview/components/Preview.css
@@ -76,21 +76,11 @@
 
 .touch-area {
   position: absolute;
-  width: var(--phone-touch-area-width);
-  height: var(--phone-touch-area-height);
-  top: var(--phone-touch-area-top);
-  left: var(--phone-touch-area-left);
-  user-select: none;
-}
-
-.phone-screen-background {
-  position: absolute;
-  width: calc(var(--phone-screen-width));
+  width: var(--phone-screen-width);
   height: var(--phone-screen-height);
   top: var(--phone-top);
-  left: calc(var(--phone-left));
-  rotate: var(--frame-rotation);
-  display: none;
+  left: var(--phone-left);
+  user-select: none;
 }
 
 .phone-sized {
@@ -109,10 +99,10 @@
 
 .phone-screen {
   position: absolute;
-  width: var(--phone-touch-area-screen-width);
-  height: var(--phone-touch-area-screen-height);
-  top: var(--phone-touch-area-screen-top);
-  left: var(--phone-touch-area-screen-left);
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
   -webkit-mask-image: var(--phone-mask-image);
   mask-image: var(--phone-mask-image);
   -webkit-mask-size: cover;


### PR DESCRIPTION
### Description

This PR fixes issue with persistent overflow when device is in portrait mode due to problems with touch-area dimensions. Touch area dimensions have been changed, to not include 7px additional margin on both sides, which has been deemed unnecessary because of current implementation of touch-handling.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **test whether during window-resizing the overflow persist, check if the device properly handles touches which start beyond the phone screen**

### How Has This Change Been Documented:

Not applicable.

