### PR TITLE
fix: changing panel location 

### DIFF
--- a/packages/vscode-extension/src/panels/Tabpanel.ts
+++ b/packages/vscode-extension/src/panels/Tabpanel.ts
@@ -141,6 +141,15 @@ export class TabPanel implements Disposable {
 
 export class TabPanelSerializer implements WebviewPanelSerializer {
   public async deserializeWebviewPanel(webviewPanel: WebviewPanel, state: any): Promise<void> {
+    // This can happen if user switches the panel location from tab to side panel
+    // via user settings. This is quite obscure case, as the default accessible by or UI
+    // is to switch the panel location via workspace settings.
+    if (workspace.getConfiguration("RadonIDE").get("panelLocation") !== "tab") {
+      webviewPanel.dispose();
+      TabPanel.currentPanel?.dispose();
+      commands.executeCommand("RNIDE.showPanel");
+      return;
+    }
     TabPanel.restore(webviewPanel);
   }
 }


### PR DESCRIPTION
This PR solves an issue introduces by https://github.com/software-mansion/radon-ide/pull/1147. 

when the user changes the location of the IDE from tab to side panel using `user` scope instead of the default `workspace` 
they could find themselves in a illegal state of having radon open in a tab panel when the setting would be set to 
`side-panel`. Then if the user used an option to open IDE panel like `preview` or just `show IDE` command. they would have to panels open at once. 

### How Has This Been Tested: 

-run a test app and open radon in tab panel 
- change it to a different app and switch "panel location" setting to side-panel with `user` scope
- return to the first app and it will open in tab panel instead of side panel

### How Has This Change Been Documented:

internal


