### PR TITLE
fix: orientation and availability handlers cleanup

### DIFF
--- a/packages/vscode-extension/lib/inspector_availability.js
+++ b/packages/vscode-extension/lib/inspector_availability.js
@@ -76,26 +76,6 @@ const updateAvailabilityAndSendMessage = () => {
   }
 };
 
-const handleDimensionsChange = () => {
-  isEdgeToEdge = determineIfEdgeToEdge();
-  updateAvailabilityAndSendMessage();
-};
-
-const handleAppStateChange = (appState) => {
-  isAppStateActive = appState === "active";
-  updateAvailabilityAndSendMessage();
-};
-
-const handleBlurChange = () => {
-  isFocused = false;
-  updateAvailabilityAndSendMessage();
-};
-
-const handleFocusChange = () => {
-  isFocused = true;
-  updateAvailabilityAndSendMessage();
-};
-
 const initializeInspectorAvailability = () => {
   isEdgeToEdge = determineIfEdgeToEdge();
   isAppStateActive = AppState.currentState === "active";
@@ -104,6 +84,28 @@ const initializeInspectorAvailability = () => {
 
 export function setup() {
   initializeInspectorAvailability();
+
+  // Define callbacks inside the setup, in order for dimensionsObserver to be able
+  // to properly differentiate between created functions
+  const handleDimensionsChange = () => {
+    isEdgeToEdge = determineIfEdgeToEdge();
+    updateAvailabilityAndSendMessage();
+  };
+
+  const handleAppStateChange = (appState) => {
+    isAppStateActive = appState === "active";
+    updateAvailabilityAndSendMessage();
+  };
+
+  const handleBlurChange = () => {
+    isFocused = false;
+    updateAvailabilityAndSendMessage();
+  };
+
+  const handleFocusChange = () => {
+    isFocused = true;
+    updateAvailabilityAndSendMessage();
+  };
 
   let appBlurSubscription = null;
   let appFocusSubscription = null;

--- a/packages/vscode-extension/lib/orientation.js
+++ b/packages/vscode-extension/lib/orientation.js
@@ -95,8 +95,7 @@ const getMappedOrientation = (orientation, isLandscape) => {
 // send message to the extension with the information whether the app is in landscape mode or not.
 // This is used to infer the initial orientation of the app, due to IOS limitations.
 const initializeOrientationAndSendInitMessage = () => {
-  const { width: screenWidth, height: screenHeight } =
-    DimensionsObserver.getScreenDimensions();
+  const { width: screenWidth, height: screenHeight } = DimensionsObserver.getScreenDimensions();
   const isLandscape = screenWidth > screenHeight;
   // infer currentOrientation based on the screen dimensions
   // android still fires the namedOrientationDidChangeEvent on app load,
@@ -109,8 +108,7 @@ const initializeOrientationAndSendInitMessage = () => {
 };
 
 const updateOrientationAndSendMessage = (orientation) => {
-  const { width: screenWidth, height: screenHeight } =
-    DimensionsObserver.getScreenDimensions();
+  const { width: screenWidth, height: screenHeight } = DimensionsObserver.getScreenDimensions();
   const isLandscape = screenWidth > screenHeight;
   const mappedOrientation = getMappedOrientation(orientation, isLandscape);
 
@@ -123,19 +121,21 @@ const updateOrientationAndSendMessage = (orientation) => {
   }
 };
 
-const handleOrientationChange = ({ name: orientation }) => {
-  lastRegisteredOrientation = orientation;
-  updateOrientationAndSendMessage(orientation);
-};
-
-// Fire additionally on Dimensions change because of iOS "lag" issue described
-// in the above context.
-const handleDimensionsChange = () => {
-  updateOrientationAndSendMessage(lastRegisteredOrientation);
-};
-
 export function setup() {
   initializeOrientationAndSendInitMessage();
+
+  // Define callbacks inside the setup, in order for dimensionsObserver to be able
+  // to properly differentiate between created functions
+  const handleOrientationChange = ({ name: orientation }) => {
+    lastRegisteredOrientation = orientation;
+    updateOrientationAndSendMessage(orientation);
+  };
+
+  // Fire additionally on Dimensions change because of iOS "lag" issue described
+  // in the above context.
+  const handleDimensionsChange = () => {
+    updateOrientationAndSendMessage(lastRegisteredOrientation);
+  };
 
   // Suppress warnings about UIManager not implementing proper methods by overwriting console.warn temporarily.
   // This is needed, because UIManager.addListener and UIManager.removeListeners methods


### PR DESCRIPTION
### Description

This PR fixes an issue, where after some component, also wrapped by the AppWrapper (for example - LogBox) triggered the cleanup of the orientation.js or inspector_availability.js, DimensionsObserver would get rid of all listeners of the same type, because of they were considered equal. In short - inspector was buggy after LogBox was triggered and closed.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **test whether opening and closing LogBox causes issues with inspector or inspect availability**

### How Has This Change Been Documented:

Not applicable.


