### PR TITLE
fix: right click inspector in preview

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -101,10 +101,17 @@ function extractComponentStack(startNode, viewDataHierarchy) {
 
     // Optimization: we break after reaching fiber node corresponding to OffscreenComponent
     while (node && node.tag !== OffscreenComponentReactTag) {
-      const data = rendererConfig.getInspectorDataForInstance(node);
-      const item = data.hierarchy[data.hierarchy.length - 1];
-      stackItems.push(item);
-      node = node.return;
+      try {
+        const data = rendererConfig.getInspectorDataForInstance(node);
+        const item = data.hierarchy[data.hierarchy.length - 1];
+        stackItems.push(item);
+        node = node.return;
+      } catch (e) {
+        // In the preview mode getInspectorDataForInstance may throw an error 
+        // in the root node, because it is unmounted. We break the loop in this case,
+        // as there is no more information to extract.
+        break;
+      }
     }
   } else if (viewDataHierarchy && viewDataHierarchy.length > 0) {
     // fallback to using viewDataHierarchy


### PR DESCRIPTION
This PR fixes an issue with right click inspector throwing an error in preview mode, because the tested component was unmounted. Now we handle it instead of letting it propagate to the user.

### How Has This Been Tested: 

- run `expo-53` test app 
- open preview 
- right click on something that is part of the preview (not on the background) 

### How Has This Change Been Documented:

internal change


