### PR TITLE
feat: add replay keyboard controls

### DIFF
--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.css
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.css
@@ -84,6 +84,34 @@
   align-items: center;
 }
 
+.replay-controls-actions {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+}
+
+.replay-controls-steps {
+  display: flex;
+  flex-direction: row;
+  gap: 1px;
+}
+
+.replay-controls-left {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.replay-controls-right {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.replay-controls-step-separator {
+  width: 1px;
+  height: 20px;
+  background-color: #aaa;
+}
+
 .replay-controls-pad {
   width: 0%;
 }

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
@@ -268,7 +268,7 @@ export default function ReplayOverlay({
     return () => {
       document.removeEventListener("keydown", handleKeyboardControls, false);
     };
-  }, []);
+  }, [handleKeyboardControls]);
 
   useEffect(() => {
     const video = videoRef.current;

--- a/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/ReplayOverlay.tsx
@@ -232,11 +232,19 @@ export default function ReplayOverlay({
         break;
 
       case "ArrowLeft":
-        event.shiftKey ? stepBackward(10) : stepBackward();
+        if (event.shiftKey) {
+          stepBackward(10);
+        } else {
+          stepBackward();
+        }
         break;
 
       case "ArrowRight":
-        event.shiftKey ? stepForward(10) : stepForward();
+        if (event.shiftKey) {
+          stepForward(10);
+        } else {
+          stepForward();
+        }
         break;
 
       case " ":
@@ -249,6 +257,8 @@ export default function ReplayOverlay({
           event.preventDefault();
           saveReplay();
         }
+        break;
+      default:
         break;
     }
   }


### PR DESCRIPTION
This PR makes the Replay feature easier to navigate by adding keyboard controls. 

`Escape` → closes the Replay UI
`Arrow Right` → advances the video preview by one frame
`Arrow Left` → goes back in the video frame by one frame
`Shift + Arrow Right` → advances the video by 10 frames
`Shift + Arrow Left` → goes back by 10 frames
`Space` → stops/starts playback
`CMD + S` / `Ctrl +S` → saves the replay 

Here's a video of me navigating the video with keyboard

https://github.com/user-attachments/assets/38cb2a03-8af1-4d19-991e-39abef175386

