### PR TITLE
chore: drop SafeAreaView from preview 

### DIFF
--- a/packages/vscode-extension/lib/preview.js
+++ b/packages/vscode-extension/lib/preview.js
@@ -1,5 +1,5 @@
 const { useEffect, useState } = require("react");
-const { AppRegistry, SafeAreaView, View } = require("react-native");
+const { AppRegistry, View } = require("react-native");
 
 export const PREVIEW_APP_KEY = "RNIDE_preview";
 
@@ -23,9 +23,9 @@ export function Preview({ previewKey }) {
   }, [previewData]);
 
   return (
-    <SafeAreaView style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
       {previewData.component}
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
In the latest (0.81) React Native version the `SafeAreaView` was deprecated (https://github.com/facebook/react-native/commit/73133a31d5a47e71edd4e6b798184df8045e2234). 

We used it exclusively in Preview functionality and in result of the above changes came to the conclusion that it's usage wasn't even correct, as the user might wan't to test components outside safe area. 

This PR replaces `SafeAreaView` with `View` in the Preview component. 

### How Has This Been Tested: 

- run any react native 81 app in radon 
- the first log in the debug console should be: 
```
Running "${application}" with {"rootTag":${ROOT_TAG},"initialProps":${someProps},"fabric":${IS_FABRIC}}
```

note: the deprecation message might pop out any way if your test app use it but it should not come before the above log.

### How Has This Change Been Documented:

internal change


