### PR TITLE
fix: force-starting a new build doesn't cancel the ongoing build

### DIFF
--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -219,10 +219,45 @@ describe("BatchingBuildManager", () => {
         resolve(BUILD_RESULT);
         resolve2(BUILD_RESULT_2);
 
-        assert.strictEqual(await result1, BUILD_RESULT);
+        await result1;
         assert.strictEqual(await result2, BUILD_RESULT_2);
 
         assert(buildAppMock.calledTwice);
+      });
+
+      it("should cancel the ongoing build when forceCleanBuild is passed", async () => {
+        const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
+        const options = {
+          progressListener,
+          cancelToken: new CancelToken(),
+          buildOutputChannel: {} as any,
+        };
+
+        const { promise, resolve } = Promise.withResolvers();
+        buildAppMock.returns(promise);
+
+        // First call
+        const result1 = batchingBuildManager.buildApp(BUILD_CONFIG, options);
+
+        const { promise: promise2, resolve: resolve2 } = Promise.withResolvers();
+        buildAppMock.returns(promise2);
+
+        // Second call with the same configuration but forceCleanBuild is true
+        const result2 = batchingBuildManager.buildApp(
+          { ...BUILD_CONFIG, forceCleanBuild: true },
+          options
+        );
+
+        resolve(BUILD_RESULT);
+        resolve2(BUILD_RESULT_2);
+        await result1;
+        await result2;
+
+        assert(buildAppMock.calledTwice);
+        assert(
+          buildAppMock.getCall(0).args[1].cancelToken.cancelled,
+          "The first build should be cancelled"
+        );
       });
     });
   }


### PR DESCRIPTION
Fixes an omission in the `BatchingBuildManager` which would cause new builds (started by passing the "force clean build" flag) wouldn't cancel ongoing builds, causing two builds for the same configuration to run concurrently.

### How Has This Been Tested: 
- added unit test for the scenario which fails on main



