### PR TITLE
Fix loading the app when launching with booted device

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -323,6 +323,24 @@ export class IosSimulatorDevice extends DeviceBase {
       // Delete command fails if the key doesn't exists, but later commands run regardless,
       // despite that process exits with non-zero code. We can ignore this error.
     }
+    try {
+      // Simulator may keep the defaults in memory with cfprefsd, we restart the deamon to make sure
+      // it reads the latest values from disk.
+      // We'd normally try to use defaults command that would write the updates via the daemon, however
+      // for some reason that doesn't work with custom device sets.
+      await exec("xcrun", [
+        "simctl",
+        "--set",
+        deviceSetLocation,
+        "spawn",
+        this.deviceUDID,
+        "launchctl",
+        "stop",
+        "com.apple.cfprefsd.xpc.daemon",
+      ]);
+    } catch (e) {
+      // ignore errors here and hope for the best
+    }
   }
 
   async terminateApp(bundleID: string) {


### PR DESCRIPTION
After #1464 we started noticing an error when loading the app after forced reboot of the Extension Devlopment Host for iOS. The error suggested that the device couldn't reach the packager.

The investigation shown, that the problem was due to the fact that the updates of metro port weren't propagated properly when the install step was skipped. This is due to the fact that iOS caches updates in cfprefs daemon and the app process reads from that daemon first. So updating the files wouldn't result in the daemon seeing it. The problem didn't surface before, as overinstalling the app would result in a new app container being created and therefore after launching the app, daemon would need to read from the disk anyway.

Apparently, we cannot use `defaults` command that talks with the daemon and also updates files, however, the command doesn't work with custom device set option for an unknown reason (it works ok on default device set though). We therefore found a workaround which is to shut down the cfprefs daemon and let system restart it with clean in-memory cache.

### How Has This Been Tested: 
1) run iOS example in development
2) use "restart" button to hard-reset the extension development window
3) open the app again
4) before this change the app would get stuck on loading (couldn't reach packager), after change the app loads normally

