### PR TITLE
feat: add option to configure the default multimedia saving location

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -259,6 +259,12 @@
           "default": null,
           "description": "Files matching this pattern fill be excluded for the inspector jump to file functionality. This can be used if your codebase has some design system primitives that are used everywhere in your codebase and that you don't want to always get opened when using inspect functionality."
         },
+        "RadonIDE.defaultMultimediaSavingLocation": {
+          "type": "string",
+          "scope": "window",
+          "default": null,
+          "description": "Controls the default saving location for multimedia files."
+        },
         "RadonIDE.stopPreviousDevices": {
           "type": "string",
           "scope": "window",

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -17,6 +17,7 @@ export type WorkspaceConfiguration = {
   stopPreviousDevices: boolean;
   deviceRotation: DeviceRotation;
   inspectorExcludePattern: string | null;
+  defaultMultimediaSavingLocation: string | null;
 };
 
 // #endregion Workspace Configuration
@@ -174,6 +175,7 @@ export const initialState: State = {
     stopPreviousDevices: false,
     deviceRotation: DeviceRotation.Portrait,
     inspectorExcludePattern: null,
+    defaultMultimediaSavingLocation: null,
   },
 };
 

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -35,6 +35,8 @@ export class WorkspaceConfigController implements Disposable {
         stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
         deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
         inspectorExcludePattern: config.get<string>("inspectorExcludePattern") ?? null,
+        defaultMultimediaSavingLocation:
+          config.get<string>("defaultMultimediaSavingLocation") ?? null,
       };
 
       for (const partialStateEntry of partialStateEntries) {
@@ -68,6 +70,8 @@ export class WorkspaceConfigController implements Disposable {
       stopPreviousDevices: config.get<boolean>("stopPreviousDevices")!,
       deviceRotation: config.get<DeviceRotation>("deviceRotation")!,
       inspectorExcludePattern: config.get<string>("inspectorExcludePattern") ?? null,
+      defaultMultimediaSavingLocation:
+        config.get<string>("defaultMultimediaSavingLocation") ?? null,
     };
 
     const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -557,11 +557,18 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       multimediaData.fileName.length - extension.length
     );
     const newFileName = `${baseFileName} ${timestamp}${extension}`;
-    const defaultFolder = Platform.select({
-      macos: path.join(homedir(), "Desktop"),
-      windows: homedir(),
-      linux: homedir(),
-    });
+
+    const defaultMultimediaSavingLocation =
+      this.workspaceStateManager.getState().defaultMultimediaSavingLocation;
+
+    const defaultFolder =
+      defaultMultimediaSavingLocation && fs.existsSync(defaultMultimediaSavingLocation)
+        ? defaultMultimediaSavingLocation
+        : Platform.select({
+            macos: path.join(homedir(), "Desktop"),
+            windows: homedir(),
+            linux: homedir(),
+          });
     const defaultUri = Uri.file(path.join(defaultFolder, newFileName));
 
     // save dialog open the location dialog, it also warns the user if the file already exists


### PR DESCRIPTION
This PR adds an option to set a default Location for multimedia files created by the IDE. 

resolves #1083

### How Has This Been Tested: 

- run `expo-53` test app 
- modify the defaultMultimediaSavingLocation setting to the path that exist and create a screenshot 
- modify the defaultMultimediaSavingLocation setting to the path that does not exist and create a screenshot 

### How Has This Change Been Documented:

I'll update this description shortly 


