### PR TITLE
feat: allow sending certificate files to the iOS simulator

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -726,7 +726,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
     // No need to copy clipboard, Android Emulator syncs it for us whenever a user clicks on 'Copy'
   }
 
-  public async sendFile(filePath: string): Promise<void> {
+  public async sendFile(filePath: string) {
     const args = ["push", "-q", filePath, `/sdcard/Download/${path.basename(filePath)}`];
     await exec(ADB_PATH, ["-s", this.serial!, ...args]);
     // Notify the media scanner about the new file
@@ -742,6 +742,7 @@ export class AndroidEmulatorDevice extends DeviceBase {
       "-d",
       `file:///sdcard/Download`,
     ]);
+    return { canSafelyRemove: true };
   }
 }
 

--- a/packages/vscode-extension/src/devices/DeviceBase.ts
+++ b/packages/vscode-extension/src/devices/DeviceBase.ts
@@ -115,7 +115,11 @@ export abstract class DeviceBase implements Disposable {
   ): Promise<void>;
   abstract terminateApp(packageNameOrBundleID: string): Promise<void>;
   protected abstract makePreview(): Preview;
-  abstract sendFile(filePath: string): Promise<void>;
+
+  /**
+   * @returns whether the file can be safely removed after the operation finished.
+   */
+  abstract sendFile(filePath: string): Promise<{ canSafelyRemove: boolean }>;
   abstract get platform(): DevicePlatform;
   abstract get deviceInfo(): DeviceInfo;
   abstract resetAppPermissions(

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -521,7 +521,7 @@ export class IosSimulatorDevice extends DeviceBase {
     ]);
   }
 
-  public async sendFile(filePath: string): Promise<void> {
+  public async sendFile(filePath: string) {
     const fileExtension = path.extname(filePath);
     if (SUPPORTED_FILE_URL_EXTS.includes(fileExtension)) {
       await exec("xcrun", [
@@ -532,7 +532,7 @@ export class IosSimulatorDevice extends DeviceBase {
         this.deviceUDID,
         `file://${filePath}`,
       ]);
-      return;
+      return { canSafelyRemove: false };
     }
     if (!isMediaFile(filePath)) {
       throw new Error(
@@ -549,6 +549,7 @@ export class IosSimulatorDevice extends DeviceBase {
       filePath,
     ];
     await exec("xcrun", args);
+    return { canSafelyRemove: true };
   }
 }
 


### PR DESCRIPTION
Adds support for sending `.cer` and `.pem` files to iOS Simulator devices.
Closes #486

### How Has This Been Tested: 
- open an iOS device in Radon
- try sending a `.cer` or `.pem` file with a CA Certificate to the device (either by drag-n-dropping while holding Shift or using the "Send File" option in the device settings dropdown)
- Safari should open and ask you to install a "security profile"

### How Has This Change Been Documented:
WIP, waiting on #1456 