### PR TITLE
feat: improve inspector compatibility across devices

### DIFF
--- a/packages/vscode-extension/lib/instrumentation.js
+++ b/packages/vscode-extension/lib/instrumentation.js
@@ -9,7 +9,8 @@ const {
   traverseRenderedFibers,
 } = require("__RNIDE_lib__/bippy");
 const { getFabricUIManager } = require("react-native/Libraries/ReactNative/FabricUIManager.js");
-const { Dimensions, StatusBar, UIManager, Platform } = require("react-native");
+const { StatusBar, UIManager, Platform } = require("react-native");
+const WindowDimensionsManager = require("./window_layout_manager");
 const FabricUIManager = getFabricUIManager();
 
 const CORE_COMPONENT_NAMES = new Set([
@@ -78,7 +79,8 @@ function shouldHideComponent(name) {
 }
 
 function getWindowRect() {
-  const { width: screenWidth, height: screenHeight } = Dimensions.get("screen");
+  const { width: screenWidth, height: screenHeight } =
+    WindowDimensionsManager.getScreenDimensionsCompat();
   if (Platform.OS === "android") {
     const statusBarHeight = StatusBar.currentHeight || 0;
     return {

--- a/packages/vscode-extension/lib/orientation.js
+++ b/packages/vscode-extension/lib/orientation.js
@@ -1,11 +1,12 @@
-const { Dimensions, Platform, UIManager, NativeEventEmitter } = require("react-native");
+const { Platform, UIManager, NativeEventEmitter, NativeModules } = require("react-native");
+const NativeUIManager = NativeModules.UIManager ?? UIManager;
 const inspectorBridge = require("./inspector_bridge");
-
+const WindowDimensionsManager = require("./window_layout_manager");
 
 // The approach implemented below is best we can do as of today, becuase of lack
 // of support for orientation getter sync requests in the React Native core.
 // Hence, the orientation is determined by the event listener via NativeEventEmitter(UIManager)
-// and the Dimensions API, which is not 100% reliable and works differently across platforms.
+// and the WindowDimensionsManager, which is not 100% reliable and works differently across platforms.
 
 // The orientation events on Android work as one would expect - the orientation change
 // is reported after the app actually rotates and is distinct from the device orientation.
@@ -16,15 +17,15 @@ const inspectorBridge = require("./inspector_bridge");
 // On iOS, the orientation events are fired when the DEVICE ROTATES, because the API is based on device sensors.
 // Hence, orientation change event is not fired when the app starts,
 // and the app's initial orientation is not known until the first rotation occurs - this
-// is why we need to use the Dimensions API and appOrientationInit to properly handle it on the frontend.
+// is why we need to use the WindowDimensionsManager and appOrientationInit to properly handle it on the frontend.
 // Additionally, when app does not support given orientation, the event still fires (new orientation is reported
 // even though the app remains in previous mode, only because the device was rotated). This is why, we need to
 // infer information about the app's orientation based on the device orientation and ASSUME THAT PORTRAIT-SECONDARY IS NOT SET.
 // We also assume that, if one of the landscape orientations is supported, the other one is supported as well.
 
 // For IOS the orientation event is fired after the DEVICE rotates, but before the APP actually rotates.
-// This means, we are experiencing a lag between current orientation and information from Dimensions API,
-// which is why additional listener is added to the Dimensions API to amend the effect.
+// This means, we are experiencing a lag between current orientation and information from WindowDimensionsManager,
+// which is why additional listener is added to the WindowDimensionsManager to amend the effect.
 
 /**
  * Mapping from namedOrientationDidChangeEvent names to DeviceRotation names or "Landscape" specific case
@@ -94,9 +95,9 @@ const getMappedOrientation = (orientation, isLandscape) => {
 // send message to the extension with the information whether the app is in landscape mode or not.
 // This is used to infer the initial orientation of the app, due to IOS limitations.
 const initializeOrientationAndSendInitMessage = () => {
-  const { width: screenWidth, height: screenHeight } = Dimensions.get("screen");
+  const { width: screenWidth, height: screenHeight } =
+    WindowDimensionsManager.getScreenDimensionsCompat();
   const isLandscape = screenWidth > screenHeight;
-
   // infer currentOrientation based on the screen dimensions
   // android still fires the namedOrientationDidChangeEvent on app load,
   // but for safety still set it here first
@@ -108,10 +109,11 @@ const initializeOrientationAndSendInitMessage = () => {
 };
 
 const updateOrientationAndSendMessage = (orientation) => {
-  const { width: screenWidth, height: screenHeight } = Dimensions.get("screen");
-
+  const { width: screenWidth, height: screenHeight } =
+    WindowDimensionsManager.getScreenDimensionsCompat();
   const isLandscape = screenWidth > screenHeight;
   const mappedOrientation = getMappedOrientation(orientation, isLandscape);
+
   if (currentAppOrientation !== mappedOrientation) {
     currentAppOrientation = mappedOrientation;
     inspectorBridge.sendMessage({
@@ -137,30 +139,31 @@ export function setup() {
 
   // Suppress warnings about UIManager not implementing proper methods by overwriting console.warn temporarily.
   // This is needed, because UIManager.addListener and UIManager.removeListeners methods
-  // are undefined. When the same trick is applied to those methods (overwriting and assigning the original 
+  // are undefined. When the same trick is applied to those methods (overwriting and assigning the original
   // methods later), we begin to get Render and Console errors in LogBox after the assignment:
   // "_this$_nativeModule2.removeListeners is not a function (it is undefined)"
   const originalConsoleWarn = console.warn;
   console.warn = () => {};
 
-  const orientationEventSubscription = new NativeEventEmitter(UIManager).addListener(
+  const orientationEventSubscription = new NativeEventEmitter(NativeUIManager).addListener(
     "namedOrientationDidChange",
     handleOrientationChange
   );
 
   // Dimension change lags behind Orientation change in the IOS case, so we add a second listener to amend the effect.
   // Explained in the context above.
-  const dimensionEventSubscription = Dimensions.addEventListener("change", handleDimensionsChange);
+  const dimensionsChangeSubscription = WindowDimensionsManager.addListener(handleDimensionsChange);
 
   // Restore the original console.warn function
-  console.warn = originalConsoleWarn; 
+  console.warn = originalConsoleWarn;
 
   return function cleanup() {
     if (orientationEventSubscription) {
       orientationEventSubscription.remove();
     }
-    if (dimensionEventSubscription) {
-      dimensionEventSubscription.remove();
+    // Remove layout change listener using subscription
+    if (dimensionsChangeSubscription) {
+      dimensionsChangeSubscription.remove();
     }
   };
 }

--- a/packages/vscode-extension/lib/window_layout_manager.js
+++ b/packages/vscode-extension/lib/window_layout_manager.js
@@ -1,0 +1,98 @@
+const { Dimensions, Platform } = require("react-native");
+
+// This manager exists solely due to the fact that Dimensions API is bugged on iPads since
+// around 2020 and has yet to be fixed. See link below:
+// https://github.com/facebook/react-native/issues/29290
+// In order to provide a reliable way to get window dimensions across the lib,
+// we use the onLayout event of the main view wrapper to determine dimension changes
+// and synchronize them across the lib components, as well as getting proper window dimensions.
+
+// The manager also provides a compatibility getScreenDimensionsCompat() method, which
+// on ipads returns the same dimensions as getWindowDimensions() to avoid affecting the
+// already-working part of the codebase that uses Dimensions.get("screen") when called on
+// devices other than ipads.
+
+/**
+ * WindowDimensionsManager - Simplified dimensions change event manager
+ * Provides means to get proper window dimensions across the lib, due to the fact
+ * that Dimensions API is bugged and not reliable on iPads. Instead, the manager
+ * uses the onLayout event of the main view wrapper to determine dimension changes
+ * and synchronize them across the lib components.
+ */
+class WindowDimensionsManager {
+  constructor() {
+    this.dimensionsListeners = [];
+    // Initialize with current window dimensions - before first dimension change
+    // Dimensions.get() seems to return the proper dimensions of the window
+    const { width, height } = Dimensions.get("window");
+    this.currentWindowDimensions = { width, height };
+  }
+
+  /**
+   * Emit dimenions change event with {width, height} of the window
+   * @param {Object} dimensionEventProps - {width, height} of the window
+   */
+  emitDimensionsChange(dimensionEventProps) {
+    this.currentWindowDimensions = dimensionEventProps;
+
+    // Notify all listeners
+    this.dimensionsListeners.forEach((callback) => {
+      try {
+        callback(dimensionEventProps);
+      } catch (error) {
+        console.error("Error in dimension change listener:", error);
+      }
+    });
+  }
+
+  /**
+   * Get the current window dimensions
+   * @returns {Object} Current window dimensions
+   */
+  getWindowDimensions() {
+    return this.currentWindowDimensions;
+  }
+
+  /**
+   * Get the current screen dimensions if available
+   * On iPads, the function works exactly as getWindowDimensions(),
+   * due to the fact that Dimensions.get("screen") is bugged on iPads.
+   * @returns {Object} Current screen dimensions (window dimensions on iPads)
+   */
+  getScreenDimensionsCompat() {
+    if (Platform.isPad) {
+      return this.getWindowDimensions();
+    }
+    const { width, height } = Dimensions.get("screen");
+    return { width, height };
+  }
+
+  /**
+   * Add listener for dimensions changes - returns a subscription object with remove() method
+   * @param {Function} callback - Callback function to handle dimensions change events
+   * @returns {Object} Subscription object with remove() method
+   */
+  addListener(callback) {
+    this.dimensionsListeners.push(callback);
+
+    return {
+      remove: () => {
+        this.dimensionsListeners = this.dimensionsListeners.filter(
+          (listener) => listener !== callback
+        );
+      },
+    };
+  }
+
+  /**
+   * Remove all listeners
+   */
+  removeAllListeners() {
+    this.dimensionsListeners = [];
+  }
+}
+
+// Singleton instance of WindowDimensionsManager used across lib
+const windowDimensionsManager = new WindowDimensionsManager();
+
+module.exports = windowDimensionsManager;


### PR DESCRIPTION
### Description

This PR introduces `WindowDimensionsManager` in the lib directory and replaces `Dimensions.get("screen")` calls in lib with `WindowDimensionsManager.getScreenDimensionsCompat()` to account for Element Inspector and Render-Overlay compatibility with (to be added) **iPad devices**, where Dimensions API is bugged since 2020.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **run different kind of apps (reactNative, expo-go, etc.) to test whether inspector and render-overlay functionality remains consistent with previous implementation**

### How Has This Change Been Documented:

Not applicable.


