### PR TITLE
fix: android dimensions difference bug, InspectorUnavailableBox fadeout bug

### DIFF
--- a/packages/vscode-extension/lib/inspector_availability.js
+++ b/packages/vscode-extension/lib/inspector_availability.js
@@ -7,6 +7,12 @@ const DimensionsObserver = require("./dimensions_observer");
 // unexpected behavior when the app is not edge-to-edge, because
 // of margins, which are unavailable to fetch using react-native API.
 
+// epsilon for dimensions comparison, needed for some cases of Android devices
+// where the screen (Dimensions API) and window (ifnotmation from main View layout)
+// dimensions are differ on the 5th decimal place (for unknown reason)
+// This value is chosen empirically until information about this behavior is found
+const eps = 1;
+
 const INSPECTOR_AVAILABLE_STATUS = "available";
 const INSPECTOR_UNAVAILABLE_EDGE_TO_EDGE_STATUS = "unavailableEdgeToEdge";
 const INSPECTOR_UNAVAILABLE_INACTIVE_STATUS = "unavailableInactive";
@@ -34,7 +40,7 @@ const determineIfEdgeToEdge = () => {
   // This way of determining the edge-to-edge availability does not work on iPads when
   // Stage Manager is used for React Native before version 77 - windowWidth and windowHeight
   // will always be equal to the screenWidth and screenHeight, the onLayout event does not
-  // register the layout change properly. 
+  // register the layout change properly.
   const { width: screenWidth, height: screenHeight } = Dimensions.get("screen");
   const { width: windowWidth, height: windowHeight } = DimensionsObserver.getWindowDimensions();
 
@@ -47,7 +53,9 @@ const determineIfEdgeToEdge = () => {
       ? { windowGreater: windowWidth, windowLesser: windowHeight }
       : { windowGreater: windowHeight, windowLesser: windowWidth };
 
-  return screenGreater === windowGreater && screenLesser === windowLesser;
+  return (
+    Math.abs(screenGreater - windowGreater) <= eps && Math.abs(screenLesser - windowLesser) <= eps
+  );
 };
 
 const updateAvailabilityAndSendMessage = () => {

--- a/packages/vscode-extension/src/webview/components/InspectorUnavailableBox.css
+++ b/packages/vscode-extension/src/webview/components/InspectorUnavailableBox.css
@@ -2,6 +2,7 @@
   --box-transform: translate(-50%, -125%);
   background-color: var(--dimensions-box-background);
   color: var(--swm-tooltip-primary);
+  opacity: 1;
 
   /* Transition duration dependent on the code in InspectorUnavailableTooltip.tsx */
   transition: opacity 0.3s ease-out;

--- a/packages/vscode-extension/src/webview/components/InspectorUnavailableBox.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectorUnavailableBox.tsx
@@ -16,16 +16,16 @@ function InspectorUnavailableBox({ clickPosition, onClose }: InspectorUnavailabl
     }, 500);
 
     // Call onClose after fade animation completes (additional 0.3s)
-    // as in InspectorUnavailableBox.css transition
+    // as in InspectorUnavailableBox.css transition (0.3s duration)
     const closeTimer = setTimeout(() => {
       onClose();
-    }, 800);
+    }, 500 + 300); // 500ms delay + 300ms transition duration
 
     return () => {
       clearTimeout(fadeTimer);
       clearTimeout(closeTimer);
     };
-  }, []);
+  }, [onClose]);
 
   const cssPropertiesForTooltip = {
     "--top": `${clickPosition.y * 100}%`,


### PR DESCRIPTION
### Description

This PR fixes two issues found on main branch:
- Bug considering the apps Window and Screen dimensions being different on 5th decimal place in some projects (expo-53, ReactNative81) on Android devices, which caused them to not be considered Edge-to-Edge in `inspector-availability.sj`. There is now an `epsilon`(empirically set to equal 1) which allows the dimensions to differ by 1 pixel at most to be considered equal. 
> Note: The handling of screen dimensions handling could possibly improved by taking into account difference between Screen and Window dimensions and including the information about the app orientation on android based on this note:
https://stackoverflow.com/a/60561393


- Bug considering the InspectorUnavailableBox (showing up when the user uses right click when inspector is turned of) not fading out properly and abruptly dissapearing, especially when the user spammed right-click. The fix mainly update the dependency array and set initial opacity to 1, which should fix the issue

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **test whether the element inspector in apps like RN81, Expo-53 on Android devices work correctly**
- **test whether spamming right click when the element inspector is turned off results in proper InspectorUnavailableBox rendering**

### How Has This Change Been Documented:

Not applicable.


