### PR TITLE
fix: replay rotation and controls z-index

### DIFF
--- a/packages/vscode-extension/src/webview/Preview/MediaCanvas.tsx
+++ b/packages/vscode-extension/src/webview/Preview/MediaCanvas.tsx
@@ -88,7 +88,7 @@ const TRANSFORM_CONFIGS = {
   [DeviceRotation.LandscapeLeft]: {
     // Transformations based on current device rotation
     [DeviceRotation.Portrait]: {
-      angle: -Math.PI / 2, // Rotate 90° counter-clockwise
+      angle: Math.PI / 2, // Rotate 90° counter-clockwise
       dimensionsSwapped: true,
       shouldDrawWithoutTransform: false,
     },
@@ -103,7 +103,7 @@ const TRANSFORM_CONFIGS = {
       shouldDrawWithoutTransform: false,
     },
     [DeviceRotation.PortraitUpsideDown]: {
-      angle: Math.PI / 2, // Rotate 90° clockwise
+      angle: -Math.PI / 2, // Rotate 90° clockwise
       dimensionsSwapped: true,
       shouldDrawWithoutTransform: false,
     },
@@ -113,7 +113,7 @@ const TRANSFORM_CONFIGS = {
   [DeviceRotation.LandscapeRight]: {
     // Transformations based on current device rotation
     [DeviceRotation.Portrait]: {
-      angle: Math.PI / 2, // Rotate 90° clockwise
+      angle: -Math.PI / 2, // Rotate 90° clockwise
       dimensionsSwapped: true,
       shouldDrawWithoutTransform: false,
     },
@@ -128,7 +128,7 @@ const TRANSFORM_CONFIGS = {
       shouldDrawWithoutTransform: true, // Native orientation
     },
     [DeviceRotation.PortraitUpsideDown]: {
-      angle: -Math.PI / 2, // Rotate 90° counter-clockwise
+      angle: Math.PI / 2, // Rotate 90° counter-clockwise
       dimensionsSwapped: true,
       shouldDrawWithoutTransform: false,
     },

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.css
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.css
@@ -82,6 +82,7 @@
   flex-direction: row;
   gap: 5px;
   align-items: center;
+  z-index: var(--replay-controls-z-index); /* defined in ReplayUI.css */
 }
 
 .replay-controls-pad {
@@ -125,6 +126,7 @@
   background-color: var(--swm-replay-len-select-background);
   border-radius: 18px 18px 18px 18px;
   transform: translateY(4px);
+  z-index: 2; /* must equal --replay-controls-z-index, does not have access to variable because of portal */
 }
 
 .len-select-viewport {

--- a/packages/vscode-extension/src/webview/components/ReplayUI.css
+++ b/packages/vscode-extension/src/webview/components/ReplayUI.css
@@ -1,5 +1,6 @@
 .replay-ui-wrapper {
   --replay-z-index: 1;
+  --replay-controls-z-index: 2;
 }
 
 .replay-video,


### PR DESCRIPTION
### Description

This PR fixes:
-  issues with replay rotation, after the device has been rotated during the replay using shortcut
- issues with incorrect controls layout caused by z-index (the 5s/10s/30s/Full dropdown)

<img width="372" height="789" alt="Screenshot 2025-08-11 at 12 47 30" src="https://github.com/user-attachments/assets/9274d491-7a48-4311-b3be-ac2b98903463" />

### Fixes #(issue)

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **test whether the dropdown in orange circle is laying out correctly on top of the replay video**
- **check if rotating device during replay behaves as expected**

### How Has This Change Been Documented:

Not applicable.


