### PR TITLE
fix: state updates lost when frequently updated

### DIFF
--- a/packages/vscode-extension/src/project/StateManager.ts
+++ b/packages/vscode-extension/src/project/StateManager.ts
@@ -62,8 +62,10 @@ class RootStateManager<T extends object> extends StateManager<T> {
 
   setState(partialState: RecursivePartial<T>): void {
     const [newState, changes] = mergeAndCalculateChanges(this.state, partialState);
-    this.state = newState;
-    this.onSetStateEmitter.fire(changes);
+    if (this.state !== newState) {
+      this.state = newState;
+      this.onSetStateEmitter.fire(changes);
+    }
   }
 
   getState(): T {

--- a/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/AppRootSelect.tsx
@@ -2,7 +2,7 @@ import * as Select from "@radix-ui/react-select";
 import "./AppRootSelect.css";
 import "./shared/Dropdown.css";
 import _ from "lodash";
-import React, { PropsWithChildren, useEffect } from "react";
+import React, { PropsWithChildren, useEffect, useMemo } from "react";
 import { use$ } from "@legendapp/state/react";
 import { useProject } from "../providers/ProjectProvider";
 import { LaunchConfiguration, LaunchConfigurationKind } from "../../common/LaunchConfig";
@@ -159,14 +159,18 @@ function AppRootSelect() {
     );
   }
 
-  const detectedConfigurations = applicationRoots.map(({ path, displayName, name }) => {
-    return {
-      appRoot: path,
-      name: displayName || name,
-      kind: LaunchConfigurationKind.Detected,
-      env: {},
-    };
-  });
+  const detectedConfigurations = useMemo(
+    () =>
+      applicationRoots.map(({ path, displayName, name }) => {
+        return {
+          appRoot: path,
+          name: displayName || name,
+          kind: LaunchConfigurationKind.Detected,
+          env: {},
+        };
+      }),
+    [applicationRoots]
+  );
 
   const handleAppRootChange = async (value: string) => {
     if (value === "manage") {

--- a/packages/vscode-extension/src/webview/providers/storeProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/storeProvider.tsx
@@ -2,7 +2,7 @@ import { Change, Observable, observable } from "@legendapp/state";
 import { synced, SyncedSetParams, SyncedSubscribeParams } from "@legendapp/state/sync";
 import { vscode } from "../utilities/vscode";
 import { createContext, PropsWithChildren, useContext } from "react";
-import { initialState, State } from "../../common/State";
+import { initialState, RecursivePartial, State } from "../../common/State";
 import { merge } from "../../common/Merge";
 
 let instanceToken = Math.floor(Math.random() * 1000000);
@@ -70,11 +70,17 @@ const setState = async (params: SyncedSetParams<State>) => {
 };
 
 const subscribeToState = (params: SyncedSubscribeParams<State>) => {
-  const { update, value$ } = params;
+  const { update } = params;
   const listener = (event: any) => {
     if (event.data.command === "RNIDE_state_updated") {
-      const newState = merge(value$.get(), event.data.state);
-      update({ value: newState, mode: "set" });
+      const changes = event.data.state as RecursivePartial<State>;
+      update({
+        //@ts-ignore Legend State is mistyping the param, but it works. _Trust me_.
+        value: (prev) => {
+          return merge(prev, changes);
+        },
+        mode: "set",
+      });
     }
   };
 


### PR DESCRIPTION
- Fixes a bug introduced in #1404 which caused some updates to be lost when the extension sent frequent updates to the webview[^1].
- Skips calling `onSetState` when nothing changed in `StateManager`.
- Adds a random `useMemo` in `AppRootSelect` because why not.

[^1]: The bug was caused by changing the legend-state update mode to `"set"` and setting a merge of the current state in the store with the updates received in the listener which synchronizes state changes in the Extension with the Webview's state.
Because the `update` function is called asynchronously, if the listener is called multiple times before the update can be applied, we merge the changes with the stale state stored in the Legend State observable and set that, losing the intermediate updates.
The fix passes a callback to the `update` function which receives the value set at the time the assignment happens, not at the time the changes were received.
The `update` function is typed to expect the actual values, but the implementation _does_ accept the callback and handles it correctly.

### How Has This Been Tested: 
- set a breakpoint in `ide.ts` on `this.stateManager.setState({ applicationRoots });`
- open a workspace in Radon
- after stopping at the breakpoint and waiting a while, resume the debugger
- the application roots should set up correctly

