### PR TITLE
refactor: cleanup `inspectElementAt` extension-side implementation

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -329,12 +329,7 @@ export interface ProjectInterface {
   ): Promise<void>;
   terminateSession(deviceId: DeviceId): Promise<void>;
 
-  inspectElementAt(
-    xRatio: number,
-    yRatio: number,
-    requestStack: boolean,
-    callback: (inspectData: InspectData) => void
-  ): Promise<void>;
+  inspectElementAt(xRatio: number, yRatio: number, requestStack: boolean): Promise<InspectData>;
 
   createAndroidDevice(
     modelId: string,

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -16,6 +16,7 @@ export type WorkspaceConfiguration = {
   showDeviceFrame: boolean;
   stopPreviousDevices: boolean;
   deviceRotation: DeviceRotation;
+  inspectorExcludePattern: string | null;
 };
 
 // #endregion Workspace Configuration
@@ -172,6 +173,7 @@ export const initialState: State = {
     showDeviceFrame: true,
     stopPreviousDevices: false,
     deviceRotation: DeviceRotation.Portrait,
+    inspectorExcludePattern: null,
   },
 };
 

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -29,11 +29,12 @@ export class WorkspaceConfigController implements Disposable {
 
       const config = workspace.getConfiguration("RadonIDE");
 
-      const currentWorkspaceConfig = {
+      const currentWorkspaceConfig: WorkspaceConfiguration = {
         panelLocation: config.get<PanelLocation>("panelLocation")!,
         showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
         stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
         deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
+        inspectorExcludePattern: config.get<string>("inspectorExcludePattern") ?? null,
       };
 
       for (const partialStateEntry of partialStateEntries) {
@@ -66,6 +67,7 @@ export class WorkspaceConfigController implements Disposable {
       showDeviceFrame: config.get<boolean>("showDeviceFrame")!,
       stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
       deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
+      inspectorExcludePattern: config.get<string>("inspectorExcludePattern") ?? null,
     };
 
     const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -8,7 +8,7 @@ import { BuildManagerImpl, BuildManager } from "../builders/BuildManager";
 import { BatchingBuildManager } from "../builders/BatchingBuildManager";
 import { LaunchConfiguration, LaunchOptions } from "../common/LaunchConfig";
 import { StateManager } from "./StateManager";
-import { ApplicationContextState } from "../common/State";
+import { ApplicationContextState, WorkspaceConfiguration } from "../common/State";
 import { ApplicationDependencyManager } from "../dependency/ApplicationDependencyManager";
 import { Logger } from "../Logger";
 
@@ -70,6 +70,7 @@ export class ApplicationContext implements Disposable {
 
   constructor(
     private readonly stateManager: StateManager<ApplicationContextState>,
+    private readonly workspaceConfigState: StateManager<WorkspaceConfiguration>, // owned by `Project`, do not dispose
     launchConfig: LaunchConfiguration,
     public readonly buildCache: BuildCache
   ) {
@@ -82,6 +83,10 @@ export class ApplicationContext implements Disposable {
     this.buildManager = buildManager;
 
     this.disposables.push(this.applicationDependencyManager, buildManager);
+  }
+
+  public get workspaceConfiguration(): WorkspaceConfiguration {
+    return this.workspaceConfigState.getState();
   }
 
   public get appRootFolder(): string {

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -34,6 +34,7 @@ import { focusSource } from "../utilities/focusSource";
 import { CancelToken } from "../utilities/cancelToken";
 import { BuildResult } from "../builders/BuildManager";
 import { DevicePlatform } from "../common/State";
+import { isAppSourceFile } from "../utilities/isAppSourceFile";
 
 interface LaunchApplicationSessionDeps {
   applicationContext: ApplicationContext;
@@ -512,16 +513,4 @@ export class ApplicationSession implements ToolsDelegate, Disposable {
     this.debugSession = undefined;
     this.device.terminateApp(this.packageNameOrBundleId);
   }
-}
-
-export function isAppSourceFile(filePath: string) {
-  const relativeToWorkspace = workspace.asRelativePath(filePath, false);
-
-  if (relativeToWorkspace === filePath) {
-    // when path is outside of any workspace folder, workspace.asRelativePath returns the original path
-    return false;
-  }
-
-  // if the relative path contain node_modules, we assume it's not user's app source file:
-  return !relativeToWorkspace.includes("node_modules");
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -25,6 +25,7 @@ import {
   DeviceSessionStatus,
   FatalErrorDescriptor,
   DeviceRotation,
+  InspectData,
 } from "../common/Project";
 import { throttle, throttleAsync } from "../utilities/throttle";
 import { getTelemetryReporter } from "../utilities/telemetry";
@@ -785,7 +786,11 @@ export class DeviceSession implements Disposable {
     this.device.sendWheel(point, deltaX, deltaY);
   }
 
-  public inspectElementAt(xRatio: number, yRatio: number, requestStack: boolean): Promise<any> {
+  public inspectElementAt(
+    xRatio: number,
+    yRatio: number,
+    requestStack: boolean
+  ): Promise<InspectData> {
     if (!this.applicationSession) {
       throw new Error("Cannot inspect element while the application is not running");
     }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -5,6 +5,7 @@ import path from "path";
 import assert from "assert";
 import { env, Disposable, commands, workspace, window, Uri } from "vscode";
 import _ from "lodash";
+import { TelemetryEventProperties } from "@vscode/extension-telemetry";
 import {
   AppPermissionType,
   DeviceButtonType,
@@ -63,11 +64,9 @@ import {
   WorkspaceConfiguration,
 } from "../common/State";
 import { EnvironmentDependencyManager } from "../dependency/EnvironmentDependencyManager";
-import { isAppSourceFile } from "../utilities/isAppSourceFile";
 import { getTimestamp } from "../utilities/getTimestamp";
 import { Platform } from "../utilities/platform";
 import { Telemetry } from "./telemetry";
-import { TelemetryEventProperties } from "@vscode/extension-telemetry";
 import { EditorBindings } from "./EditorBindings";
 
 const PREVIEW_ZOOM_KEY = "preview_zoom";

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -195,28 +195,33 @@ function Preview({
 
     const requestStack = type === "Down" || type === "RightButtonDown";
     const showInspectStackModal = type === "RightButtonDown";
-    project.inspectElementAt(translatedX, translatedY, requestStack).then((inspectData) => {
-      if (requestStack && inspectData?.stack) {
-        if (showInspectStackModal) {
-          setInspectStackData({
-            requestLocation: {
-              x: event.clientX,
-              y: event.clientY,
-            },
-            stack: inspectData.stack,
-          });
-        } else {
-          // find first item w/o hide flag and open file
-          const firstItem = inspectData.stack.find((item) => !item.hide);
-          if (firstItem) {
-            onInspectorItemSelected(firstItem);
+    project
+      .inspectElementAt(translatedX, translatedY, requestStack)
+      .then((inspectData) => {
+        if (requestStack && inspectData?.stack) {
+          if (showInspectStackModal) {
+            setInspectStackData({
+              requestLocation: {
+                x: event.clientX,
+                y: event.clientY,
+              },
+              stack: inspectData.stack,
+            });
+          } else {
+            // find first item w/o hide flag and open file
+            const firstItem = inspectData.stack.find((item) => !item.hide);
+            if (firstItem) {
+              onInspectorItemSelected(firstItem);
+            }
           }
         }
-      }
-      if (inspectData.frame) {
-        setInspectFrame(inspectData.frame);
-      }
-    });
+        if (inspectData.frame) {
+          setInspectFrame(inspectData.frame);
+        }
+      })
+      .catch(() => {
+        // NOTE: we can safely ignore errors, we'll simply not show the frame in that case
+      });
   }
 
   const sendInspect = throttle(sendInspectUnthrottled, 50);

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -195,7 +195,7 @@ function Preview({
 
     const requestStack = type === "Down" || type === "RightButtonDown";
     const showInspectStackModal = type === "RightButtonDown";
-    project.inspectElementAt(translatedX, translatedY, requestStack, (inspectData) => {
+    project.inspectElementAt(translatedX, translatedY, requestStack).then((inspectData) => {
       if (requestStack && inspectData?.stack) {
         if (showInspectStackModal) {
           setInspectStackData({


### PR DESCRIPTION
- moves the implementation of `inspectElementAt` fully to application session (from `Project` and `DeviceSession`)
- changes the API to return a Promise with InspectData instead of accepting a callback

Fixes #1244

### How Has This Been Tested: 
- open app in Radon
- verify that the element inspector still works
- verify that after hovering a lot of elements in a short time with the element inspector enabled, you don't see "Too many callbacks in memory! Something is wrong!" warnings in the console logs