### PR TITLE
Reactor build to make builds depend on device and also fix cache to rely on device config

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -76,6 +76,7 @@
         "execa": "^5.1.1",
         "express": "^5.1.0",
         "fantasticon": "^3.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
         "file-loader": "^6.2.0",
         "globals": "^16.1.0",
         "jsonc-parser": "^3.3.1",
@@ -23908,6 +23909,8 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1026,6 +1026,7 @@
     "execa": "^5.1.1",
     "express": "^5.1.0",
     "fantasticon": "^3.0.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "file-loader": "^6.2.0",
     "globals": "^16.1.0",
     "jsonc-parser": "^3.3.1",

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -11,6 +11,7 @@ describe("BatchingBuildManager", () => {
   let buildAppMock = Sinon.stub();
   let buildManagerMock = {
     buildApp: buildAppMock,
+    calculateBuildFingerprint: Sinon.stub(),
     dispose: Sinon.stub(),
   };
   const APP_ROOT = "appRoot";
@@ -24,6 +25,7 @@ describe("BatchingBuildManager", () => {
     buildAppMock = Sinon.stub();
     buildManagerMock = {
       buildApp: buildAppMock,
+      calculateBuildFingerprint: Sinon.stub(),
       dispose: Sinon.stub(),
     };
   });

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.test.ts
@@ -53,6 +53,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         buildAppMock.resolves(BUILD_RESULT);
@@ -68,6 +69,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -93,6 +95,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -120,6 +123,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -145,7 +149,12 @@ describe("BatchingBuildManager", () => {
       it("should cancel the build in progress when the passed cancel token is cancelled", async () => {
         const batchingBuildManager = new BatchingBuildManager(buildManagerMock);
         const cancelToken = new CancelToken();
-        const options = { progressListener, cancelToken, buildOutputChannel: {} as any };
+        const options = {
+          progressListener,
+          cancelToken,
+          buildOutputChannel: {} as any,
+          forceCleanBuild: false,
+        };
 
         const { promise } = Promise.withResolvers();
         buildAppMock.returns(promise);
@@ -175,11 +184,13 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken,
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         });
         batchingBuildManager.buildApp(BUILD_CONFIG, {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         });
 
         // Cancel the token
@@ -199,6 +210,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -211,10 +223,10 @@ describe("BatchingBuildManager", () => {
         buildAppMock.returns(promise2);
 
         // Second call with the same configuration but forceCleanBuild is true
-        const result2 = batchingBuildManager.buildApp(
-          { ...BUILD_CONFIG, forceCleanBuild: true },
-          options
-        );
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG, {
+          ...options,
+          forceCleanBuild: true,
+        });
 
         resolve(BUILD_RESULT);
         resolve2(BUILD_RESULT_2);
@@ -231,6 +243,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -243,10 +256,10 @@ describe("BatchingBuildManager", () => {
         buildAppMock.returns(promise2);
 
         // Second call with the same configuration but forceCleanBuild is true
-        const result2 = batchingBuildManager.buildApp(
-          { ...BUILD_CONFIG, forceCleanBuild: true },
-          options
-        );
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG, {
+          ...options,
+          forceCleanBuild: true,
+        });
 
         resolve(BUILD_RESULT);
         resolve2(BUILD_RESULT_2);
@@ -266,6 +279,7 @@ describe("BatchingBuildManager", () => {
           progressListener,
           cancelToken: new CancelToken(),
           buildOutputChannel: {} as any,
+          forceCleanBuild: false,
         };
 
         const { promise, resolve } = Promise.withResolvers();
@@ -278,10 +292,10 @@ describe("BatchingBuildManager", () => {
         buildAppMock.returns(promise2);
 
         // Second call with the same configuration but forceCleanBuild is true
-        const result2 = batchingBuildManager.buildApp(
-          { ...BUILD_CONFIG_2, forceCleanBuild: true },
-          options
-        );
+        const result2 = batchingBuildManager.buildApp(BUILD_CONFIG_2, {
+          ...options,
+          forceCleanBuild: true,
+        });
 
         resolve(BUILD_RESULT);
         resolve2(BUILD_RESULT_2);

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -1,7 +1,7 @@
 import { Disposable } from "vscode";
 import { BuildConfig } from "../common/BuildConfig";
 import { Logger } from "../Logger";
-import { BuildManager, BuildOptions, BuildResult } from "./BuildManager";
+import { BuildFingerprint, BuildManager, BuildOptions, BuildResult } from "./BuildManager";
 import { CancelToken } from "../utilities/cancelToken";
 
 class BuildInProgress {
@@ -47,6 +47,10 @@ export class BatchingBuildManager implements BuildManager, Disposable {
 
   private makeBuildKey(buildConfig: BuildConfig) {
     return `${buildConfig.platform}:${buildConfig.type}:${buildConfig.appRoot}`;
+  }
+
+  public async calculateBuildFingerprint(buildConfig: BuildConfig): Promise<BuildFingerprint> {
+    return this.wrappedBuildManager.calculateBuildFingerprint(buildConfig);
   }
 
   public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {

--- a/packages/vscode-extension/src/builders/BatchingBuildManager.ts
+++ b/packages/vscode-extension/src/builders/BatchingBuildManager.ts
@@ -52,7 +52,7 @@ export class BatchingBuildManager implements BuildManager, Disposable {
   public async buildApp(buildConfig: BuildConfig, options: BuildOptions): Promise<BuildResult> {
     const { progressListener, cancelToken } = options;
     const buildKey = this.makeBuildKey(buildConfig);
-    const { forceCleanBuild } = buildConfig;
+    const { forceCleanBuild } = options;
 
     const existingBuild = this.buildsInProgress.get(buildKey);
     // NOTE: if forceCleanBuild is true, we always start a new build
@@ -75,6 +75,7 @@ export class BatchingBuildManager implements BuildManager, Disposable {
         progressListener: (newProgress) => {
           buildInProgress.onProgress(newProgress);
         },
+        forceCleanBuild,
         buildOutputChannel: options.buildOutputChannel,
       }),
       cancelTokenForBuild

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -42,6 +42,9 @@ export class BuildCache {
 
   private async collectGarbageCacheEntriesNow() {
     const keys = await extensionContext.globalState.keys();
+    Logger.info(
+      `Collecting garbage cache entries. ${keys.length} keys present in the global state.`
+    );
     const keysToRemove = keys.filter((key) => key.startsWith(GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX));
     const buildResultsForAppPaths = new Map<string, [BuildResult]>();
     const promises = [];

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -6,6 +6,7 @@ import { BuildFingerprint, BuildResult } from "./BuildManager";
 import { DevicePlatform } from "../common/State";
 
 const GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX = "build-cache";
+const GLOBAL_STATE_LGACY_BUILD_CACHE_PREFIXES = ["android_build_cache", "ios_build_cache"];
 
 function globalStateKey(fingerprint: BuildFingerprint) {
   return `${GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX}:${fingerprint}`;
@@ -24,6 +25,16 @@ export class BuildCache {
 
   public async clearCache(fingerprint: BuildFingerprint) {
     await extensionContext.globalState.update(globalStateKey(fingerprint), undefined);
+  }
+
+  public static async clearLegacyCacheEntries() {
+    const keys = await extensionContext.globalState.keys();
+    const keysToRemove = keys.filter((key) =>
+      GLOBAL_STATE_LGACY_BUILD_CACHE_PREFIXES.some((prefix) => key.startsWith(prefix))
+    );
+    await Promise.all(
+      keysToRemove.map((key) => extensionContext.globalState.update(key, undefined))
+    );
   }
 
   private async collectGarbageCacheEntriesNow() {

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -13,6 +13,9 @@ function globalStateKey(fingerprint: BuildFingerprint) {
 }
 
 export class BuildCache {
+  constructor() {
+    BuildCache.clearLegacyCacheEntries();
+  }
   /**
    * Passed fingerprint should be calculated at the time build is started.
    */

--- a/packages/vscode-extension/src/builders/BuildCache.ts
+++ b/packages/vscode-extension/src/builders/BuildCache.ts
@@ -1,80 +1,104 @@
 import fs from "fs";
-import crypto from "crypto";
-import stableStringify from "fast-json-stable-stringify";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
-import { IOSBuildResult } from "./buildIOS";
-import { AndroidBuildResult } from "./buildAndroid";
-import { calculateAppHash } from "../utilities/common";
-import { BuildResult } from "./BuildManager";
-import { FingerprintProvider } from "../project/FingerprintProvider";
+import { calculateAppArtifactHash } from "../utilities/common";
+import { BuildFingerprint, BuildResult } from "./BuildManager";
 import { DevicePlatform } from "../common/State";
-import { BuildConfig } from "../common/BuildConfig";
 
-const ANDROID_BUILD_CACHE_KEY = "android_build_cache";
-const BASE_IOS_BUILD_CACHE_KEY = "ios_build_cache";
-// Add a key for new builds that support iPad since 1.10.0
-// This is to ensure that old cached iOS builds that do not support iPad
-// (made before 1.10.0) are not used when the user opens a project using iPad
-// New builds support both iPhone and iPad, without having to rebuild,
-// so we can use the same cache key from that point on
-const IPAD_SUPPORT_BUILD_CACHE_KEY = "ipad_support_build_cache";
-// Add a key for new builds that support iOS supported orientations for >1.10.0
-// to invalidate old builds that do not have supportedInterfaceOrientations field
-const IOS_SUPPORTED_ORIENTATIONS_KEY = "ios_supported_orientations";
-const IOS_BUILD_CACHE_KEY =
-  BASE_IOS_BUILD_CACHE_KEY + IPAD_SUPPORT_BUILD_CACHE_KEY + IOS_SUPPORTED_ORIENTATIONS_KEY;
+const GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX = "build-cache";
 
-export type BuildCacheInfo = {
-  fingerprint: string;
-  buildResult: AndroidBuildResult | IOSBuildResult;
-};
-
-function buildCacheKey(buildConfig: BuildConfig) {
-  const keyPrefix =
-    buildConfig.platform === DevicePlatform.Android ? ANDROID_BUILD_CACHE_KEY : IOS_BUILD_CACHE_KEY;
-
-  const buildConfigHash = crypto.createHash("md5");
-  buildConfigHash.update(stableStringify(buildConfig));
-  const hash = buildConfigHash.digest("hex");
-
-  return `${keyPrefix}:${hash}`;
+function globalStateKey(fingerprint: BuildFingerprint) {
+  return `${GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX}:${fingerprint}`;
 }
 
 export class BuildCache {
-  constructor(private readonly fingerprintProvider: FingerprintProvider) {}
-
   /**
    * Passed fingerprint should be calculated at the time build is started.
    */
-  public async storeBuild(buildFingerprint: string, buildConfig: BuildConfig, build: BuildResult) {
-    await extensionContext.globalState.update(buildCacheKey(buildConfig), {
-      fingerprint: buildFingerprint,
-      buildResult: build,
-    });
+  public async storeBuild(build: BuildResult) {
+    await extensionContext.globalState.update(globalStateKey(build.fingerprint), build);
+    // we expect store build not to happen frequently (we only call it after ssucesfull builds which typically takes some time)
+    // therefore we use this place to fire cache GC asynchronously (no await)
+    this.collectGarbageCacheEntriesNow();
   }
 
-  public async clearCache(cacheKey: BuildConfig) {
-    await extensionContext.globalState.update(buildCacheKey(cacheKey), undefined);
+  public async clearCache(fingerprint: BuildFingerprint) {
+    await extensionContext.globalState.update(globalStateKey(fingerprint), undefined);
   }
 
-  public async getBuild(currentFingerprint: string, buildConfig: BuildConfig) {
-    const cache = extensionContext.globalState.get<BuildCacheInfo>(buildCacheKey(buildConfig));
-    if (!cache) {
+  private async collectGarbageCacheEntriesNow() {
+    const keys = await extensionContext.globalState.keys();
+    const keysToRemove = keys.filter((key) => key.startsWith(GLOBAL_STATE_BUILD_CACHE_KEY_PREFIX));
+    const buildResultsForAppPaths = new Map<string, [BuildResult]>();
+    const promises = [];
+
+    for (const key of keysToRemove) {
+      const cachedBuild = extensionContext.globalState.get<BuildResult>(key);
+      if (cachedBuild) {
+        // the GC logic tries to only check if the app artifact exists, it does not verify the
+        // hash of the artifact, unless there's a key collision.
+        // Key collision means that there are two distinct configurations with different
+        // fingerprints that produce the same app artifacts. In that case, we want to only
+        // keep the one with matching hash
+        // the GC logic only checks if the app artifact exists, it does not verify the
+        // hash of the artifacts as this is a more expensive operation and we rely on
+        // the build artifacts to be eventually wiped from the disk if not used.
+        const appPath =
+          cachedBuild.platform === DevicePlatform.Android
+            ? cachedBuild.apkPath
+            : cachedBuild.appPath;
+        const appExists = await fs.existsSync(appPath);
+        if (appExists) {
+          const appPaths = buildResultsForAppPaths.get(appPath);
+          if (appPaths) {
+            appPaths.push(cachedBuild);
+          } else {
+            buildResultsForAppPaths.set(appPath, [cachedBuild]);
+          }
+        } else {
+          promises.push(extensionContext.globalState.update(key, undefined));
+        }
+      }
+    }
+
+    for (const [appPath, buildResults] of buildResultsForAppPaths) {
+      if (buildResults.length > 1) {
+        // this means that there are multiple keys pointing to the same app artifact
+        // we need to calculate the hash of the app artifact and delete ones with different hashes
+        const appHash = await calculateAppArtifactHash(appPath);
+        buildResults.forEach((cachedBuild) => {
+          if (cachedBuild.buildHash !== appHash) {
+            promises.push(
+              extensionContext.globalState.update(
+                globalStateKey(cachedBuild.fingerprint),
+                undefined
+              )
+            );
+          }
+        });
+      }
+    }
+
+    await Promise.all(promises);
+  }
+
+  public async getBuild(fingerprint: BuildFingerprint) {
+    const cachedBuild = extensionContext.globalState.get<BuildResult>(globalStateKey(fingerprint));
+    if (!cachedBuild) {
       Logger.debug("No cached build found.");
       return undefined;
     }
 
-    const fingerprintsMatch = cache.fingerprint === currentFingerprint;
+    const fingerprintsMatch = cachedBuild.fingerprint === fingerprint;
     if (!fingerprintsMatch) {
       Logger.info(
-        `Fingerprint mismatch, cannot use cached build. Old: '${cache.fingerprint}', new: '${currentFingerprint}'.`
+        `Fingerprint mismatch, cannot use cached build. Old: '${cachedBuild.fingerprint}', new: '${fingerprint}'.`
       );
       return undefined;
     }
 
-    const build = cache.buildResult;
-    const appPath = build.platform === DevicePlatform.Android ? build.apkPath : build.appPath;
+    const appPath =
+      cachedBuild.platform === DevicePlatform.Android ? cachedBuild.apkPath : cachedBuild.appPath;
     try {
       const builtAppExists = fs.existsSync(appPath);
       if (!builtAppExists) {
@@ -82,32 +106,16 @@ export class BuildCache {
         return undefined;
       }
 
-      const appHash = await calculateAppHash(appPath);
-      const hashesMatch = appHash === build.buildHash;
+      const appHash = await calculateAppArtifactHash(appPath);
+      const hashesMatch = appHash === cachedBuild.buildHash;
       if (hashesMatch) {
         Logger.info("Using cached build.");
-        return build;
+        return cachedBuild;
       }
     } catch (e) {
       // we only log the error and ignore it to allow new build to start
       Logger.error("Error while attempting to load cached build: ", e);
       return undefined;
     }
-  }
-
-  public async calculateFingerprint(buildConfig: BuildConfig) {
-    return this.fingerprintProvider.calculateFingerprint(buildConfig);
-  }
-
-  public async isCacheStale(buildConfig: BuildConfig) {
-    const currentFingerprint = await this.calculateFingerprint(buildConfig);
-    const { fingerprint } =
-      extensionContext.globalState.get<BuildCacheInfo>(buildCacheKey(buildConfig)) ?? {};
-
-    return currentFingerprint !== fingerprint;
-  }
-
-  public hasCachedBuild(buildConfig: BuildConfig) {
-    return !!extensionContext.globalState.get<BuildCacheInfo>(buildCacheKey(buildConfig));
   }
 }

--- a/packages/vscode-extension/src/builders/BuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.test.ts
@@ -7,16 +7,8 @@ import { CustomBuild, EasConfig } from "../common/LaunchConfig";
 import { createBuildConfig, inferBuildType } from "./BuildManager";
 import * as ExpoGo from "./expoGo";
 import { ResolvedLaunchConfig } from "../project/ApplicationContext";
-import {
-  DevicePlatform,
-  DeviceInfo,
-  DeviceType,
-  AndroidDeviceInfo,
-  IOSDeviceInfo,
-} from "../common/State";
+import { DevicePlatform, DeviceType, AndroidDeviceInfo, IOSDeviceInfo } from "../common/State";
 import { DeviceBase } from "../devices/DeviceBase";
-import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
-import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 
 const APP_ROOT = "appRoot";
 const APP_ROOT_ABSOLUTE = "/appRoot";
@@ -193,7 +185,6 @@ describe("BuildManager", () => {
           for (const [buildType, launchConfig] of entries) {
             const mockDevice = Sinon.createStubInstance(DeviceBase);
 
-            // Override the getter properties
             Object.defineProperty(mockDevice, "platform", {
               get: () => platform,
             });

--- a/packages/vscode-extension/src/builders/BuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.test.ts
@@ -8,6 +8,7 @@ import { createBuildConfig, inferBuildType } from "./BuildManager";
 import * as ExpoGo from "./expoGo";
 import { ResolvedLaunchConfig } from "../project/ApplicationContext";
 import { DevicePlatform } from "../common/State";
+import { DeviceBase } from "../devices/DeviceBase";
 
 const APP_ROOT = "appRoot";
 const APP_ROOT_ABSOLUTE = "/appRoot";
@@ -166,7 +167,11 @@ describe("BuildManager", () => {
 
         it(`should include passed information`, async function () {
           launchConfigByType.entries().forEach(([buildType, launchConfig]) => {
-            const buildConfig = createBuildConfig(platform, false, launchConfig, buildType);
+            const device = {
+              id: "some-device",
+              platform,
+            };
+            const buildConfig = createBuildConfig(device, false, launchConfig, buildType);
             assert.equal(buildConfig.platform, platform);
             assert.equal(buildConfig.type, buildType);
             assert.equal(buildConfig.appRoot, APP_ROOT_ABSOLUTE);

--- a/packages/vscode-extension/src/builders/BuildManager.test.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.test.ts
@@ -7,8 +7,16 @@ import { CustomBuild, EasConfig } from "../common/LaunchConfig";
 import { createBuildConfig, inferBuildType } from "./BuildManager";
 import * as ExpoGo from "./expoGo";
 import { ResolvedLaunchConfig } from "../project/ApplicationContext";
-import { DevicePlatform } from "../common/State";
+import {
+  DevicePlatform,
+  DeviceInfo,
+  DeviceType,
+  AndroidDeviceInfo,
+  IOSDeviceInfo,
+} from "../common/State";
 import { DeviceBase } from "../devices/DeviceBase";
+import { AndroidEmulatorDevice } from "../devices/AndroidEmulatorDevice";
+import { IosSimulatorDevice } from "../devices/IosSimulatorDevice";
 
 const APP_ROOT = "appRoot";
 const APP_ROOT_ABSOLUTE = "/appRoot";
@@ -45,6 +53,36 @@ const COMMON_CONFIG: ResolvedLaunchConfig = {
   },
   usePrebuild: false,
 };
+
+const ANDROID_MOCK_DEVICE_INFO = {
+  id: "mock-device",
+  platform: DevicePlatform.Android,
+  avdId: "mock-avd-id",
+  modelId: "mock-model-id",
+  systemName: "mock-system",
+  displayName: "Mock Android Device",
+  deviceType: DeviceType.Phone,
+  available: true,
+} as AndroidDeviceInfo;
+
+const IOS_MOCK_DEVICE_INFO = {
+  id: "mock-device",
+  platform: DevicePlatform.IOS,
+  UDID: "mock-udid",
+  modelId: "mock-model-id",
+  systemName: "mock-system",
+  displayName: "Mock iOS Device",
+  deviceType: DeviceType.Phone,
+  available: true,
+  runtimeInfo: {
+    platform: DevicePlatform.IOS,
+    identifier: "mock-runtime-id",
+    name: "Mock iOS Runtime",
+    version: "0.0",
+    supportedDeviceTypes: [],
+    available: true,
+  },
+} as IOSDeviceInfo;
 
 describe("BuildManager", () => {
   Object.values(DevicePlatform).forEach((platform) => {
@@ -125,58 +163,53 @@ describe("BuildManager", () => {
       });
 
       describe("createBuildConfig", function () {
-        const launchConfigByType = new Map<BuildType, ResolvedLaunchConfig>([
-          [
-            BuildType.Custom,
-            {
-              ...COMMON_CONFIG,
-              customBuild: toPlatformConfig(platform, CUSTOM_BUILD_CONFIG),
-            },
-          ],
-          [
-            BuildType.Eas,
-            {
-              ...COMMON_CONFIG,
-              eas: toPlatformConfig(platform, EAS_CONFIG),
-            },
-          ],
-          [
-            BuildType.EasLocal,
-            {
-              ...COMMON_CONFIG,
-              eas: toPlatformConfig(platform, EAS_LOCAL_CONFIG),
-            },
-          ],
-          [
-            BuildType.ExpoGo,
-            {
-              ...COMMON_CONFIG,
-            },
-          ],
-          [
-            BuildType.Local,
-            {
-              ...COMMON_CONFIG,
-              env: {
-                OPTION: "value",
-                ANOTHER_OPTION: "another value",
-              },
-            },
-          ],
-        ]);
+        const launchConfigByType = new Map<BuildType, ResolvedLaunchConfig>();
+        launchConfigByType.set(BuildType.Custom, {
+          ...COMMON_CONFIG,
+          customBuild: toPlatformConfig(platform, CUSTOM_BUILD_CONFIG),
+        });
+        launchConfigByType.set(BuildType.Eas, {
+          ...COMMON_CONFIG,
+          eas: toPlatformConfig(platform, EAS_CONFIG),
+        });
+        launchConfigByType.set(BuildType.EasLocal, {
+          ...COMMON_CONFIG,
+          eas: toPlatformConfig(platform, EAS_LOCAL_CONFIG),
+        });
+        launchConfigByType.set(BuildType.ExpoGo, {
+          ...COMMON_CONFIG,
+        });
+        launchConfigByType.set(BuildType.Local, {
+          ...COMMON_CONFIG,
+          env: {
+            OPTION: "value",
+            ANOTHER_OPTION: "another value",
+          },
+        });
 
         it(`should include passed information`, async function () {
-          launchConfigByType.entries().forEach(([buildType, launchConfig]) => {
-            const device = {
-              id: "some-device",
-              platform,
-            };
-            const buildConfig = createBuildConfig(device, false, launchConfig, buildType);
+          // Test all build types to ensure they all work correctly
+          const entries = Array.from(launchConfigByType.entries());
+          for (const [buildType, launchConfig] of entries) {
+            const mockDevice = Sinon.createStubInstance(DeviceBase);
+
+            // Override the getter properties
+            Object.defineProperty(mockDevice, "platform", {
+              get: () => platform,
+            });
+            Object.defineProperty(mockDevice, "deviceInfo", {
+              get: () =>
+                platform === DevicePlatform.Android
+                  ? ANDROID_MOCK_DEVICE_INFO
+                  : IOS_MOCK_DEVICE_INFO,
+            });
+
+            const buildConfig = createBuildConfig(mockDevice, launchConfig, buildType);
             assert.equal(buildConfig.platform, platform);
             assert.equal(buildConfig.type, buildType);
             assert.equal(buildConfig.appRoot, APP_ROOT_ABSOLUTE);
             assert.equal(buildConfig.env, launchConfig.env);
-          });
+          }
         });
       });
     });

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -68,7 +68,6 @@ export function createBuildConfig(
           type: BuildType.Local,
           scheme: ios?.scheme,
           configuration: ios?.configuration,
-          runtimeId: runtime.identifier,
           fingerprintCommand,
           usePrebuild,
         };

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import semver from "semver";
-import { OutputChannel } from "vscode";
 import loadConfig from "@react-native-community/cli-config";
 import { getNativeABI } from "../utilities/common";
 import { ANDROID_HOME, findJavaHome } from "../utilities/android";

--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import semver from "semver";
 import loadConfig from "@react-native-community/cli-config";
-import { calculateAppHash, getNativeABI } from "../utilities/common";
+import { calculateAppArtifactHash, getNativeABI } from "../utilities/common";
 import { ANDROID_HOME, findJavaHome } from "../utilities/android";
 import { Logger } from "../Logger";
 import { exec, lineReader } from "../utilities/subprocess";
@@ -109,7 +109,7 @@ export async function buildAndroid(
         apkPath,
         packageName: await extractPackageName(apkPath, cancelToken),
         platform: DevicePlatform.Android,
-        buildHash: await calculateAppHash(apkPath),
+        buildHash: await calculateAppArtifactHash(apkPath),
       };
     }
     case BuildType.Eas: {
@@ -128,7 +128,7 @@ export async function buildAndroid(
         apkPath,
         packageName: await extractPackageName(apkPath, cancelToken),
         platform: DevicePlatform.Android,
-        buildHash: await calculateAppHash(apkPath),
+        buildHash: await calculateAppArtifactHash(apkPath),
       };
     }
     case BuildType.EasLocal: {
@@ -147,7 +147,7 @@ export async function buildAndroid(
         apkPath,
         packageName: await extractPackageName(apkPath, cancelToken),
         platform: DevicePlatform.Android,
-        buildHash: await calculateAppHash(apkPath),
+        buildHash: await calculateAppArtifactHash(apkPath),
       };
     }
     case BuildType.ExpoGo: {
@@ -159,7 +159,7 @@ export async function buildAndroid(
         apkPath,
         packageName: EXPO_GO_PACKAGE_NAME,
         platform: DevicePlatform.Android,
-        buildHash: await calculateAppHash(apkPath),
+        buildHash: await calculateAppArtifactHash(apkPath),
       };
     }
     case BuildType.Local: {
@@ -233,7 +233,7 @@ async function buildLocal(
     return {
       ...apkInfo,
       platform: DevicePlatform.Android,
-      buildHash: await calculateAppHash(apkInfo.apkPath),
+      buildHash: await calculateAppArtifactHash(apkInfo.apkPath),
     };
   } catch (e) {
     Logger.error("Failed to extract package name from APK", e);

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -1,5 +1,4 @@
 import path from "path";
-import { OutputChannel } from "vscode";
 import { exec, lineReader } from "../utilities/subprocess";
 import { Logger } from "../Logger";
 import { CancelToken } from "../utilities/cancelToken";

--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -7,7 +7,7 @@ import { EXPO_GO_BUNDLE_ID, downloadExpoGo } from "./expoGo";
 import { findXcodeProject, findXcodeScheme, IOSProjectInfo } from "../utilities/xcode";
 import { runExternalBuild } from "./customBuild";
 import { fetchEasBuild, performLocalEasBuild } from "./eas";
-import { calculateAppHash, calculateMD5, getXcodebuildArch } from "../utilities/common";
+import { calculateAppArtifactHash, calculateMD5, getXcodebuildArch } from "../utilities/common";
 import { getTelemetryReporter } from "../utilities/telemetry";
 import { BuildType, IOSBuildConfig, IOSLocalBuildConfig } from "../common/BuildConfig";
 import { DevicePlatform } from "../common/State";
@@ -140,7 +140,7 @@ export async function buildIos(
         bundleID: await getBundleID(appPath),
         supportedInterfaceOrientations: await getSupportedInterfaceOrientations(appPath),
         platform: DevicePlatform.IOS,
-        buildHash: await calculateAppHash(appPath),
+        buildHash: await calculateAppArtifactHash(appPath),
       };
     }
     case BuildType.Eas: {
@@ -161,7 +161,7 @@ export async function buildIos(
         bundleID: await getBundleID(appPath),
         supportedInterfaceOrientations: await getSupportedInterfaceOrientations(appPath),
         platform: DevicePlatform.IOS,
-        buildHash: await calculateAppHash(appPath),
+        buildHash: await calculateAppArtifactHash(appPath),
       };
     }
     case BuildType.EasLocal: {
@@ -181,7 +181,7 @@ export async function buildIos(
         bundleID: await getBundleID(appPath),
         supportedInterfaceOrientations: await getSupportedInterfaceOrientations(appPath),
         platform: DevicePlatform.IOS,
-        buildHash: await calculateAppHash(appPath),
+        buildHash: await calculateAppArtifactHash(appPath),
       };
     }
     case BuildType.ExpoGo: {
@@ -195,7 +195,7 @@ export async function buildIos(
         bundleID: EXPO_GO_BUNDLE_ID,
         supportedInterfaceOrientations,
         platform: DevicePlatform.IOS,
-        buildHash: await calculateAppHash(appPath),
+        buildHash: await calculateAppArtifactHash(appPath),
       };
     }
     case BuildType.Local: {

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -49,7 +49,6 @@ export type IOSLocalBuildConfig = {
   usePrebuild: boolean;
   scheme?: string;
   configuration?: string;
-  runtimeId: string;
 } & BuildConfigCommon;
 
 export type BuildConfig =

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -1,3 +1,4 @@
+import { JSONValue } from "../utilities/json";
 import { DevicePlatform } from "./State";
 
 export enum BuildType {
@@ -8,13 +9,12 @@ export enum BuildType {
   Custom = "custom",
 }
 
-interface BuildConfigCommon {
+type BuildConfigCommon = {
   appRoot: string;
   platform: DevicePlatform;
   env?: Record<string, string>;
-  forceCleanBuild: boolean;
   fingerprintCommand?: string;
-}
+};
 
 export type CustomBuildConfig = {
   type: BuildType.Custom;
@@ -38,7 +38,6 @@ export type EasLocalBuildConfig = {
 export type AndroidLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.Android;
-  forceCleanBuild: boolean;
   usePrebuild: boolean;
   buildType?: string;
   productFlavor?: string;
@@ -47,10 +46,10 @@ export type AndroidLocalBuildConfig = {
 export type IOSLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.IOS;
-  forceCleanBuild: boolean;
   usePrebuild: boolean;
   scheme?: string;
   configuration?: string;
+  runtimeId: string;
 } & BuildConfigCommon;
 
 export type BuildConfig =
@@ -72,3 +71,6 @@ type SupportedAndroidBuildType = AndroidBuildConfig["type"];
 type SupportedBuildType = SupportedIOSBuildType & SupportedAndroidBuildType;
 
 type _SupportsAllBuildTypes = IsSuperTypeOf<SupportedBuildType, BuildType>;
+
+// verify that the build config types are json-serializable:
+type _EnsureJSONSerializable = IsSuperTypeOf<JSONValue, BuildConfig>;

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -85,7 +85,7 @@ type DeviceSessionStateCommon = {
   previewURL: string | undefined;
   navigationHistory: NavigationHistoryItem[];
   navigationRouteList: NavigationRoute[];
-  hasStaleBuildCache: boolean;
+  isUsingStaleBuild: boolean;
   isRecordingScreen: boolean;
 };
 

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -144,7 +144,7 @@ export type IOSDeviceInfo = {
   displayName: string;
   available: boolean;
   deviceType: DeviceType;
-  runtimeInfo: IOSRuntimeInfo;
+  runtimeInfo?: IOSRuntimeInfo;
 };
 
 export type AndroidSystemImageInfo = {

--- a/packages/vscode-extension/src/dependency/pods.ts
+++ b/packages/vscode-extension/src/dependency/pods.ts
@@ -1,9 +1,11 @@
 import fs from "fs";
 import path from "path";
-import { OutputChannel, Disposable } from "vscode";
+import { Disposable } from "vscode";
 import { command, lineReader } from "../utilities/subprocess";
 import { CancelToken } from "../utilities/cancelToken";
 import { getIosSourceDir } from "../builders/buildIOS";
+import { BuildConfig } from "../common/BuildConfig";
+import { BuildOptions } from "../builders/BuildManager";
 
 /**
  * Utility class for managing CocoaPods dependencies in an iOS project workspace.
@@ -46,7 +48,8 @@ export class Pods implements Disposable {
    * @param outputChannel - The channel to which installation output will be appended.
    * @param cancelToken - A token that can be used to cancel the pod installation process.
    */
-  public async installPods(outputChannel: OutputChannel, cancelToken: CancelToken): Promise<void> {
+  public async installPods(buildOptions: BuildOptions) {
+    const { cancelToken, buildOutputChannel } = buildOptions;
     if (this.podsInstallationProcess) {
       this.podsInstallationProcess.cancelToken.cancel();
     }
@@ -76,7 +79,7 @@ export class Pods implements Disposable {
         cwd: iosDirPath,
         env: { ...env, LANG: "en_US.UTF-8" },
       });
-      lineReader(process).onLineRead((line) => outputChannel.appendLine(line));
+      lineReader(process).onLineRead((line) => buildOutputChannel.appendLine(line));
       await cancelToken.adapt(process);
     } finally {
       this.podsInstallationProcess = undefined;

--- a/packages/vscode-extension/src/dependency/pods.ts
+++ b/packages/vscode-extension/src/dependency/pods.ts
@@ -4,7 +4,6 @@ import { Disposable } from "vscode";
 import { command, lineReader } from "../utilities/subprocess";
 import { CancelToken } from "../utilities/cancelToken";
 import { getIosSourceDir } from "../builders/buildIOS";
-import { BuildConfig } from "../common/BuildConfig";
 import { BuildOptions } from "../builders/BuildManager";
 
 /**

--- a/packages/vscode-extension/src/dependency/prebuild.ts
+++ b/packages/vscode-extension/src/dependency/prebuild.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { Disposable, OutputChannel } from "vscode";
 import { exec } from "../utilities/subprocess";
-import { BuildError } from "../builders/BuildManager";
+import { BuildError, BuildOptions } from "../builders/BuildManager";
 import { IOSLocalBuildConfig, AndroidLocalBuildConfig } from "../common/BuildConfig";
 import { DevicePlatform } from "../common/State";
 import { FingerprintProvider } from "../project/FingerprintProvider";
@@ -65,9 +65,9 @@ export class Prebuild implements Disposable {
 
   public async runPrebuildIfNeeded(
     buildConfig: IOSLocalBuildConfig | AndroidLocalBuildConfig,
-    outputChannel: OutputChannel,
-    cancelToken: CancelToken
+    buildOptions: BuildOptions
   ) {
+    const { forceCleanBuild, cancelToken } = buildOptions;
     const [currentFingerprint, nativeDirectoryExists] = await Promise.all([
       this.fingerprintProvider.calculateFingerprint(buildConfig),
       checkNativeDirectoryExists(buildConfig.appRoot, buildConfig.platform),
@@ -82,9 +82,7 @@ export class Prebuild implements Disposable {
     const isCurrentlyPrebuilding = ongoingPrebuild !== undefined;
 
     const canSkipPrebuild =
-      !buildConfig.forceCleanBuild &&
-      nativeDirectoryExists &&
-      (hasAlreadyPrebuild || isCurrentlyPrebuilding);
+      !forceCleanBuild && nativeDirectoryExists && (hasAlreadyPrebuild || isCurrentlyPrebuilding);
     if (canSkipPrebuild) {
       if (isCurrentlyPrebuilding) {
         ongoingPrebuild.attach(cancelToken);
@@ -100,7 +98,7 @@ export class Prebuild implements Disposable {
 
     const prebuildCancelToken = new CancelToken();
     const prebuildProcess = new PrebuildProcess(
-      this.runPrebuild(buildConfig, outputChannel, prebuildCancelToken),
+      this.runPrebuild(buildConfig, buildOptions, prebuildCancelToken),
       prebuildCancelToken
     );
     prebuildProcess.attach(cancelToken);
@@ -121,9 +119,10 @@ export class Prebuild implements Disposable {
 
   private async runPrebuild(
     buildConfig: IOSLocalBuildConfig | AndroidLocalBuildConfig,
-    outputChannel: OutputChannel,
+    buildOptions: BuildOptions,
     cancelToken: CancelToken
   ) {
+    const { buildOutputChannel, forceCleanBuild } = buildOptions;
     const appRoot = buildConfig.appRoot;
     const cliPath = getExpoCliPath(appRoot);
     if (!cliPath) {
@@ -136,7 +135,7 @@ export class Prebuild implements Disposable {
     const args = [cliPath, "prebuild", "-p", platform];
     // NOTE: We handle installing node dependencies and pods ourselves, so we skip it in the prebuild.
     args.push("--no-install");
-    if (buildConfig.forceCleanBuild) {
+    if (forceCleanBuild) {
       args.push("--clean");
     }
 
@@ -147,7 +146,7 @@ export class Prebuild implements Disposable {
     const process = exec("node", args, { cwd: appRoot });
 
     lineReader(process).onLineRead((line) => {
-      outputChannel.appendLine(line);
+      buildOutputChannel.appendLine(line);
     });
 
     await cancelToken.adapt(process);

--- a/packages/vscode-extension/src/dependency/prebuild.ts
+++ b/packages/vscode-extension/src/dependency/prebuild.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { Disposable, OutputChannel } from "vscode";
+import { Disposable } from "vscode";
 import { exec } from "../utilities/subprocess";
 import { BuildError, BuildOptions } from "../builders/BuildManager";
 import { IOSLocalBuildConfig, AndroidLocalBuildConfig } from "../common/BuildConfig";

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -65,7 +65,7 @@ export class DeviceManager implements Disposable {
         throw new Error("Invalid platform. Expected macos.");
       }
 
-      const simulators = await listSimulators(SimulatorDeviceSet.RN_IDE);
+      const simulators = await listSimulators();
       const simulatorInfo = simulators.find((device) => device.id === deviceInfo.id);
       if (!simulatorInfo || simulatorInfo.platform !== DevicePlatform.IOS) {
         throw new Error(`Simulator ${deviceInfo.id} not found`);
@@ -139,7 +139,7 @@ export class DeviceManager implements Disposable {
     }
 
     const simulators = shouldLoadSimulators
-      ? listSimulators(SimulatorDeviceSet.RN_IDE).catch((e) => {
+      ? listSimulators().catch((e) => {
           Logger.error("Error fetching simulators", e);
           return [];
         })

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -65,7 +65,7 @@ export class DeviceManager implements Disposable {
         throw new Error("Invalid platform. Expected macos.");
       }
 
-      const simulators = await listSimulators();
+      const simulators = await listSimulators(SimulatorDeviceSet.RN_IDE);
       const simulatorInfo = simulators.find((device) => device.id === deviceInfo.id);
       if (!simulatorInfo || simulatorInfo.platform !== DevicePlatform.IOS) {
         throw new Error(`Simulator ${deviceInfo.id} not found`);
@@ -139,7 +139,7 @@ export class DeviceManager implements Disposable {
     }
 
     const simulators = shouldLoadSimulators
-      ? listSimulators().catch((e) => {
+      ? listSimulators(SimulatorDeviceSet.RN_IDE).catch((e) => {
           Logger.error("Error fetching simulators", e);
           return [];
         })

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -610,7 +610,9 @@ async function listSimulatorsForLocation(location?: string) {
   return [];
 }
 
-export async function listSimulators(location: SimulatorDeviceSet): Promise<IOSDeviceInfo[]> {
+export async function listSimulators(
+  location: SimulatorDeviceSet = SimulatorDeviceSet.RN_IDE
+): Promise<IOSDeviceInfo[]> {
   let devicesPerRuntime;
   if (location === SimulatorDeviceSet.RN_IDE) {
     const deviceSetLocation = getOrCreateDeviceSet();
@@ -643,7 +645,7 @@ export async function listSimulators(location: SimulatorDeviceSet): Promise<IOSD
             ? DeviceType.Tablet
             : DeviceType.Phone,
           available: device.isAvailable ?? false,
-          runtimeInfo: runtime,
+          runtimeInfo: runtime!,
         };
       });
     })
@@ -656,13 +658,13 @@ export enum SimulatorDeviceSet {
   RN_IDE,
 }
 
-export async function createSimulatorWithRuntimeId(
-  deviceTypeId: string,
+export async function createSimulator(
+  modelId: string,
   displayName: string,
-  runtimeId: string,
+  runtime: IOSRuntimeInfo,
   deviceSet: SimulatorDeviceSet
 ) {
-  Logger.debug(`Create simulator ${deviceTypeId} with runtime ${runtimeId}`);
+  Logger.debug(`Create simulator ${modelId} with runtime ${runtime.identifier}`);
 
   let locationArgs: string[] = [];
   if (deviceSet === SimulatorDeviceSet.RN_IDE) {
@@ -676,31 +678,15 @@ export async function createSimulatorWithRuntimeId(
     ...locationArgs,
     "create",
     displayName,
-    deviceTypeId,
-    runtimeId,
-  ]);
-
-  return UDID;
-}
-
-export async function createSimulator(
-  deviceTypeId: string,
-  displayName: string,
-  runtime: IOSRuntimeInfo,
-  deviceSet: SimulatorDeviceSet
-) {
-  const UDID = await createSimulatorWithRuntimeId(
-    deviceTypeId,
-    displayName,
+    modelId,
     runtime.identifier,
-    deviceSet
-  );
+  ]);
 
   return {
     id: `ios-${UDID}`,
     platform: DevicePlatform.IOS,
     UDID,
-    modelId: deviceTypeId,
+    modelId: modelId,
     systemName: runtime.name,
     displayName: displayName,
     available: true, // assuming if create command went through, it's available

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -610,9 +610,7 @@ async function listSimulatorsForLocation(location?: string) {
   return [];
 }
 
-export async function listSimulators(
-  location: SimulatorDeviceSet = SimulatorDeviceSet.RN_IDE
-): Promise<IOSDeviceInfo[]> {
+export async function listSimulators(location: SimulatorDeviceSet): Promise<IOSDeviceInfo[]> {
   let devicesPerRuntime;
   if (location === SimulatorDeviceSet.RN_IDE) {
     const deviceSetLocation = getOrCreateDeviceSet();
@@ -645,7 +643,7 @@ export async function listSimulators(
             ? DeviceType.Tablet
             : DeviceType.Phone,
           available: device.isAvailable ?? false,
-          runtimeInfo: runtime!,
+          runtimeInfo: runtime,
         };
       });
     })
@@ -658,13 +656,13 @@ export enum SimulatorDeviceSet {
   RN_IDE,
 }
 
-export async function createSimulator(
-  modelId: string,
+export async function createSimulatorWithRuntimeId(
+  deviceTypeId: string,
   displayName: string,
-  runtime: IOSRuntimeInfo,
+  runtimeId: string,
   deviceSet: SimulatorDeviceSet
 ) {
-  Logger.debug(`Create simulator ${modelId} with runtime ${runtime.identifier}`);
+  Logger.debug(`Create simulator ${deviceTypeId} with runtime ${runtimeId}`);
 
   let locationArgs: string[] = [];
   if (deviceSet === SimulatorDeviceSet.RN_IDE) {
@@ -678,15 +676,31 @@ export async function createSimulator(
     ...locationArgs,
     "create",
     displayName,
-    modelId,
-    runtime.identifier,
+    deviceTypeId,
+    runtimeId,
   ]);
+
+  return UDID;
+}
+
+export async function createSimulator(
+  deviceTypeId: string,
+  displayName: string,
+  runtime: IOSRuntimeInfo,
+  deviceSet: SimulatorDeviceSet
+) {
+  const UDID = await createSimulatorWithRuntimeId(
+    deviceTypeId,
+    displayName,
+    runtime.identifier,
+    deviceSet
+  );
 
   return {
     id: `ios-${UDID}`,
     platform: DevicePlatform.IOS,
     UDID,
-    modelId: modelId,
+    modelId: deviceTypeId,
     systemName: runtime.name,
     displayName: displayName,
     available: true, // assuming if create command went through, it's available

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -434,7 +434,7 @@ export class IosSimulatorDevice extends DeviceBase {
   }
 
   async launchApp(
-    build: IOSBuildResult,
+    build: BuildResult,
     metroPort: number,
     _devtoolsPort: number,
     launchArguments: string[]

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -81,14 +81,16 @@ export class ApplicationContext implements Disposable {
     launchConfig: LaunchConfiguration,
     fingerprintProvider: FingerprintProvider
   ) {
-    this.buildCache = new BuildCache(fingerprintProvider);
+    this.buildCache = new BuildCache();
     this.launchConfig = resolveLaunchConfig(launchConfig);
     this.applicationDependencyManager = new ApplicationDependencyManager(
       this.stateManager.getDerived("applicationDependencies"),
       this.launchConfig,
       fingerprintProvider
     );
-    const buildManager = new BatchingBuildManager(new BuildManagerImpl(this.buildCache));
+    const buildManager = new BatchingBuildManager(
+      new BuildManagerImpl(this.buildCache, fingerprintProvider)
+    );
     this.buildManager = buildManager;
 
     this.disposables.push(this.applicationDependencyManager, buildManager);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -35,14 +35,12 @@ import { getTelemetryReporter } from "../utilities/telemetry";
 import { CancelError, CancelToken } from "../utilities/cancelToken";
 import { ToolKey } from "./tools";
 import { ApplicationContext } from "./ApplicationContext";
-import { BuildCache } from "../builders/BuildCache";
 import { watchProjectFiles } from "../utilities/watchProjectFiles";
 import { OutputChannelRegistry } from "./OutputChannelRegistry";
 import { Output } from "../common/OutputChannel";
 import { ApplicationSession } from "./applicationSession";
 import { DevicePlatform, DeviceSessionStore } from "../common/State";
 import { ReloadAction } from "./DeviceSessionsManager";
-import { BuildConfig } from "../common/BuildConfig";
 import { StateManager } from "./StateManager";
 import { FrameReporter } from "./FrameReporter";
 import { disposeAll } from "../utilities/disposables";
@@ -75,10 +73,8 @@ export class DeviceSession implements Disposable {
   private maybeBuildResult: BuildResult | undefined;
   private devtools: Devtools;
   private buildManager: BuildManager;
-  private buildCache: BuildCache;
   private cancelToken: CancelToken = new CancelToken();
   private watchProjectSubscription: Disposable;
-  private lastSuccessfulBuildConfig?: BuildConfig;
   private frameReporter: FrameReporter;
 
   private status: DeviceSessionStatus = "starting";
@@ -129,7 +125,6 @@ export class DeviceSession implements Disposable {
     this.metro = new MetroLauncher(this.devtools);
     this.metro.onBundleProgress(({ bundleProgress }) => this.onBundleProgress(bundleProgress));
 
-    this.buildCache = this.applicationContext.buildCache;
     this.buildManager = this.applicationContext.buildManager;
 
     this.watchProjectSubscription = watchProjectFiles(this.onProjectFilesChanged);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -433,14 +433,6 @@ export class DeviceSession implements Disposable {
       platform: this.platform,
     });
 
-    const launchConfig = this.applicationContext.launchConfig;
-    const platformKey = this.platform === DevicePlatform.IOS ? "ios" : "android";
-    const fingerprintOptions = {
-      appRoot: this.applicationContext.appRootFolder,
-      env: launchConfig.env,
-      fingerprintCommand: launchConfig.customBuild?.[platformKey]?.fingerprintCommand,
-    };
-
     this.resetStartingState();
     const buildConfig = this.buildConfig;
     if (buildConfig && (await this.buildCache.isCacheStale(buildConfig))) {

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import WebSocket from "ws";
 import { Disposable, EventEmitter, ExtensionMode, Uri, workspace } from "vscode";
 import stripAnsi from "strip-ansi";
-import { exec, ChildProcess, lineReader, execSync } from "../utilities/subprocess";
+import { exec, ChildProcess, lineReader } from "../utilities/subprocess";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { shouldUseExpoCLI } from "../utilities/expoCli";

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import WebSocket from "ws";
 import { Disposable, EventEmitter, ExtensionMode, Uri, workspace } from "vscode";
 import stripAnsi from "strip-ansi";
-import { exec, ChildProcess, lineReader } from "../utilities/subprocess";
+import { exec, ChildProcess, lineReader, execSync } from "../utilities/subprocess";
 import { Logger } from "../Logger";
 import { extensionContext } from "../utilities/extensionContext";
 import { shouldUseExpoCLI } from "../utilities/expoCli";

--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -235,7 +235,10 @@ export async function calculateMD5(fsPath: string, hash: Hash = createHash("md5"
   return hash;
 }
 
-export async function calculateAppHash(appPath: string) {
+/**
+ * Calculates the md5 hash of the app artifact.
+ */
+export async function calculateAppArtifactHash(appPath: string) {
   const hash = createHash("md5");
   await calculateMD5(appPath, hash);
   return hash.digest("hex");

--- a/packages/vscode-extension/src/utilities/json.ts
+++ b/packages/vscode-extension/src/utilities/json.ts
@@ -5,4 +5,4 @@ export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
 export interface JSONObject {
   [key: string]: JSONValue;
 }
-export interface JSONArray extends Array<JSONValue> {}
+export type JSONArray = Array<JSONValue>;

--- a/packages/vscode-extension/src/utilities/json.ts
+++ b/packages/vscode-extension/src/utilities/json.ts
@@ -1,0 +1,8 @@
+// Helper types for verifying JSON-serializable objects
+
+export type JSONPrimitive = string | number | boolean | null;
+export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+export interface JSONObject {
+  [key: string]: JSONValue;
+}
+export interface JSONArray extends Array<JSONValue> {}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -496,10 +496,10 @@ function Preview({
   }, [project, shouldPreventInputEvents]);
 
   useEffect(() => {
-    if (selectedDeviceSession?.hasStaleBuildCache) {
+    if (selectedDeviceSession?.isUsingStaleBuild) {
       openRebuildAlert();
     }
-  }, [selectedDeviceSession?.hasStaleBuildCache]);
+  }, [selectedDeviceSession?.isUsingStaleBuild]);
 
   const device = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
     return sd.modelId === selectedDeviceSession?.deviceInfo.modelId;


### PR DESCRIPTION
This PR refactors the build logic to let the build configuration access the device instance. In particular, `xcodebuild` may need to know the device it builds for. But also to address two main flows of the build strategy:
1) The current implementations leaves orphaned entries in the global state. The reason is that the cache key depends on some parameters that can be adjusted by the user and in particular we also changed the key prefix recently when we added support for iPads.
2) We currently use too few parameters for fingerprinting and hence it may happen that we will attempt to reuse a build that should not be reused. In particular, we only use a subset of launch config options while all of them may impact the output of the build process.

To address the above, we are introducing a new concept of build fingerprint. Build fingerprint is an extension of the fingerprinting mechanism we used before, but also include the additional parameters that can impact the build process and are specific to Radon. The idea is that build fingerpring should represent all input that took part in producing the build artifact. This includes the project fingerprint (representing all the native code and dependencies), but also the build settings and environment constants that are set in the launch configuration.

To calculate the build fingerprint we therefore take the project fingerprint and add a deterministic hash of the build configuration. We also place a platform prefix in front for the fingerprint to be better readable.

In order to manage the build cache, we are introducing a new GC mechanism. GC scans the entries in global store and tries to delete ones that no longer has corresponding backing build artifacts. We also consider the case where many keys point to a single build artifact, in which case we cleanup the ones that expect a different artifact hash.

Finally, In order for build config to remain stable, we had to remove `forceCleanBuild` from it and move it to `BuildOption`. This is an option that can be set for some builds and not for others, and does not impact the build artifact but only forces executing the build even if the fingerprint matches.

### Test plan
1) run iOS and Android builds
2) try force clean build option
3) make sure cached builds are used after restarting the IDE
4) run unit tests
