### PR TITLE
fix: app root detection system

### DIFF
--- a/packages/vscode-extension/src/utilities/extensionContext.ts
+++ b/packages/vscode-extension/src/utilities/extensionContext.ts
@@ -41,9 +41,13 @@ export function findAppRootCandidates(maxSearchDepth: number = 3): string[] {
     return [];
   }
 
-  const searchDirectories: SearchItem[] = workspaceFolders.map((workspaceFolder) => {
-    return { path: workspaceFolder.uri.fsPath, searchDepth: 0 };
-  });
+  const searchDirectories: SearchItem[] = workspaceFolders
+    .filter((workspaceFolder) => {
+      return fs.statSync(workspaceFolder.uri.fsPath).isDirectory();
+    })
+    .map((workspaceFolder) => {
+      return { path: workspaceFolder.uri.fsPath, searchDepth: 0 };
+    });
 
   const candidates = searchForFilesDirectory(
     searchedFileNames,


### PR DESCRIPTION
This PR fixes an issue with app root detection system treating symlinks to files ad directories. 

To avoid similar problems in the future we not only change the guard check from `!....isFilie()` to .`...isDirectory()` but also encapsulate the error in try catch block.   

### How Has This Been Tested: 

check is test apps are still working and run this version of radon on the project where the issue happened.

### How Has This Change Been Documented:

this is an internal change



