### PR TITLE
feat: allow sending files to device

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -320,6 +320,8 @@ export interface ProjectInterface {
   getDeepLinksHistory(): Promise<string[]>;
   openDeepLink(link: string, terminateApp: boolean): Promise<void>;
 
+  sendFileToDevice(): Promise<void>;
+
   startRecording(): void;
   captureAndStopRecording(): void;
   captureReplay(): void;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -320,7 +320,8 @@ export interface ProjectInterface {
   getDeepLinksHistory(): Promise<string[]>;
   openDeepLink(link: string, terminateApp: boolean): Promise<void>;
 
-  sendFileToDevice(): Promise<void>;
+  openSendFileDialog(): Promise<void>;
+  sendFileToDevice(fileDescription: { fileName: string; data: ArrayBuffer }): Promise<void>;
 
   startRecording(): void;
   captureAndStopRecording(): void;

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -725,6 +725,10 @@ export class AndroidEmulatorDevice extends DeviceBase {
   async getClipboard() {
     // No need to copy clipboard, Android Emulator syncs it for us whenever a user clicks on 'Copy'
   }
+
+  public async sendFile(filePath: string): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
 }
 
 export async function createEmulator(

--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -727,7 +727,21 @@ export class AndroidEmulatorDevice extends DeviceBase {
   }
 
   public async sendFile(filePath: string): Promise<void> {
-    throw new Error("Method not implemented.");
+    const args = ["push", "-q", filePath, `/sdcard/Download/${path.basename(filePath)}`];
+    await exec(ADB_PATH, ["-s", this.serial!, ...args]);
+    // Notify the media scanner about the new file
+    await exec(ADB_PATH, [
+      "-s",
+      this.serial!,
+      "shell",
+      "am",
+      "broadcast",
+      "-a",
+      "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+      "--receiver-include-background",
+      "-d",
+      `file:///sdcard/Download`,
+    ]);
   }
 }
 

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -115,6 +115,7 @@ export abstract class DeviceBase implements Disposable {
   ): Promise<void>;
   abstract terminateApp(packageNameOrBundleID: string): Promise<void>;
   protected abstract makePreview(): Preview;
+  abstract sendFile(filePath: string): Promise<void>;
   abstract get platform(): DevicePlatform;
   abstract get deviceInfo(): DeviceInfo;
   abstract resetAppPermissions(

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { ExecaChildProcess, ExecaError } from "execa";
+import mime from "mime";
 import { getAppCachesDir, getOldAppCachesDir } from "../utilities/common";
 import { DeviceBase } from "./DeviceBase";
 import { Preview } from "./preview";
@@ -532,9 +533,8 @@ export class IosSimulatorDevice extends DeviceBase {
 }
 
 function isMediaFile(filePath: string): boolean {
-  const mediaFileExtensions = [".jpg", ".jpeg", ".png", ".gif", ".mp4", ".mov"];
-  const fileExtension = path.extname(filePath).toLowerCase();
-  return mediaFileExtensions.includes(fileExtension);
+  const type = mime.lookup(filePath);
+  return type.startsWith("image/") || type.startsWith("video/");
 }
 
 export async function getNewestAvailableIosRuntime() {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -519,6 +519,22 @@ export class IosSimulatorDevice extends DeviceBase {
       getOrCreateDeviceSet(this.deviceUDID),
     ]);
   }
+
+  public async sendFile(filePath: string): Promise<void> {
+    const args = ["simctl", "--set", getOrCreateDeviceSet(this.deviceUDID)];
+    if (isMediaFile(filePath)) {
+      args.push("addmedia", this.deviceUDID, filePath);
+    } else {
+      args.push("openurl", this.deviceUDID, `file://${filePath}`);
+    }
+    await exec("xcrun", args);
+  }
+}
+
+function isMediaFile(filePath: string): boolean {
+  const mediaFileExtensions = [".jpg", ".jpeg", ".png", ".gif", ".mp4", ".mov"];
+  const fileExtension = path.extname(filePath).toLowerCase();
+  return mediaFileExtensions.includes(fileExtension);
 }
 
 export async function getNewestAvailableIosRuntime() {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -522,12 +522,17 @@ export class IosSimulatorDevice extends DeviceBase {
   }
 
   public async sendFile(filePath: string): Promise<void> {
-    const args = ["simctl", "--set", getOrCreateDeviceSet(this.deviceUDID)];
-    if (isMediaFile(filePath)) {
-      args.push("addmedia", this.deviceUDID, filePath);
-    } else {
-      args.push("openurl", this.deviceUDID, `file://${filePath}`);
+    if (!isMediaFile(filePath)) {
+      throw new Error("Only media file transfer is supported on iOS.");
     }
+    const args = [
+      "simctl",
+      "--set",
+      getOrCreateDeviceSet(this.deviceUDID),
+      "addmedia",
+      this.deviceUDID,
+      filePath,
+    ];
     await exec("xcrun", args);
   }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -893,4 +893,8 @@ export class DeviceSession implements Disposable {
   public getMetroPort() {
     return this.metro.port;
   }
+
+  public sendFile(filePath: string) {
+    return this.device.sendFile(filePath);
+  }
 }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -908,7 +908,7 @@ export class DeviceSession implements Disposable {
       title: "Select files to send to device",
     });
     if (!pickerResult) {
-      return; // no files selected
+      throw new Error("No files selected");
     }
     const sendFilePromises = pickerResult.map((fileUri) => {
       return this.sendFile(fileUri.fsPath);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -898,6 +898,10 @@ export class DeviceSession implements Disposable {
   }
 
   public sendFile(filePath: string) {
+    getTelemetryReporter().sendTelemetryEvent("device:send-file", {
+      platform: this.device.deviceInfo.platform,
+      extension: path.extname(filePath),
+    });
     return this.device.sendFile(filePath);
   }
 

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -491,10 +491,11 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   // #region File Transfer
 
-  public async sendFileToDevice() {
+  public async openSendFileDialog() {
     const pickerResult = await window.showOpenDialog({
       canSelectMany: true,
       canSelectFolders: false,
+      title: "Select files to send to device",
     });
     if (!pickerResult) {
       return; // no files selected
@@ -503,6 +504,29 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       return this.deviceSession?.sendFile(fileUri.fsPath);
     });
     await Promise.all(sendFilePromises);
+  }
+
+  public async sendFileToDevice({
+    fileName,
+    data,
+  }: {
+    fileName: string;
+    data: ArrayBuffer;
+  }): Promise<void> {
+    if (!this.deviceSession) {
+      throw new Error("No device session available");
+    }
+    const tempDir = await fs.promises.mkdtemp(os.tmpdir());
+    try {
+      const tempFileLocation = path.join(tempDir, fileName);
+      await fs.promises.writeFile(tempFileLocation, new Uint8Array(data));
+      await this.deviceSession.sendFile(tempFileLocation);
+    } finally {
+      // NOTE: no `await` here, this can safely go in the background
+      fs.promises.rm(tempDir, { recursive: true }).catch((_e) => {
+        /* silence the errors, it's fine */
+      });
+    }
   }
 
   // #endregion

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -489,6 +489,21 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
   // #endregion DeepLinks
 
+  // #region File Transfer
+
+  public async sendFileToDevice() {
+    const pickerResult = await window.showOpenDialog({ canSelectFolders: false });
+    if (!pickerResult) {
+      return; // no files selected
+    }
+    const sendFilePromises = pickerResult.map((fileUri) => {
+      return this.deviceSession?.sendFile(fileUri.fsPath);
+    });
+    await Promise.all(sendFilePromises);
+  }
+
+  // #endregion
+
   // #region Recording
 
   private recordingTimeout: NodeJS.Timeout | undefined = undefined;

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -492,7 +492,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   // #region File Transfer
 
   public async sendFileToDevice() {
-    const pickerResult = await window.showOpenDialog({ canSelectFolders: false });
+    const pickerResult = await window.showOpenDialog({
+      canSelectMany: true,
+      canSelectFolders: false,
+    });
     if (!pickerResult) {
       return; // no files selected
     }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -492,18 +492,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   // #region File Transfer
 
   public async openSendFileDialog() {
-    const pickerResult = await window.showOpenDialog({
-      canSelectMany: true,
-      canSelectFolders: false,
-      title: "Select files to send to device",
-    });
-    if (!pickerResult) {
-      return; // no files selected
+    if (!this.deviceSession) {
+      throw new Error("No device session available");
     }
-    const sendFilePromises = pickerResult.map((fileUri) => {
-      return this.deviceSession?.sendFile(fileUri.fsPath);
-    });
-    await Promise.all(sendFilePromises);
+    this.deviceSession.openSendFileDialog();
   }
 
   public async sendFileToDevice({
@@ -516,17 +508,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     if (!this.deviceSession) {
       throw new Error("No device session available");
     }
-    const tempDir = await fs.promises.mkdtemp(os.tmpdir());
-    try {
-      const tempFileLocation = path.join(tempDir, fileName);
-      await fs.promises.writeFile(tempFileLocation, new Uint8Array(data));
-      await this.deviceSession.sendFile(tempFileLocation);
-    } finally {
-      // NOTE: no `await` here, this can safely go in the background
-      fs.promises.rm(tempDir, { recursive: true }).catch((_e) => {
-        /* silence the errors, it's fine */
-      });
-    }
+    this.deviceSession.sendFileToDevice(fileName, data);
   }
 
   // #endregion

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -246,7 +246,7 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
           {selectedDeviceSession?.deviceInfo.platform === DevicePlatform.IOS && <BiometricsItem />}
           <DropdownMenu.Item
             className="dropdown-menu-item"
-            onSelect={() => project.sendFileToDevice()}>
+            onSelect={() => project.openSendFileDialog()}>
             <span className="codicon codicon-share" />
             Send File
           </DropdownMenu.Item>

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -246,6 +246,12 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
           {selectedDeviceSession?.deviceInfo.platform === DevicePlatform.IOS && <BiometricsItem />}
           <DropdownMenu.Item
             className="dropdown-menu-item"
+            onSelect={() => project.sendFileToDevice()}>
+            <span className="codicon codicon-share" />
+            Send File
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            className="dropdown-menu-item"
             onSelect={() => {
               openModal("Location", <DeviceLocationView />);
             }}>

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -116,8 +116,6 @@ function Preview({
 
   const openRebuildAlert = useNativeRebuildAlert();
 
-  useEffect(() => {});
-
   /**
    * Converts mouse event coordinates to normalized touch coordinates ([0-1] range)
    * relative to the device preview image.
@@ -622,9 +620,6 @@ function Preview({
                   <Debugger />
                 </div>
               )}
-              {/* <div
-                style={{ position: "absolute", height: "100%", width: "100%" }}
-                {...dragHandlers}></div> */}
             </div>
           </Device>
         )}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, MouseEvent, WheelEvent } from "react";
+import { useState, useRef, useEffect, MouseEvent, WheelEvent, useMemo } from "react";
 import { use$ } from "@legendapp/state/react";
 import "./Preview.css";
 import { clamp, debounce } from "lodash";
@@ -511,6 +511,31 @@ function Preview({
   const normalTouchIndicatorSize = 33;
   const smallTouchIndicatorSize = 9;
 
+  const dragHandlers = useMemo(() => {
+    return {
+      onDrop(ev: React.DragEvent) {
+        ev.preventDefault();
+        const files = ev.dataTransfer.files;
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          file.arrayBuffer().then((buf) => {
+            project.sendFileToDevice({
+              fileName: file.name,
+              data: buf,
+            });
+          });
+        }
+      },
+      onDragOver(ev: React.DragEvent) {
+        ev.stopPropagation();
+        ev.preventDefault();
+      },
+      onDragEnter(ev: React.DragEvent) {
+        ev.preventDefault();
+      },
+    } as const;
+  }, [project]);
+
   return (
     <>
       <div
@@ -521,7 +546,7 @@ function Preview({
         {...wrapperTouchHandlers}>
         {showDevicePreview && (
           <Device device={device!} zoomLevel={zoomLevel} wrapperDivRef={wrapperDivRef}>
-            <div className="touch-area" {...touchHandlers}>
+            <div className="touch-area" {...touchHandlers} {...dragHandlers}>
               <MjpegImg
                 src={previewURL}
                 ref={previewRef}
@@ -597,6 +622,9 @@ function Preview({
                   <Debugger />
                 </div>
               )}
+              {/* <div
+                style={{ position: "absolute", height: "100%", width: "100%" }}
+                {...dragHandlers}></div> */}
             </div>
           </Device>
         )}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -116,6 +116,8 @@ function Preview({
 
   const openRebuildAlert = useNativeRebuildAlert();
 
+  useEffect(() => {});
+
   /**
    * Converts mouse event coordinates to normalized touch coordinates ([0-1] range)
    * relative to the device preview image.

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -333,14 +333,6 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
-            tooltip={{
-              label: "Send a file to the device",
-            }}
-            onClick={() => project.sendFileToDevice()}
-            disabled={!navBarButtonsActive}>
-            <span slot="start" className="codicon codicon-share" />
-          </IconButton>
-          <IconButton
             counter={logCounter}
             counterMode="compact"
             onClick={() => project.focusDebugConsole()}

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -333,6 +333,14 @@ function PreviewView() {
             <span slot="start" className="codicon codicon-device-camera" />
           </IconButton>
           <IconButton
+            tooltip={{
+              label: "Send a file to the device",
+            }}
+            onClick={() => project.sendFileToDevice()}
+            disabled={!navBarButtonsActive}>
+            <span slot="start" className="codicon codicon-share" />
+          </IconButton>
+          <IconButton
             counter={logCounter}
             counterMode="compact"
             onClick={() => project.focusDebugConsole()}


### PR DESCRIPTION
Allows sending files to the selected device via Radon.
- adds a "Send file" option to the device settings dropdown which opens the system file picker to select the file(s) to send
- allows drag-n-dropping files over the preview in order to send them over to the device

UI to be done in a separate PR.

https://github.com/user-attachments/assets/afd426d1-53a0-471d-8dd6-4cb6ab65ddf2

Limitations: 
- currently, only media files are supported on iOS due to issues with the "Files" app not working correctly in Radon Simulators. The default behaviour of the Apple Simulator app when dropping a (non-media) file over the simulator seems to be the same as `simctl openurl file://${path-to-file}` which opens the "Files" app on the device and allows selecting where the file should be saved. However, on the Radon Simulator, the "Files" app is unable to save the file (the button is disabled), and other functions (e.g. creating a new folder) also don't work -- I don't know why.

### How Has This Been Tested: 
- open the `react-native-image-picker` example app
- use "send files" option in the Device Settings dropdown and select a photo
- drag another photo to the preview
- verify both photos are selectable in the image picker

### How Has This Change Been Documented:
WIP


