### PR TITLE
feat: hide not supported devices

### DIFF
--- a/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
+++ b/packages/vscode-extension/src/webview/views/CreateDeviceView.tsx
@@ -21,6 +21,8 @@ interface CreateDeviceViewProps {
 }
 
 function useSupportedDevices() {
+  const store$ = useStore();
+  const iOSRuntimes = use$(store$.devicesState.iOSRuntimes) ?? [];
   const errors = useDependencyErrors();
 
   return [
@@ -29,10 +31,16 @@ function useSupportedDevices() {
         ? { label: "iOS – error, check diagnostics", items: [] }
         : {
             label: "iOS",
-            items: iOSSupportedDevices.map((device) => ({
-              value: device.modelId,
-              label: device.modelName,
-            })),
+            items: iOSSupportedDevices
+              .filter((device) => {
+                return iOSRuntimes.some((runtime) =>
+                  runtime.supportedDeviceTypes.some((type) => type.identifier === device.modelId)
+                );
+              })
+              .map((device) => ({
+                value: device.modelId,
+                label: device.modelName,
+              })),
           },
       windows: { label: "", items: [] },
       linux: { label: "", items: [] },


### PR DESCRIPTION
This PR hides iOS devices that are not supported by any available runtime. 

### How Has This Been Tested: 

add fake iso device to `deviceConstants.ts`: 

```js
  {
    modelName: "iPhone 16 Pro",
    modelId: "com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro",
    platform: DevicePlatform.IOS,
    screenWidth: 1178,
    screenHeight: 2556,
    screenMaskImage: iphone16proscreen,
    landscapeScreenMaskImage: iphone16proLandscapeScreen,
    bezel: {
      type: "mask" as const,
      width: 1186,
      height: 2564,
      offsetX: 4,
      offsetY: 4,
      image: iphone16probezel,
      imageLandscape: iphone16proLandscapeBezel,
    },
    skin: {
      type: "skin" as const,
      width: 1285,
      height: 2663,
      offsetX: 55,
      offsetY: 55,
      image: iphone16pro,
      imageLandscape: iphone16proLandscape,
    },
  },
```

It should not be visible in create new device modal.




