### PR TITLE
fix: system env variables impacting build caching

### DIFF
--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -39,7 +39,11 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
     // load the dotenv files for the project into `mergedEnv`
     const loadEnvResult = loadProjectEnv(absoluteAppRoot, { force: true, systemEnv: mergedEnv });
 
-    if (loadEnvResult.result === "loaded" && !_.isEqual(loadEnvResult.files, lastLoadedEnvFiles)) {
+    if (loadEnvResult.result !== "loaded") {
+      return configuredEnv;
+    }
+
+    if (!_.isEqual(loadEnvResult.files, lastLoadedEnvFiles)) {
       lastLoadedEnvFiles = loadEnvResult.files;
       Logger.info(
         `Project in "${appRoot}" loaded environment variables from .env files:`,
@@ -47,8 +51,7 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
       );
     }
 
-    // filter out any `undefined` values from the environment variables
-    const env = _.pickBy(mergedEnv, _.isString);
+    const env = { ...loadEnvResult.env, ...configuredEnv };
     return env;
   }
 


### PR DESCRIPTION
Currently we include the resolved environment variables in the build cache key in order to invalidate builds when the user changes something in their environment which can impact the build.
However, this causes issues with e.g. the `VSCODE_PID` variable which changes each time vscode is fully closed and restarted, as well as, presumably, similarly "temporary" variables set by the user's environment.
This PR changes that behaviour by only including the env variables configured in the project's `.env` files and Launch Configurations in the `env` record used throughout the code, including the Build Cache.

### How Has This Been Tested: 
- open an app in Radon
- add some env variable to the launch config
- add a `.env` file with some env variable set
- verify that changing either causes the app to be built again when restarting
