### PR TITLE
fix: suppress warning/errors from @expo/env

### DIFF
--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -37,7 +37,11 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
     const systemEnv = process.env as NodeJS.ProcessEnv;
     const mergedEnv = { ...systemEnv, ...configuredEnv };
     // load the dotenv files for the project into `mergedEnv`
-    const loadEnvResult = loadProjectEnv(absoluteAppRoot, { force: true, systemEnv: mergedEnv });
+    const loadEnvResult = loadProjectEnv(absoluteAppRoot, {
+      silent: true,
+      force: true,
+      systemEnv: mergedEnv,
+    });
 
     if (loadEnvResult.result !== "loaded") {
       return configuredEnv;


### PR DESCRIPTION
Fixes errors about missing configuration variables being logged by `@expo/env` whenever the env is being resolved.

### How Has This Been Tested: 
- start Radon in the extension development host
- verify no errors mentioning "NODE_ENV" are being logged to the debug console


