### PR TITLE
Use new badge indicator instead of counter for logs button

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -72,25 +72,14 @@
   background-color: var(--swm-button-secondary-hover);
 }
 
-.icon-button-counter {
-  border: 0px solid transparent;
+.icon-button-new-badge {
   border-radius: 4px;
   color: var(--swm-button-counter);
-  background-color: var(--swm-button-counter-background);
-  border: 1px solid var(--swm-button-counter-border);
-  padding: 2px 4px;
-  font-size: 10px;
+  background-color: var(--vscode-activityBarBadge-background);
+  border: 1px solid var(--vscode-contrastBorder);
+  width: 8px;
+  height: 8px;
   position: absolute;
-  top: 20%;
-  left: 20px;
-  opacity: 0;
-  transform: translateY(-50%);
-  transition:
-    left 200ms ease-in-out,
-    opacity 200ms ease-in-out;
-}
-
-.icon-button-counter.visible {
-  top: 20%;
-  opacity: 1;
+  top: 10%;
+  right: 10%;
 }

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -73,13 +73,14 @@
 }
 
 .icon-button-new-badge {
-  border-radius: 4px;
   color: var(--swm-button-counter);
   background-color: var(--vscode-activityBarBadge-background);
   border: 1px solid var(--vscode-contrastBorder);
-  width: 8px;
-  height: 8px;
+  border-radius: 50%;
+  width: 9px;
+  height: 9px;
   position: absolute;
   top: 10%;
   right: 10%;
+  box-sizing: border-box;
 }

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import classnames from "classnames";
 import "./IconButton.css";
 import Tooltip from "./Tooltip";

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
@@ -8,7 +8,7 @@ export interface IconButtonProps {
   children: React.ReactNode;
   disabled?: boolean;
   disableTooltip?: boolean;
-  counter?: number;
+  showNewBadge?: boolean;
   active?: boolean;
   type?: "primary" | "secondary";
   side?: "left" | "right" | "center";
@@ -23,7 +23,7 @@ export interface IconButtonProps {
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
   const {
-    counter,
+    showNewBadge,
     children,
     onClick,
     tooltip,
@@ -35,15 +35,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
     className = "",
     ...rest
   } = props;
-  const [displayCounter, setDisplayCounter] = useState(counter);
 
-  useEffect(() => {
-    if (counter !== 0) {
-      setDisplayCounter(counter);
-    }
-  }, [counter]);
-
-  const showCounter = Boolean(counter);
   const button = (
     <button
       onClick={onClick}
@@ -61,11 +53,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
       {...rest}
       ref={ref}>
       {children}
-      {counter !== null && (
-        <span className={classnames("icon-button-counter", showCounter && "visible")}>
-          {displayCounter}
-        </span>
-      )}
+      {showNewBadge && <span className="icon-button-new-badge" />}
     </button>
   );
 

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -315,7 +315,7 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            counter={logCounter}
+            showNewBadge={logCounter > 0}
             onClick={() => project.focusDebugConsole()}
             tooltip={{
               label: "Open logs panel",


### PR DESCRIPTION
This PR replaces the log counter taht we show over the logs button with a small round "new content badge"

There are two main reasons we want to get rid of the counter:
1) it is never accurate as people may also read the logs by just opening the console and we never know about that
2) when the numbers are big, they obstruct other buttons on the tool bar. We could just use a "9+" text but then it still may not be accurate as people may have viewed some of the logs already.

Light theme:
<img width="233" height="139" alt="image" src="https://github.com/user-attachments/assets/e0c7c83e-e357-404f-8f7e-47c5ddf3f0e0" />

Dark theme:
<img width="296" height="148" alt="image" src="https://github.com/user-attachments/assets/a87c9ce3-d34c-486f-b31c-650c2efb368e" />

Dark high contrast:
<img width="294" height="160" alt="image" src="https://github.com/user-attachments/assets/f896c36d-5705-404d-811d-b4ae5fb0b04d" />

Light high contrast:
<img width="322" height="155" alt="image" src="https://github.com/user-attachments/assets/4bdbe0d7-dc55-4bd7-b39c-2b272b14b0ea" />


### How Has This Been Tested: 
1. Run the extension, generate some logs and test on different themes
2. Click the button to see the indicator gone

