### PR TITLE
feat: custom bundler port configuration 

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -483,6 +483,16 @@
                 "type": "string",
                 "description": "Location of Metro config relative to the workspace. This is used for customizing metro configuration for e.g. development."
               },
+              "bundler":{
+                "type": "object",
+                "description": "Configuration for the bundler used in your project.",
+                "properties": {
+                  "port": {
+                    "type": "number",
+                    "description": "Port to use for the bundler used in your project."
+                  }
+                }
+              },
               "expoStartArgs": {
                 "type": "array",
                 "description": "Extra arguments to pass to Expo start command."
@@ -704,6 +714,16 @@
               "metroConfigPath": {
                 "type": "string",
                 "description": "Location of Metro config relative to the workspace. This is used for customizing metro configuration for e.g. development."
+              },
+              "bundler":{
+                "type": "object",
+                "description": "Configuration for the bundler used in your project.",
+                "properties": {
+                  "port": {
+                    "type": "number",
+                    "description": "Port to use for the bundler used in your project."
+                  }
+                }
               },
               "expoStartArgs": {
                 "type": "array",

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -11,6 +11,9 @@ export interface LaunchOptions {
   name?: string;
   appRoot?: string;
   metroConfigPath?: string;
+  bundler?: {
+    port?: number;
+  };
   expoStartArgs?: string[];
   customBuild?: {
     ios?: CustomBuild;
@@ -35,6 +38,7 @@ export const LAUNCH_OPTIONS_KEYS = [
   "name",
   "appRoot",
   "metroConfigPath",
+  "bundler",
   "expoStartArgs",
   "customBuild",
   "eas",

--- a/packages/vscode-extension/src/utilities/checkPortOpen.ts
+++ b/packages/vscode-extension/src/utilities/checkPortOpen.ts
@@ -1,0 +1,27 @@
+import net from "node:net";
+
+export async function checkPortOpen(host: string, port: number, timeout = 3000) {
+  return new Promise((resolve, _) => {
+    const socket = new net.Socket();
+
+    const onError = (e: Error) => {
+      socket.destroy();
+      console.log(`Error: ${e.message}`);
+      resolve(false);
+    };
+
+    socket.setTimeout(timeout);
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+
+    socket.once("error", onError);
+    socket.once("connect", () => {
+      socket.end();
+      resolve(true);
+    });
+
+    socket.connect(port, host);
+  });
+}


### PR DESCRIPTION
This is a draft of a feature that allows to specify metro or other bundlers port via launch configuration, as requested by #1367. 

The solution presented here would work in isolation, but would crash our multi-devices capabilities. To avoid that we consider: 
- blocking multi-device use if the custom port is selected 
- moving in the direction of "single bundler" approach instead of spawning a server for each device. 

the second solution seems more favorable  a specially in light of #910, but is risky and requires a lot of refactoring. 

### How Has This Been Tested: 

not relevant for draft 

### How Has This Change Been Documented:

wip


