### PR TITLE
docs: add posthog integration

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -29,6 +29,7 @@
     "front-matter": "^4.0.2",
     "glob": "^11.0.1",
     "motion": "^11.11.17",
+    "posthog-js": "^1.259.0",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/docs/src/hooks/usePosthog.tsx
+++ b/packages/docs/src/hooks/usePosthog.tsx
@@ -1,0 +1,36 @@
+import PostHog, { PostHogConfig } from "posthog-js";
+import { useEffect, useState } from "react";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+const posthogOptions: Partial<PostHogConfig> = isProduction
+  ? {
+      // production api_host must match rewrites in vercel.json
+      api_host: "/rnide-PsHg/",
+      ui_host: "https://eu.posthog.com",
+    }
+  : {
+      api_host: "https://eu.i.posthog.com",
+    };
+
+const commonPosthogOptions: Partial<PostHogConfig> = {
+  person_profiles: "always",
+  defaults: "2025-05-24",
+};
+
+function usePosthog() {
+  const [posthog, setPosthog] = useState<typeof PostHog | undefined>();
+
+  useEffect(() => {
+    const p = PostHog.init("phc_tfuWCtrXJ8OFqvy3eT0ehYAoJWQ0KLQhGeOVqbPdIiJ", {
+      ...posthogOptions,
+      ...commonPosthogOptions,
+    });
+
+    setPosthog(p);
+  }, []);
+
+  return posthog;
+}
+
+export default usePosthog;

--- a/packages/docs/src/hooks/usePosthog.tsx
+++ b/packages/docs/src/hooks/usePosthog.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 
 const isProduction = process.env.NODE_ENV === "production";
 
+const PUBLIC_POSTHOG_KEY = "phc_tfuWCtrXJ8OFqvy3eT0ehYAoJWQ0KLQhGeOVqbPdIiJ";
+
 const posthogOptions: Partial<PostHogConfig> = isProduction
   ? {
       // production api_host must match rewrites in vercel.json
@@ -22,7 +24,7 @@ function usePosthog() {
   const [posthog, setPosthog] = useState<typeof PostHog | undefined>();
 
   useEffect(() => {
-    const p = PostHog.init("phc_tfuWCtrXJ8OFqvy3eT0ehYAoJWQ0KLQhGeOVqbPdIiJ", {
+    const p = PostHog.init(PUBLIC_POSTHOG_KEY, {
       ...posthogOptions,
       ...commonPosthogOptions,
     });

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -18,6 +18,7 @@ import usePosthog from "@site/src/hooks/usePosthog";
 export default function Home(): JSX.Element {
   // We need to initialize on the landing coz Paddle redirects here when the user wants to change the card info, there's no way to change it
   usePaddle();
+  // Sets up PostHog for A/B testing (and analytics) on the landing page
   usePosthog();
 
   return (

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -9,13 +9,16 @@ import LandingBackground from "@site/src/components/Hero/LandingBackground";
 import Overview from "@site/src/components/Sections/Overview";
 import FAQ from "@site/src/components/Sections/FAQ";
 
-import usePaddle from "@site/src/hooks/usePaddle";
 import styles from "./index.module.css";
 import Testimonials from "../components/Sections/Testimonials";
+
+import usePaddle from "@site/src/hooks/usePaddle";
+import usePosthog from "@site/src/hooks/usePosthog";
 
 export default function Home(): JSX.Element {
   // We need to initialize on the landing coz Paddle redirects here when the user wants to change the card info, there's no way to change it
   usePaddle();
+  usePosthog();
 
   return (
     <Layout description="Radon IDE is a VSCode extension that turns your editor into an advanced React Native IDE with a robust debugger, network inspector, and more.">

--- a/packages/docs/src/pages/legal/subprocessors.mdx
+++ b/packages/docs/src/pages/legal/subprocessors.mdx
@@ -2,7 +2,7 @@
 
 <br />
 
-#### Last updated on July 7, 2025
+#### Last updated on August 12, 2025
 
 Software Mansion S.A. is a data processor and uses sub-processors to assist it in providing Radon IDE and all the services connected with Radon IDE. A sub-processor is a third-party data processor engaged by us who may receive and process personal data to the extent necessary for us to provide the services.
 
@@ -15,3 +15,4 @@ Authorized sub-processors are listed below along with a description of the servi
 | Google        | Website analytics                               | EU                                                |
 | Reddit        | Website analytics                               | Various locations including US UK EEA Switzerland |
 | Cookie Script | Cookie management                               | EU                                                |
+| PostHog       | Website analytics                               | EU                                                |

--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -85,5 +85,15 @@
       "destination": "/legal/supporter-terms",
       "permanent": true
     }
+  ],
+  "rewrites": [
+    {
+      "source": "/rnide-PsHg/static/(.*)",
+      "destination": "https://eu-assets.i.posthog.com/static/$1"
+    },
+    {
+      "source": "/rnide-PsHg/(.*)",
+      "destination": "https://eu.i.posthog.com/$1"
+    }
   ]
 }

--- a/packages/docs/yarn.lock
+++ b/packages/docs/yarn.lock
@@ -3862,6 +3862,11 @@ core-js@^3.31.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.42.0.tgz#edbe91f78ac8cfb6df8d997e74d368a68082fe37"
   integrity sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==
 
+core-js@^3.38.1:
+  version "3.45.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.45.0.tgz#556c2af44a2d9c73ea7b49504392474a9f7c947e"
+  integrity sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -4737,6 +4742,11 @@ feed@^4.2.2:
   integrity sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==
   dependencies:
     xml-js "^1.6.11"
+
+fflate@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
 
 figures@^3.2.0:
   version "3.2.0"
@@ -7826,6 +7836,21 @@ postcss@^8.4.33:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+posthog-js@^1.259.0:
+  version "1.259.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.259.0.tgz#9389f7c8180b403dcdc7990a383ebd9b6eeda115"
+  integrity sha512-6usLnJshky8fQ82ask7PIJh4BSFOU0VkRbFg8Zanm/HIlYMG1VOdRWlToA63JXeO7Bzm9TuREq1wFm5U2VEVCg==
+  dependencies:
+    core-js "^3.38.1"
+    fflate "^0.4.8"
+    preact "^10.19.3"
+    web-vitals "^4.2.4"
+
+preact@^10.19.3:
+  version "10.27.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.27.0.tgz#7e614fb651cc1f49275bfb7682e811d759a5364f"
+  integrity sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw==
+
 prettier@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
@@ -8912,16 +8937,7 @@ std-env@^3.7.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
   integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8970,14 +8986,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9459,6 +9468,11 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
+web-vitals@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-4.2.4.tgz#1d20bc8590a37769bd0902b289550936069184b7"
+  integrity sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==
+
 webpack-bundle-analyzer@^4.10.2:
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz#633af2862c213730be3dbdf40456db171b60d5bd"
@@ -9631,16 +9645,7 @@ wildcard@^2.0.0, wildcard@^2.0.1:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This PR adds a PostHog integration for future use for A/B experimentation on the landing page.

This also requires changes in rewrites to send requests from our domain to mitigate them being blocked by adblockers.
Here's the tutorial I followed:

https://posthog.com/docs/advanced/proxy/vercel


Also requires changes to subprocessors legal page.