### PR TITLE
add stepInto/stepOut controls to debugger overlay

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -303,6 +303,8 @@ export interface ProjectInterface {
 
   resumeDebugger(): Promise<void>;
   stepOverDebugger(): Promise<void>;
+  stepIntoDebugger(): Promise<void>;
+  stepOutDebugger(): Promise<void>;
   focusDebugConsole(): Promise<void>;
 
   openNavigation(navigationItemID: string): Promise<void>;

--- a/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/CDPDebugAdapter.ts
@@ -297,6 +297,34 @@ export class CDPDebugAdapter extends DebugSession implements CDPSessionDelegate 
     this.sendResponse(response);
   }
 
+  protected override async stepInRequest(
+    response: DebugProtocol.StepInResponse,
+    args: DebugProtocol.StepInArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [stepInRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    await this.cdpSession.sendCDPMessage("Debugger.stepInto", {});
+    this.sendResponse(response);
+  }
+
+  protected override async stepOutRequest(
+    response: DebugProtocol.StepOutResponse,
+    args: DebugProtocol.StepOutArguments
+  ): Promise<void> {
+    if (!this.cdpSession) {
+      Logger.warn("[DebugAdapter] [stepOutRequest] The CDPSession was not initialized yet");
+      this.sendResponse(response);
+      return;
+    }
+
+    await this.cdpSession.sendCDPMessage("Debugger.stepOut", {});
+    this.sendResponse(response);
+  }
+
   protected disconnectRequest(
     response: DebugProtocol.DisconnectResponse,
     args: DebugProtocol.DisconnectArguments

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -47,6 +47,8 @@ export interface DebugSession {
   // debugger controls
   resumeDebugger(): void;
   stepOverDebugger(): void;
+  stepOutDebugger(): void;
+  stepIntoDebugger(): void;
   evaluateExpression(params: Cdp.Runtime.EvaluateParams): Promise<Cdp.Runtime.EvaluateResult>;
 
   // Profiling controls
@@ -249,6 +251,16 @@ export class DebugSessionImpl implements DebugSession, Disposable {
 
   public stepOverDebugger() {
     commands.executeCommand("workbench.action.debug.stepOver", undefined, {
+      sessionId: this.jsDebugSession?.id,
+    });
+  }
+  public stepOutDebugger() {
+    commands.executeCommand("workbench.action.debug.stepOut", undefined, {
+      sessionId: this.jsDebugSession?.id,
+    });
+  }
+  public stepIntoDebugger() {
+    commands.executeCommand("workbench.action.debug.stepInto", undefined, {
       sessionId: this.jsDebugSession?.id,
     });
   }

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -212,19 +212,6 @@ export class ProxyDebugAdapter extends DebugSession {
     });
   }
 
-  protected nextRequest(
-    response: DebugProtocol.NextResponse,
-    args: DebugProtocol.NextArguments,
-    request?: DebugProtocol.Request
-  ): void {
-    if (!this.nodeDebugSession) {
-      return;
-    }
-    vscode.commands.executeCommand("workbench.action.debug.stepOver", undefined, {
-      sessionId: this.nodeDebugSession.id,
-    });
-  }
-
   protected async disconnectRequest(
     response: DebugProtocol.DisconnectResponse,
     args: DebugProtocol.DisconnectArguments,

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,9 +1,9 @@
+import path from "path";
+import fs from "fs/promises";
 import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
 import { EventEmitter } from "vscode";
 import { Minimatch } from "minimatch";
 import _ from "lodash";
-import path from "path";
-import fs from "fs/promises";
 import { CDPProxyDelegate, ProxyTunnel } from "./CDPProxy";
 import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { Logger } from "../Logger";
@@ -155,7 +155,9 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   ): Promise<IProtocolCommand> {
     const { method } = command;
     switch (method) {
-      case "Debugger.stepOver": {
+      case "Debugger.stepOver":
+      case "Debugger.stepOut":
+      case "Debugger.stepInto": {
         // setting this will cause the "resume" event from being slightly delayed as we
         // expect the "paused" event to be fired almost immediately.
         this.justCalledStepOver = true;

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -110,6 +110,12 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   public stepOverDebugger(): void {
     this.debugSession.stepOverDebugger();
   }
+  public stepOutDebugger() {
+    this.debugSession.stepOutDebugger();
+  }
+  public stepIntoDebugger() {
+    this.debugSession.stepIntoDebugger();
+  }
   public async startProfilingCPU(): Promise<void> {
     return this.debugSession.startProfilingCPU();
   }

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -361,6 +361,12 @@ export class ApplicationSession implements ToolsDelegate, Disposable {
   public stepOverDebugger() {
     this.debugSession?.stepOverDebugger();
   }
+  public stepOutDebugger() {
+    this.debugSession?.stepOutDebugger();
+  }
+  public stepIntoDebugger() {
+    this.debugSession?.stepIntoDebugger();
+  }
 
   private async connectJSDebugger() {
     const websocketAddress = await this.metro.getDebuggerURL();

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -860,6 +860,12 @@ export class DeviceSession implements Disposable {
   public stepOverDebugger() {
     this.applicationSession?.stepOverDebugger();
   }
+  public stepOutDebugger() {
+    this.applicationSession?.stepOutDebugger();
+  }
+  public stepIntoDebugger() {
+    this.applicationSession?.stepIntoDebugger();
+  }
 
   public async startProfilingCPU() {
     await this.applicationSession?.startProfilingCPU();

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -384,6 +384,12 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   public async stepOverDebugger() {
     this.deviceSession?.stepOverDebugger();
   }
+  public async stepOutDebugger() {
+    this.deviceSession?.stepOutDebugger();
+  }
+  public async stepIntoDebugger() {
+    this.deviceSession?.stepIntoDebugger();
+  }
 
   public async focusDebugConsole() {
     this.deviceSession?.resetLogCounter();

--- a/packages/vscode-extension/src/webview/components/Debugger.tsx
+++ b/packages/vscode-extension/src/webview/components/Debugger.tsx
@@ -25,6 +25,22 @@ function Debugger() {
           <span className="codicon codicon-debug-step-over" />
         </IconButton>
         <IconButton
+          onClick={() => project.stepIntoDebugger()}
+          tooltip={{
+            label: "Step into",
+            side: "bottom",
+          }}>
+          <span className="codicon codicon-debug-step-into" />
+        </IconButton>
+        <IconButton
+          onClick={() => project.stepOutDebugger()}
+          tooltip={{
+            label: "Step out",
+            side: "bottom",
+          }}>
+          <span className="codicon codicon-debug-step-out" />
+        </IconButton>
+        <IconButton
           onClick={() => project.focusDebugConsole()}
           tooltip={{
             label: "Open debugger console",


### PR DESCRIPTION
Adds "Step Into" / "Step Out" controls to the debugger overlay.
Closes #283 

### How Has This Been Tested: 
- open (ReactNative74, ReactNative81) test apps in Radon (to test both old and new debugger implementations)
- modify `printLogs` function to call something else:
```
function getText() {
  return 'console.log';
}

function printLogs() {
  // put breakpoint on the next line
  const text = getText();
  console.log(text);
}
```
- place a breakpoint inside `printLogs`
- verify "Step Into" and "Step Out" buttons correctly step through the code.

### How Has This Change Been Documented:
nah


