### PR TITLE
fix: cacheing ios installed applications

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -466,7 +466,6 @@ export class IosSimulatorDevice extends DeviceBase {
       ]);
       return path.join(appContainerLocation, ".radonide.buildhash");
     } catch (error) {
-      Logger.debug("[iosSimulatorDevice] Error locating app build hash file location:", error);
       return undefined;
     }
   }
@@ -486,10 +485,9 @@ export class IosSimulatorDevice extends DeviceBase {
 
   async updateInstalledAppBuildHash(build: IOSBuildResult) {
     const buildHashFileLocation = await this.locateInstalledAppBuildHashFile(build);
-    if (buildHashFileLocation === undefined) {
-      return;
+    if (buildHashFileLocation !== undefined) {
+      await fs.promises.writeFile(buildHashFileLocation, build.buildHash);
     }
-    await fs.promises.writeFile(buildHashFileLocation, build.buildHash);
   }
 
   async installApp(build: BuildResult, forceReinstall: boolean) {

--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -454,20 +454,28 @@ export class IosSimulatorDevice extends DeviceBase {
 
   async locateInstalledAppBuildHashFile(build: IOSBuildResult) {
     const deviceSetLocation = getOrCreateDeviceSet(this.deviceUDID);
-    const { stdout: appContainerLocation } = await exec("xcrun", [
-      "simctl",
-      "--set",
-      deviceSetLocation,
-      "get_app_container",
-      this.deviceUDID,
-      build.bundleID,
-      "app",
-    ]);
-    return path.join(appContainerLocation, ".radonide.buildhash");
+    try {
+      const { stdout: appContainerLocation } = await exec("xcrun", [
+        "simctl",
+        "--set",
+        deviceSetLocation,
+        "get_app_container",
+        this.deviceUDID,
+        build.bundleID,
+        "app",
+      ]);
+      return path.join(appContainerLocation, ".radonide.buildhash");
+    } catch (error) {
+      Logger.debug("[iosSimulatorDevice] Error locating app build hash file location:", error);
+      return undefined;
+    }
   }
 
   async checkInstalledAppBuildHashFile(build: IOSBuildResult) {
     const buildHashFileLocation = await this.locateInstalledAppBuildHashFile(build);
+    if (buildHashFileLocation === undefined) {
+      return null;
+    }
     try {
       const buildHash = await fs.promises.readFile(buildHashFileLocation, "utf8");
       return buildHash === build.buildHash;
@@ -478,6 +486,9 @@ export class IosSimulatorDevice extends DeviceBase {
 
   async updateInstalledAppBuildHash(build: IOSBuildResult) {
     const buildHashFileLocation = await this.locateInstalledAppBuildHashFile(build);
+    if (buildHashFileLocation === undefined) {
+      return;
+    }
     await fs.promises.writeFile(buildHashFileLocation, build.buildHash);
   }
 


### PR DESCRIPTION
This PR solves a problem with a new installed application cacheing system, which would throw an error if the application was never installed on the device before. 

### How Has This Been Tested: 

- create a new ios device 
- open any non expo go application 

### How Has This Change Been Documented:

internal change 


