### PR TITLE
Skip installing iOS app when it is already there

### DIFF
--- a/packages/vscode-extension/src/utilities/common.ts
+++ b/packages/vscode-extension/src/utilities/common.ts
@@ -235,6 +235,12 @@ export async function calculateMD5(fsPath: string, hash: Hash = createHash("md5"
   return hash;
 }
 
+export async function calculateAppHash(appPath: string) {
+  const hash = createHash("md5");
+  await calculateMD5(appPath, hash);
+  return hash.digest("hex");
+}
+
 export async function getOpenPort(): Promise<number> {
   const { promise, resolve, reject } = Promise.withResolvers<number>();
 


### PR DESCRIPTION
This PR implements a fast-path for the case when an app is already installed on iOS simulator.

App installation is one of the necessary step when starting Radon IDE. After looking into it, the test-apps typically install within 5-8 seconds on my Mac M2. This can be improved by skipping installation when the app is already installed.

This PR introduces a mechanism that allows us to determine if app in the exact installed form already exists:
1) we calculated md5 hash for the build directory that gives us the hash of the output
2) we use app container location (place in local filesystem where app is "installed")
3) we place a .dotfile with the hash in that directory
4) when testing whether app is installed, we take the hash of the new app, and compare it with what's in the .dotfile
5) this works, because when over-installing, simctl wipes out the whole app container directory and the newly installed app is located in a new directory (this holds true even if we install exactly the same app binary)

As a result, we replace 5-8sec installation step (on Mac M2) with the check which takes 0.3sec (on the same machine)

### How Has This Been Tested: 
1) install test app on iOS sim
2) restart IDE, see the installation takes less time (we print "skipping installation" in the logs)
3) test force re-installation which should print "App installed" message in logs
4) change something in app.json which result in the app rebuilding and you should see "app installed" message again.


