### PR TITLE
feat: warn user if the runtime does not support selected device

### DIFF
--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -79,7 +79,9 @@ function CreateDeviceView({ onCreate, onCancel }: CreateDeviceViewProps) {
           value: runtime.identifier,
           label: runtime.name,
           disabled: !runtime.available,
-          marked: false,
+          marked: runtime.supportedDeviceTypes.every((device) => {
+            return deviceProperties.modelName !== device.name;
+          }),
         }))
       : androidImages.map((systemImage) => ({
           value: systemImage.location,


### PR DESCRIPTION
This PR adds a warning if the user tires to select a runtime that does not support the selected device. I the device manager modal. This will have the follow up to remove devices that are not supported by any runtime from the 
devices list. 


