### PR TITLE
feat: add ping animation to a log indicator

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/IconButton.css
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.css
@@ -112,3 +112,13 @@
 .icon-button-indicator.visible {
   transform: scale(1);
 }
+
+.icon-button-indicator.ping {
+  animation: ping 300ms cubic-bezier(0, 0, 0.2, 1);
+}
+
+@keyframes ping {
+  50% {
+    transform: scale(1.2);
+  }
+}

--- a/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
@@ -3,6 +3,8 @@ import classnames from "classnames";
 import "./IconButton.css";
 import Tooltip from "./Tooltip";
 
+const PING_DURATION = 300; // ms
+
 export interface IconButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
@@ -38,12 +40,20 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
     ...rest
   } = props;
   const [displayCounter, setDisplayCounter] = useState(counter);
+  const [shouldPing, setShouldPing] = useState(false);
 
   useEffect(() => {
     if (counter !== 0) {
       setDisplayCounter(counter);
     }
-  }, [counter]);
+    if (counterMode === "compact" && counter !== 0) {
+      setShouldPing(true);
+      const timer = setTimeout(() => {
+        setShouldPing(false);
+      }, PING_DURATION);
+      return () => clearTimeout(timer);
+    }
+  }, [counter, counterMode]);
 
   const showCounter = Boolean(counter);
   const button = (
@@ -69,7 +79,13 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, 
         </span>
       )}
       {counterMode === "compact" && counter !== null && (
-        <span className={classnames("icon-button-indicator", showCounter && "visible")} />
+        <span
+          className={classnames(
+            "icon-button-indicator",
+            showCounter && "visible",
+            shouldPing && "ping"
+          )}
+        />
       )}
     </button>
   );


### PR DESCRIPTION
This PR makes the log indicator indicate whenever there's a new log with a delicate ping animation. Related to https://github.com/software-mansion/radon-ide/pull/1406 

light theme

https://github.com/user-attachments/assets/1085ed95-21bb-43d7-a657-482dd601f835


dark theme


https://github.com/user-attachments/assets/8ae618ab-0233-4282-9f6d-ae1d01e50fdf


high-contrast

https://github.com/user-attachments/assets/49c0eac6-43f7-4abf-8b65-a33e5ab6827c