### PR TITLE
feat: improve network inspector select and scroll behaviour

### DIFF
--- a/packages/vscode-extension/src/network/App.tsx
+++ b/packages/vscode-extension/src/network/App.tsx
@@ -24,7 +24,7 @@ function App() {
   const [selectedNetworkLogId, setSelectedNetworkLogId] = useState<string | null>(null);
 
   const selectedNetworkLog = useMemo(() => {
-    if(!selectedNetworkLogId){
+    if (!selectedNetworkLogId) {
       return null;
     }
     const fullLog = networkLogs.find((log) => log.requestId === selectedNetworkLogId);
@@ -60,20 +60,24 @@ function App() {
   useEffect(() => {
     // Set the size of the network log details container, after users decides to resize it
     // https://vscode-elements.github.io/components/split-layout/api/
+
+    const networkDetailsContainer = networkDetailsContainerRef.current;
+    if (!networkDetailsContainer) {
+      return;
+    }
+
     const handleResize = debounce(() => {
-      if (!networkLogContainerRef.current || !networkDetailsContainerRef.current) {
+      const networkLogContainer = networkLogContainerRef.current;
+      if (!networkLogContainer || !networkDetailsContainer) {
         return;
       }
-      const containerWidth = networkLogContainerRef.current.clientWidth;
-      const detailsWidth = networkDetailsContainerRef.current?.clientWidth;
+      const containerWidth = networkLogContainer.clientWidth;
+      const detailsWidth = networkDetailsContainer?.clientWidth;
       networkLogDetailsSize.current = `${((containerWidth - detailsWidth) / containerWidth) * 100}%`;
     }, DEBOUNCE_TIME);
 
     const detailsResizeObserver = new ResizeObserver(handleResize);
-
-    if (networkDetailsContainerRef.current) {
-      detailsResizeObserver.observe(networkDetailsContainerRef.current);
-    }
+    detailsResizeObserver.observe(networkDetailsContainer);
 
     return () => {
       detailsResizeObserver.disconnect();

--- a/packages/vscode-extension/src/network/App.tsx
+++ b/packages/vscode-extension/src/network/App.tsx
@@ -8,6 +8,8 @@ import NetworkRequestLog from "./components/NetworkRequestLog";
 import NetworkLogDetails from "./components/NetworkLogDetails";
 import { useNetwork } from "./providers/NetworkProvider";
 
+const DEBOUNCE_TIME = 30;
+
 function App() {
   const networkLogContainerRef = useRef<HTMLDivElement | null>(null);
   const networkDetailsContainerRef = useRef<HTMLDivElement>(null);
@@ -26,7 +28,7 @@ function App() {
       return null;
     }
     const fullLog = networkLogs.find((log) => log.requestId === selectedNetworkLogId);
-    
+
     if (!fullLog) {
       setSelectedNetworkLogId(null);
       return null;
@@ -42,7 +44,7 @@ function App() {
       if (networkLogContainerRef.current) {
         setNetworkLogContainerHeight(networkLogContainerRef.current.clientHeight);
       }
-    }, 30);
+    }, DEBOUNCE_TIME);
 
     handleResize();
     handleResize.flush();
@@ -65,7 +67,7 @@ function App() {
       const containerWidth = networkLogContainerRef.current.clientWidth;
       const detailsWidth = networkDetailsContainerRef.current?.clientWidth;
       networkLogDetailsSize.current = `${((containerWidth - detailsWidth) / containerWidth) * 100}%`;
-    });
+    }, DEBOUNCE_TIME);
 
     const detailsResizeObserver = new ResizeObserver(handleResize);
 

--- a/packages/vscode-extension/src/network/App.tsx
+++ b/packages/vscode-extension/src/network/App.tsx
@@ -22,14 +22,19 @@ function App() {
   const [selectedNetworkLogId, setSelectedNetworkLogId] = useState<string | null>(null);
 
   const selectedNetworkLog = useMemo(() => {
+    if(!selectedNetworkLogId){
+      return null;
+    }
     const fullLog = networkLogs.find((log) => log.requestId === selectedNetworkLogId);
+    
     if (!fullLog) {
       setSelectedNetworkLogId(null);
+      return null;
     }
-    return fullLog || null;
+    return fullLog;
   }, [selectedNetworkLogId, networkLogs]);
 
-  const isNetworkLogDetailsVisible = !!selectedNetworkLog;
+  const areNetworkLogDetailsVisible = !!selectedNetworkLog;
 
   useEffect(() => {
     // debounce the resize event to avoid performance issues
@@ -72,7 +77,7 @@ function App() {
       detailsResizeObserver.disconnect();
       handleResize.cancel();
     };
-  }, [isNetworkLogDetailsVisible]);
+  }, [areNetworkLogDetailsVisible]);
 
   return (
     <main>
@@ -81,8 +86,8 @@ function App() {
       <div className="network-log-container" ref={networkLogContainerRef}>
         <VscodeSplitLayout
           className="network-log-split-layout"
-          handleSize={isNetworkLogDetailsVisible ? 4 : 0}
-          handlePosition={isNetworkLogDetailsVisible ? networkLogDetailsSize.current : "100%"}>
+          handleSize={areNetworkLogDetailsVisible ? 4 : 0}
+          handlePosition={areNetworkLogDetailsVisible ? networkLogDetailsSize.current : "100%"}>
           <div slot="start">
             <NetworkRequestLog
               selectedNetworkLog={selectedNetworkLog}
@@ -91,7 +96,7 @@ function App() {
               parentHeight={networkLogContainerHeight}
             />
           </div>
-          {isNetworkLogDetailsVisible ? (
+          {areNetworkLogDetailsVisible ? (
             <div ref={networkDetailsContainerRef} slot="end">
               <NetworkLogDetails
                 key={selectedNetworkLog.requestId}

--- a/packages/vscode-extension/src/network/components/NetworkLogDetails.css
+++ b/packages/vscode-extension/src/network/components/NetworkLogDetails.css
@@ -18,6 +18,7 @@
   border-radius: 5px;
   padding: 3px;
   cursor: pointer;
+  z-index: 1;
 }
 
 .network-log-details-close-button:hover {

--- a/packages/vscode-extension/src/network/components/NetworkRequestLog.css
+++ b/packages/vscode-extension/src/network/components/NetworkRequestLog.css
@@ -10,6 +10,7 @@
   background-color: var(--vscode-list-hoverBackground);
 }
 
-.selected, .selected:hover {
+.selected,
+.selected:hover {
   background-color: var(--vscode-terminal-selectionBackground);
 }

--- a/packages/vscode-extension/src/network/components/NetworkRequestLog.css
+++ b/packages/vscode-extension/src/network/components/NetworkRequestLog.css
@@ -9,3 +9,7 @@
   cursor: pointer;
   background-color: var(--vscode-list-hoverBackground);
 }
+
+.selected, .selected:hover {
+  background-color: var(--vscode-terminal-selectionBackground);
+}

--- a/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
+++ b/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
@@ -20,6 +20,8 @@ interface NetworkRequestLogProps {
   parentHeight: number | undefined;
 }
 
+const SCROLL_TO_TOP_TIMEOUT = 200;
+
 /**
  * Navigates through the shadow DOM hierarchy to find the scrollable container within a VSCode table element.
  *
@@ -85,7 +87,7 @@ const NetworkRequestLog = ({
           behavior: "smooth",
         });
       }
-    }, 200);
+    }, SCROLL_TO_TOP_TIMEOUT);
 
     return () => {
       clearTimeout(timeout);

--- a/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
+++ b/packages/vscode-extension/src/network/components/NetworkRequestLog.tsx
@@ -32,13 +32,8 @@ interface NetworkRequestLogProps {
  *          or undefined if any intermediate elements in the shadow DOM hierarchy are missing
  */
 function getScrollableTableContainer(table: VscodeTableElement): HTMLDivElement | null | undefined {
-  const tableShadowRoot = table.shadowRoot;
-  const scrollableShadowRoot =
-    tableShadowRoot?.querySelector<HTMLDivElement>(".scrollable")?.shadowRoot;
-  const scrollableContainer =
-    scrollableShadowRoot?.querySelector<HTMLDivElement>(".scrollable-container");
-
-  return scrollableContainer;
+  //@ts-ignore - ignore accessing the private property - needed to avoid ugly selectors
+  return table._scrollableElement?._scrollableContainer;
 }
 
 const NetworkRequestLog = ({


### PR DESCRIPTION
### Description

This PR improves network inspector scroll and select behaviour:
- the selected request logs are now highlighted
- the element now does not re-render whenever height changes
- - if log is selected, after resizing the inspector now ensures that it remains visible and scrolls the list accordingly
- fixed issue, where scroll was reset to the top after closing the details window or changed the inspector's height

https://github.com/user-attachments/assets/f08bb04d-bec0-4786-820c-f86bb0c1d304

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, launch app on selected device, open network inspector
- **select logs, see if scroll behaves as expected**

### How Has This Change Been Documented:

Not applicable.


