### PR TITLE
fix: node version check

### DIFF
--- a/packages/vscode-extension/src/utilities/getMinimumSupportedNodeVersion.ts
+++ b/packages/vscode-extension/src/utilities/getMinimumSupportedNodeVersion.ts
@@ -1,5 +1,8 @@
 import fs from "fs";
 import { Logger } from "../Logger";
+import semver from "semver";
+
+const DEFAULT_MINIMUM_NODE_VERSION = ">=18";
 
 /* 
 This function return a minimum supported node version for given appRoot assuming node_modules are installed,
@@ -8,8 +11,10 @@ of react native, so it should be always used after node_modules installation.
 */
 export function getMinimumSupportedNodeVersion(appRoot: string): string {
   const appPackageJson = require(`${appRoot}/package.json`);
+  let applicationMinimumNodeVersion;
+  let reactNativeMinimumNodeVersion;
   if (appPackageJson.engines && appPackageJson.engines.node) {
-    return appPackageJson.engines.node;
+    applicationMinimumNodeVersion = appPackageJson.engines.node;
   }
 
   if (
@@ -18,15 +23,33 @@ export function getMinimumSupportedNodeVersion(appRoot: string): string {
   ) {
     const reactNativePackageJson = require(`${appRoot}/node_modules/react-native/package.json`);
     if (reactNativePackageJson.engines && reactNativePackageJson.engines.node) {
-      return reactNativePackageJson.engines.node;
+      reactNativeMinimumNodeVersion = reactNativePackageJson.engines.node;
     }
   }
 
-  // this is minimum supported version at the time this code was written, and therefore a default for this function,
-  // but this code should never be reached as react-native contains this information in its package json and reaching,
-  // this code suggests that the function was incorrectly called before installing node_modules.
-  Logger.warn(
-    "[Minimum Supported node version] Utility function called before node modules were installed, the returned value might, be deprecated."
-  );
-  return ">=18";
+  const ranges = [
+    applicationMinimumNodeVersion,
+    reactNativeMinimumNodeVersion,
+    DEFAULT_MINIMUM_NODE_VERSION,
+  ].filter(Boolean);
+
+  if (ranges.length === 1) {
+    // this is minimum supported version at the time this code was written, and therefore a default for this function,
+    // but this code should never be reached as react-native contains this information in its package json and reaching,
+    // this code suggests that the function was incorrectly called before installing node_modules.
+    Logger.warn(
+      "[Minimum Supported node version] Utility function called before node modules were installed, the returned value might, be deprecated."
+    );
+    return DEFAULT_MINIMUM_NODE_VERSION;
+  }
+
+  return ranges.reduce((mostRestrictive, current) => {
+    const currentMinVersion = semver.minVersion(current);
+    const restrictiveMinVersion = semver.minVersion(mostRestrictive);
+
+    if (currentMinVersion && restrictiveMinVersion) {
+      return semver.gt(currentMinVersion, restrictiveMinVersion) ? current : mostRestrictive;
+    }
+    return current || mostRestrictive;
+  });
 }

--- a/packages/vscode-extension/src/utilities/getMinimumSupportedNodeVersion.ts
+++ b/packages/vscode-extension/src/utilities/getMinimumSupportedNodeVersion.ts
@@ -1,8 +1,35 @@
 import fs from "fs";
-import { Logger } from "../Logger";
 import semver from "semver";
+import { Logger } from "../Logger";
+import { requireNoCache } from "./requireNoCache";
 
+// this is minimum supported version at the time this code was written, and therefore a default for this function,
+// but this code should never be reached as react-native contains this information in its package json and reaching,
+// this code suggests that the function was incorrectly called before installing node_modules.
 const DEFAULT_MINIMUM_NODE_VERSION = ">=18";
+
+function getReactNativeMinimumNodeVersion(appRoot: string): string | undefined {
+  if (
+    fs.existsSync(`${appRoot}/node_modules`) &&
+    fs.existsSync(`${appRoot}/node_modules/react-native`)
+  ) {
+    const reactNativePackageJson = requireNoCache(
+      `${appRoot}/node_modules/react-native/package.json`
+    );
+    if (reactNativePackageJson.engines && reactNativePackageJson.engines.node) {
+      return reactNativePackageJson.engines.node;
+    }
+    return undefined;
+  }
+}
+
+function getApplicationMinimumNodeVersion(appRoot: string): string | undefined {
+  const appPackageJson = requireNoCache(`${appRoot}/package.json`);
+  if (appPackageJson.engines && appPackageJson.engines.node) {
+    return appPackageJson.engines.node;
+  }
+  return undefined;
+}
 
 /* 
 This function return a minimum supported node version for given appRoot assuming node_modules are installed,
@@ -10,38 +37,18 @@ if node modules are not installed the function will return a default value, but 
 of react native, so it should be always used after node_modules installation.
 */
 export function getMinimumSupportedNodeVersion(appRoot: string): string {
-  const appPackageJson = require(`${appRoot}/package.json`);
-  let applicationMinimumNodeVersion;
-  let reactNativeMinimumNodeVersion;
-  if (appPackageJson.engines && appPackageJson.engines.node) {
-    applicationMinimumNodeVersion = appPackageJson.engines.node;
-  }
+  const applicationMinimumNodeVersion = getApplicationMinimumNodeVersion(appRoot);
+  const reactNativeMinimumNodeVersion = getReactNativeMinimumNodeVersion(appRoot);
 
-  if (
-    fs.existsSync(`${appRoot}/node_modules`) &&
-    fs.existsSync(`${appRoot}/node_modules/react-native`)
-  ) {
-    const reactNativePackageJson = require(`${appRoot}/node_modules/react-native/package.json`);
-    if (reactNativePackageJson.engines && reactNativePackageJson.engines.node) {
-      reactNativeMinimumNodeVersion = reactNativePackageJson.engines.node;
-    }
-  }
-
-  const ranges = [
-    applicationMinimumNodeVersion,
-    reactNativeMinimumNodeVersion,
-    DEFAULT_MINIMUM_NODE_VERSION,
-  ].filter(Boolean);
-
-  if (ranges.length === 1) {
-    // this is minimum supported version at the time this code was written, and therefore a default for this function,
-    // but this code should never be reached as react-native contains this information in its package json and reaching,
-    // this code suggests that the function was incorrectly called before installing node_modules.
+  if (reactNativeMinimumNodeVersion === undefined) {
     Logger.warn(
       "[Minimum Supported node version] Utility function called before node modules were installed, the returned value might, be deprecated."
     );
-    return DEFAULT_MINIMUM_NODE_VERSION;
   }
+
+  const ranges = [applicationMinimumNodeVersion, reactNativeMinimumNodeVersion].filter(
+    (e) => e !== undefined
+  );
 
   return ranges.reduce((mostRestrictive, current) => {
     const currentMinVersion = semver.minVersion(current);
@@ -51,5 +58,5 @@ export function getMinimumSupportedNodeVersion(appRoot: string): string {
       return semver.gt(currentMinVersion, restrictiveMinVersion) ? current : mostRestrictive;
     }
     return current || mostRestrictive;
-  });
+  }, DEFAULT_MINIMUM_NODE_VERSION);
 }


### PR DESCRIPTION
This PR changes `getMinimumSupportedNodeVersion` logic to return the most restrictive version instead of the first found one. This Solves an issue with projects that have updated rn version but not the engine requirements in their package.json. 

### How Has This Been Tested: 

add a brak point to the `getMinimumSupportedNodeVersion` method run in tin the `react-native-81` test app and check if the return value is 22.14 instead of 18

### How Has This Change Been Documented:

internal change



