### PR TITLE
fix: bundle load failing due to agent initalising late

### DIFF
--- a/packages/vscode-extension/lib/inspector_bridge.js
+++ b/packages/vscode-extension/lib/inspector_bridge.js
@@ -1,7 +1,8 @@
-const agent = globalThis.__radon_agent;
+let agent = globalThis.__radon_agent;
 
 if (!agent) {
-  throw new Error("Radon inspector bridge agent is not installed");
+  // if the agent was not loaded yet, we do it here -- hopefully connect had the time to register its bridge already
+  agent = require("./react_devtools_agent");
 }
 
 const messageListeners = [];

--- a/packages/vscode-extension/lib/react_devtools_agent.js
+++ b/packages/vscode-extension/lib/react_devtools_agent.js
@@ -37,3 +37,5 @@ if (hook.reactDevtoolsAgent) {
 }
 
 globalThis.__radon_agent = agent;
+
+module.exports = agent;


### PR DESCRIPTION
Fixes runtime errors during JS bundle loading when the `inspectorBridge` is accessed before the DevTools Radon Agent is set up.

Currently, we load the Devtools Radon Agent in `wrapper.js`, which is only loaded when the application first starts and React Native loads the component registered through `AppRegistry.setWrapperComponentProvider`.
However, some of our plugins import `inspectorBridge` directly, but can be loaded before the application runs, during the initial bundle evaluation:
- `react-query-devtools.js` is loaded whenever the `react-query` module is evaluated.
- `expo_dev_plugins.js` is loaded whenever the `redux-devtools-expo-dev-plugin` module is evaluated.
Which causes the `inspectorBridge` to throw an error when checking if the `agent` is already set up, causing the whole bundle execution to fail.

This PR fixes that by assuming that, when the `inspectorBridge` loads and no `agent` is already registered, we're not in Connect mode and we can simply import the Devtools implementation (this should not break anything since, if we hit that branch in connect mode before connect sets up the CDP agent implementation, we'd throw an error and break something anyway).

Related #1280

### How Has This Been Tested: 
- setup an app which loads `react-query` before `react-native`
- check if the app gets stuck on "Waiting for app to load..."

