### PR TITLE
fix: network inspector - payload and response tabs

### DIFF
--- a/packages/vscode-extension/lib/network.js
+++ b/packages/vscode-extension/lib/network.js
@@ -103,7 +103,6 @@ function deserializeDataContent(data, contentType) {
     return data;
   }
 
-  
   // Handle native typed Uint8Arrays
   if (data instanceof Uint8Array) {
     return shouldDecodeAsText(contentType) ? decode(data) : dataToBase64(data);
@@ -155,13 +154,15 @@ export function setup() {
 
   let enabled = false;
   messageBridge.addMessageListener("cdp-message", (message) => {
-    if (message.method === "Network.enable" && !enabled) {
-      enabled = true;
-      enableNetworkInspect(messageBridge);
-    } else if (message.method === "Network.disable" && enabled) {
-      enabled = false;
-      disableNetworkInspect();
-    }
+    try {
+      if (message.method === "Network.enable" && !enabled) {
+        enabled = true;
+        enableNetworkInspect(messageBridge);
+      } else if (message.method === "Network.disable" && enabled) {
+        enabled = false;
+        disableNetworkInspect();
+      }
+    } catch (error) {}
   });
 }
 
@@ -179,115 +180,133 @@ function enableNetworkInspect(networkProxy) {
   let requestIdCounter = 0;
 
   function listener(message) {
-    if (message.method === "Network.disable") {
-      networkProxy.removeMessageListener("cdp-message", listener);
-    } else if (
-      message.method === "Network.getResponseBody" &&
-      message.params.requestId.startsWith(requestIdPrefix)
-    ) {
-      const requestId = message.params.requestId;
-      const xhr = xhrsMap.get(requestId)?.deref();
-      // typically with devtools UI, each request details will be fetched at most once.
-      // we can safely delete the record once the request data is retrieved.
-      xhrsMap.delete(requestId);
+    try {
+      if (message.method === "Network.disable") {
+        networkProxy.removeMessageListener("cdp-message", listener);
+      } else if (
+        message.method === "Network.getResponseBody" &&
+        message.params.requestId.startsWith(requestIdPrefix)
+      ) {
+        const requestId = message.params.requestId;
+        const xhr = xhrsMap.get(requestId)?.deref();
+        // typically with devtools UI, each request details will be fetched at most once.
+        // we can safely delete the record once the request data is retrieved.
+        xhrsMap.delete(requestId);
 
-      readResponseBodyContent(xhr).then((body) => {
-        networkProxy.sendMessage(
-          "cdp-message",
-          JSON.stringify({
-            id: message.id,
-            result: { body },
+        readResponseBodyContent(xhr)
+          .then((body) => {
+            try {
+              networkProxy.sendMessage(
+                "cdp-message",
+                JSON.stringify({
+                  id: message.id,
+                  result: { body },
+                })
+              );
+            } catch (error) {}
           })
-        );
-      });
-    }
+          .catch((error) => {});
+      }
+    } catch (error) {}
   }
   networkProxy.addMessageListener("cdp-message", listener);
 
   const HEADERS_RECEIVED = 2; // readyState value when headers are received
 
   function sendCallback(data, xhr) {
-    const requestId = `${requestIdPrefix}-${requestIdCounter++}`;
-    const sendTime = Date.now();
-    let ttfb;
+    try {
+      const requestId = `${requestIdPrefix}-${requestIdCounter++}`;
+      const sendTime = Date.now();
+      let ttfb;
 
-    xhrsMap.set(requestId, new WeakRefImpl(xhr));
+      xhrsMap.set(requestId, new WeakRefImpl(xhr));
 
-    function sendCDPMessage(method, params) {
-      networkProxy.sendMessage("cdp-message", JSON.stringify({ method, params }));
-    }
-
-    sendCDPMessage("Network.requestWillBeSent", {
-      requestId: requestId,
-      loaderId,
-      timestamp: sendTime / 1000,
-      wallTime: Math.floor(Date.now() / 1000),
-      request: {
-        url: xhr._url,
-        method: xhr._method,
-        headers: xhr._headers,
-        postData: deserializeDataContent(data, xhr._headers["content-type"]),
-      },
-      type: "XHR",
-      initiator: {
-        type: "script",
-      },
-    });
-
-    xhr.addEventListener("abort", (event) => {
-      sendCDPMessage("Network.loadingFailed", {
-        requestId: requestId,
-        timestamp: Date.now() / 1000,
-        type: "XHR",
-        errorText: "Aborted",
-        canceled: true,
-      });
-    });
-
-    xhr.addEventListener("error", (event) => {
-      sendCDPMessage("Network.loadingFailed", {
-        requestId: requestId,
-        timestamp: Date.now() / 1000,
-        type: "XHR",
-        errorText: "Failed",
-        cancelled: false,
-      });
-    });
-
-    xhr.addEventListener("readystatechange", (event) => {
-      if (xhr.readyState === HEADERS_RECEIVED) {
-        ttfb = Date.now() - sendTime;
+      function sendCDPMessage(method, params) {
+        networkProxy.sendMessage("cdp-message", JSON.stringify({ method, params }));
       }
-    });
 
-    xhr.addEventListener("load", (event) => {
-      const mimeType = mimeTypeFromResponseType(xhr.responseType);
-      sendCDPMessage("Network.responseReceived", {
+      sendCDPMessage("Network.requestWillBeSent", {
         requestId: requestId,
         loaderId,
-        timestamp: Date.now() / 1000,
-        ttfb,
-        type: "XHR",
-        response: {
-          type: xhr.responseType,
+        timestamp: sendTime / 1000,
+        wallTime: Math.floor(Date.now() / 1000),
+        request: {
           url: xhr._url,
-          status: xhr.status,
-          statusText: xhr.statusText,
-          headers: xhr.responseHeaders,
-          mimeType: mimeType,
-          data: deserializeDataContent(data, mimeType),
+          method: xhr._method,
+          headers: xhr._headers,
+          postData: deserializeDataContent(data, xhr._headers["content-type"]),
+        },
+        type: "XHR",
+        initiator: {
+          type: "script",
         },
       });
-    });
 
-    xhr.addEventListener("loadend", (event) => {
-      sendCDPMessage("Network.loadingFinished", {
-        requestId: requestId,
-        timestamp: Date.now() / 1000,
-        duration: Date.now() - sendTime,
-        encodedDataLength: xhr._response.size || xhr._response.length, // when response is blob, we use size, and length otherwise
+      xhr.addEventListener("abort", (event) => {
+        try {
+          sendCDPMessage("Network.loadingFailed", {
+            requestId: requestId,
+            timestamp: Date.now() / 1000,
+            type: "XHR",
+            errorText: "Aborted",
+            canceled: true,
+          });
+        } catch (error) {}
       });
-    });
+
+      xhr.addEventListener("error", (event) => {
+        try {
+          sendCDPMessage("Network.loadingFailed", {
+            requestId: requestId,
+            timestamp: Date.now() / 1000,
+            type: "XHR",
+            errorText: "Failed",
+            cancelled: false,
+          });
+        } catch (error) {}
+      });
+
+      xhr.addEventListener("readystatechange", (event) => {
+        try {
+          if (xhr.readyState === HEADERS_RECEIVED) {
+            ttfb = Date.now() - sendTime;
+          }
+        } catch (error) {}
+      });
+
+      xhr.addEventListener("load", (event) => {
+        try {
+          const mimeType = mimeTypeFromResponseType(xhr.responseType);
+          sendCDPMessage("Network.responseReceived", {
+            requestId: requestId,
+            loaderId,
+            timestamp: Date.now() / 1000,
+            ttfb,
+            type: "XHR",
+            response: {
+              type: xhr.responseType,
+              url: xhr._url,
+              status: xhr.status,
+              statusText: xhr.statusText,
+              headers: xhr.responseHeaders,
+              mimeType: mimeType,
+              data: deserializeDataContent(data, mimeType),
+            },
+          });
+        } catch (error) {}
+      });
+
+      xhr.addEventListener("loadend", (event) => {
+        try {
+          sendCDPMessage("Network.loadingFinished", {
+            requestId: requestId,
+            timestamp: Date.now() / 1000,
+            duration: Date.now() - sendTime,
+            encodedDataLength: xhr._response.size || xhr._response.length, // when response is blob, we use size, and length otherwise
+          });
+        } catch (error) {}
+      });
+    } catch (error) {}
   }
 
   XHRInterceptor.disableInterception();

--- a/packages/vscode-extension/lib/network.js
+++ b/packages/vscode-extension/lib/network.js
@@ -195,17 +195,15 @@ function enableNetworkInspect(networkProxy) {
 
         readResponseBodyContent(xhr)
           .then((body) => {
-            try {
-              networkProxy.sendMessage(
-                "cdp-message",
-                JSON.stringify({
-                  id: message.id,
-                  result: { body },
-                })
-              );
-            } catch (error) {}
+            networkProxy.sendMessage(
+              "cdp-message",
+              JSON.stringify({
+                id: message.id,
+                result: { body },
+              })
+            );
           })
-          .catch((error) => {});
+          .catch(() => {});
       }
     } catch (error) {}
   }

--- a/packages/vscode-extension/lib/network.js
+++ b/packages/vscode-extension/lib/network.js
@@ -1,5 +1,6 @@
 const RNInternals = require("./rn-internals/rn-internals");
 const { PluginMessageBridge } = require("./plugins/PluginMessageBridge");
+const TextDecoder = require("./polyfills").TextDecoder;
 
 function mimeTypeFromResponseType(responseType) {
   switch (responseType) {
@@ -102,6 +103,7 @@ function deserializeDataContent(data, contentType) {
     return data;
   }
 
+  
   // Handle native typed Uint8Arrays
   if (data instanceof Uint8Array) {
     return shouldDecodeAsText(contentType) ? decode(data) : dataToBase64(data);

--- a/packages/vscode-extension/lib/network.js
+++ b/packages/vscode-extension/lib/network.js
@@ -25,6 +25,7 @@ function readResponseBodyContent(xhr) {
     return Promise.resolve(undefined);
   }
   const responseType = xhr.responseType;
+
   if (responseType === "" || responseType === "text") {
     return Promise.resolve(xhr.responseText);
   }
@@ -42,6 +43,78 @@ function readResponseBodyContent(xhr) {
   }
   // don't want to read binary data here
   return Promise.resolve(undefined);
+}
+
+// Allowed content types for processing text-based data
+const ALLOWED_APPLICATION_CONTENT_TYPES = new Set([
+  "application/x-sh",
+  "application/x-csh",
+  "application/rtf",
+  "application/manifest+json",
+  "application/xhtml+xml",
+  "application/xml",
+  "application/XUL",
+  "application/ld+json",
+  "application/json",
+]);
+
+function deserializeDataContent(data, contentType) {
+  const shouldDecodeAsText = (dataContentType) => {
+    if (!dataContentType) {
+      return false;
+    }
+
+    if (dataContentType.startsWith("text/")) {
+      return true;
+    }
+
+    const mimeType = dataContentType.split(";")[0].trim().toLowerCase();
+    return ALLOWED_APPLICATION_CONTENT_TYPES.has(mimeType);
+  };
+
+  const isSerializedTypedArray = (obj) => {
+    return (
+      obj &&
+      typeof obj === "object" &&
+      !Array.isArray(obj) &&
+      typeof obj.length === "number" &&
+      Object.keys(obj).every((key) => !isNaN(parseInt(key)))
+    );
+  };
+
+  const dataToBase64 = (array) => {
+    return btoa(String.fromCharCode.apply(null, Array.from(array)));
+  };
+  const decode = (array) => {
+    return new TextDecoder().decode(array);
+  };
+
+  const reconstructTypedArray = (serializedData) => {
+    const length = Object.keys(serializedData).length;
+    const uint8Array = new Uint8Array(length);
+    Object.keys(serializedData).forEach((key) => {
+      uint8Array[parseInt(key)] = serializedData[key];
+    });
+    return uint8Array;
+  };
+
+  if (!data || !contentType) {
+    return data;
+  }
+
+  // Handle native typed Uint8Arrays
+  if (data instanceof Uint8Array) {
+    return shouldDecodeAsText(contentType) ? decode(data) : dataToBase64(data);
+  }
+
+  // Handle objects with numeric keys, which lost information about their type
+  if (isSerializedTypedArray(data)) {
+    const uint8Array = reconstructTypedArray(data);
+    return shouldDecodeAsText(contentType) ? decode(uint8Array) : dataToBase64(uint8Array);
+  }
+
+  // String or other types
+  return data;
 }
 
 // WeakRef support is only available on the new architecture. We keep XHR objects
@@ -151,7 +224,7 @@ function enableNetworkInspect(networkProxy) {
         url: xhr._url,
         method: xhr._method,
         headers: xhr._headers,
-        postData: data,
+        postData: deserializeDataContent(data, xhr._headers["content-type"]),
       },
       type: "XHR",
       initiator: {
@@ -186,6 +259,7 @@ function enableNetworkInspect(networkProxy) {
     });
 
     xhr.addEventListener("load", (event) => {
+      const mimeType = mimeTypeFromResponseType(xhr.responseType);
       sendCDPMessage("Network.responseReceived", {
         requestId: requestId,
         loaderId,
@@ -198,8 +272,8 @@ function enableNetworkInspect(networkProxy) {
           status: xhr.status,
           statusText: xhr.statusText,
           headers: xhr.responseHeaders,
-          mimeType: mimeTypeFromResponseType(xhr.responseType),
-          data: xhr._response,
+          mimeType: mimeType,
+          data: deserializeDataContent(data, mimeType),
         },
       });
     });

--- a/packages/vscode-extension/lib/polyfills/index.js
+++ b/packages/vscode-extension/lib/polyfills/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  get TextDecoder() {
+    if (typeof global.TextDecoder !== "undefined") {
+      return global.TextDecoder;
+    }
+    return require("./third-party/text_decoder").TextDecoder;
+  },
+};

--- a/packages/vscode-extension/lib/polyfills/index.js
+++ b/packages/vscode-extension/lib/polyfills/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   get TextDecoder() {
-    if (typeof global.TextDecoder !== "undefined") {
+    if (global.TextDecoder !== undefined) {
       return global.TextDecoder;
     }
     return require("./third-party/text_decoder").TextDecoder;

--- a/packages/vscode-extension/lib/polyfills/third-party/text_decoder.ts
+++ b/packages/vscode-extension/lib/polyfills/third-party/text_decoder.ts
@@ -1,0 +1,455 @@
+// A fork of text-encoding but with only UTF-8 decoder. `TextEncoder` is in Hermes and we only need utf-8 decoder for RSC.
+//
+// https://github.com/inexorabletash/text-encoding/blob/3f330964c0e97e1ed344c2a3e963f4598610a7ad/lib/encoding.js#L1
+
+/**
+ * Checks if a number is within a specified range.
+ * @param {number} a The number to test.
+ * @param {number} min The minimum value in the range, inclusive.
+ * @param {number} max The maximum value in the range, inclusive.
+ * @returns {boolean} True if a is within the range.
+ */
+function inRange(a: number, min: number, max: number): boolean {
+  return min <= a && a <= max;
+}
+
+/**
+ * Converts an array of code points to a string.
+ * @param {number[]} codePoints Array of code points.
+ * @returns {string} The string representation.
+ */
+function codePointsToString(codePoints: number[]): string {
+  let s = "";
+  for (let i = 0; i < codePoints.length; ++i) {
+    let cp = codePoints[i];
+    if (cp <= 0xffff) {
+      s += String.fromCharCode(cp);
+    } else {
+      cp -= 0x10000;
+      s += String.fromCharCode((cp >> 10) + 0xd800, (cp & 0x3ff) + 0xdc00);
+    }
+  }
+  return s;
+}
+
+function normalizeBytes(input?: ArrayBuffer | DataView): Uint8Array {
+  if (typeof input === "object" && input instanceof ArrayBuffer) {
+    return new Uint8Array(input);
+  } else if (
+    typeof input === "object" &&
+    "buffer" in input &&
+    input.buffer instanceof ArrayBuffer
+  ) {
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  }
+  return new Uint8Array(0);
+}
+
+/**
+ * End-of-stream is a special token that signifies no more tokens
+ * are in the stream.
+ */
+const END_OF_STREAM = -1;
+
+const FINISHED = -1;
+
+/**
+ * A stream represents an ordered sequence of tokens.
+ *
+ * @constructor
+ * @param {!(number[]|Uint8Array)} tokens Array of tokens that provide the stream.
+ */
+class Stream {
+  private tokens: number[];
+
+  constructor(tokens: number[] | Uint8Array) {
+    this.tokens = Array.prototype.slice.call(tokens);
+    // Reversed as push/pop is more efficient than shift/unshift.
+    this.tokens.reverse();
+  }
+
+  /**
+   * @return {boolean} True if end-of-stream has been hit.
+   */
+  endOfStream(): boolean {
+    return !this.tokens.length;
+  }
+
+  /**
+   * When a token is read from a stream, the first token in the
+   * stream must be returned and subsequently removed, and
+   * end-of-stream must be returned otherwise.
+   *
+   * @return {number} Get the next token from the stream, or
+   * end_of_stream.
+   */
+  read(): number {
+    if (!this.tokens.length) {
+      return END_OF_STREAM;
+    }
+    return this.tokens.pop()!;
+  }
+
+  /**
+   * When one or more tokens are prepended to a stream, those tokens
+   * must be inserted, in given order, before the first token in the
+   * stream.
+   *
+   * @param token The token(s) to prepend to the stream.
+   */
+  prepend(token: number | number[]): void {
+    if (Array.isArray(token)) {
+      while (token.length) {
+        this.tokens.push(token.pop()!);
+      }
+    } else {
+      this.tokens.push(token);
+    }
+  }
+
+  /**
+   * When one or more tokens are pushed to a stream, those tokens
+   * must be inserted, in given order, after the last token in the
+   * stream.
+   *
+   * @param token The tokens(s) to push to the stream.
+   */
+  push(token: number | number[]): void {
+    if (Array.isArray(token)) {
+      while (token.length) {
+        this.tokens.unshift(token.shift()!);
+      }
+    } else {
+      this.tokens.unshift(token);
+    }
+  }
+}
+
+function decoderError(fatal: boolean, opt_code_point?: number) {
+  if (fatal) {
+    throw TypeError("Decoder error");
+  }
+  return opt_code_point || 0xfffd;
+}
+
+interface Encoding {
+  name: string;
+  labels: string[];
+}
+
+const LABEL_ENCODING_MAP: { [key: string]: Encoding } = {};
+
+function getEncoding(label: string): Encoding | null {
+  label = label.trim().toLowerCase();
+  if (label in LABEL_ENCODING_MAP) {
+    return LABEL_ENCODING_MAP[label];
+  }
+  return null;
+}
+
+/** [Encodings table](https://encoding.spec.whatwg.org/encodings.json) (Incomplete as we only need TextDecoder utf8 in Expo RSC. A more complete implementation should be added to Hermes as native code.) */
+const ENCODING_MAP: { heading: string; encodings: Encoding[] }[] = [
+  {
+    encodings: [
+      {
+        labels: ["unicode-1-1-utf-8", "utf-8", "utf8"],
+        name: "UTF-8",
+      },
+    ],
+    heading: "The Encoding",
+  },
+];
+
+ENCODING_MAP.forEach((category) => {
+  category.encodings.forEach((encoding) => {
+    encoding.labels.forEach((label) => {
+      LABEL_ENCODING_MAP[label] = encoding;
+    });
+  });
+});
+
+// Registry of of encoder/decoder factories, by encoding name.
+const DECODERS: {
+  [key: string]: (options: { fatal: boolean }) => UTF8Decoder;
+} = {
+  "UTF-8": (options) => new UTF8Decoder(options),
+};
+
+// 9.1.1 utf-8 decoder
+
+interface Decoder {
+  handler: (stream: Stream, bite: number) => number | number[] | null | -1;
+}
+
+class UTF8Decoder implements Decoder {
+  // utf-8's decoder's has an associated utf-8 code point, utf-8
+  // bytes seen, and utf-8 bytes needed (all initially 0), a utf-8
+  // lower boundary (initially 0x80), and a utf-8 upper boundary
+  // (initially 0xBF).
+  private utf8CodePoint = 0;
+  private utf8BytesSeen = 0;
+  private utf8BytesNeeded = 0;
+  private utf8LowerBoundary = 0x80;
+  private utf8UpperBoundary = 0xbf;
+  constructor(private options: { fatal: boolean }) {}
+  /**
+   * @param {Stream} stream The stream of bytes being decoded.
+   * @param {number} bite The next byte read from the stream.
+   * @return {?(number|!Array.<number>)} The next code point(s)
+   *     decoded, or null if not enough data exists in the input
+   *     stream to decode a complete code point.
+   */
+  handler(stream: Stream, bite: number): number | null | -1 {
+    // 1. If byte is end-of-stream and utf-8 bytes needed is not 0,
+    // set utf-8 bytes needed to 0 and return error.
+    if (bite === END_OF_STREAM && this.utf8BytesNeeded !== 0) {
+      this.utf8BytesNeeded = 0;
+      return decoderError(this.options.fatal);
+    }
+
+    // 2. If byte is end-of-stream, return finished.
+    if (bite === END_OF_STREAM) {
+      return FINISHED;
+    }
+
+    // 3. If utf-8 bytes needed is 0, based on byte:
+    if (this.utf8BytesNeeded === 0) {
+      // 0x00 to 0x7F
+      if (inRange(bite, 0x00, 0x7f)) {
+        // Return a code point whose value is byte.
+        return bite;
+      }
+
+      // 0xC2 to 0xDF
+      else if (inRange(bite, 0xc2, 0xdf)) {
+        // 1. Set utf-8 bytes needed to 1.
+        this.utf8BytesNeeded = 1;
+
+        // 2. Set UTF-8 code point to byte & 0x1F.
+        this.utf8CodePoint = bite & 0x1f;
+      }
+
+      // 0xE0 to 0xEF
+      else if (inRange(bite, 0xe0, 0xef)) {
+        // 1. If byte is 0xE0, set utf-8 lower boundary to 0xA0.
+        if (bite === 0xe0) {
+          this.utf8LowerBoundary = 0xa0;
+        }
+        // 2. If byte is 0xED, set utf-8 upper boundary to 0x9F.
+        if (bite === 0xed) {
+          this.utf8UpperBoundary = 0x9f;
+        }
+        // 3. Set utf-8 bytes needed to 2.
+        this.utf8BytesNeeded = 2;
+        // 4. Set UTF-8 code point to byte & 0xF.
+        this.utf8CodePoint = bite & 0xf;
+      }
+
+      // 0xF0 to 0xF4
+      else if (inRange(bite, 0xf0, 0xf4)) {
+        // 1. If byte is 0xF0, set utf-8 lower boundary to 0x90.
+        if (bite === 0xf0) {
+          this.utf8LowerBoundary = 0x90;
+        }
+        // 2. If byte is 0xF4, set utf-8 upper boundary to 0x8F.
+        if (bite === 0xf4) {
+          this.utf8UpperBoundary = 0x8f;
+        }
+        // 3. Set utf-8 bytes needed to 3.
+        this.utf8BytesNeeded = 3;
+        // 4. Set UTF-8 code point to byte & 0x7.
+        this.utf8CodePoint = bite & 0x7;
+      }
+
+      // Otherwise
+      else {
+        // Return error.
+        return decoderError(this.options.fatal);
+      }
+
+      // Return continue.
+      return null;
+    }
+
+    // 4. If byte is not in the range utf-8 lower boundary to utf-8
+    // upper boundary, inclusive, run these substeps:
+    if (!inRange(bite, this.utf8LowerBoundary, this.utf8UpperBoundary)) {
+      // 1. Set utf-8 code point, utf-8 bytes needed, and utf-8
+      // bytes seen to 0, set utf-8 lower boundary to 0x80, and set
+      // utf-8 upper boundary to 0xBF.
+      this.utf8CodePoint = 0;
+      this.utf8BytesNeeded = 0;
+      this.utf8BytesSeen = 0;
+      this.utf8LowerBoundary = 0x80;
+      this.utf8UpperBoundary = 0xbf;
+
+      // 2. Prepend byte to stream.
+      stream.prepend(bite);
+
+      // 3. Return error.
+      return decoderError(this.options.fatal);
+    }
+
+    // 5. Set utf-8 lower boundary to 0x80 and utf-8 upper boundary
+    // to 0xBF.
+    this.utf8LowerBoundary = 0x80;
+    this.utf8UpperBoundary = 0xbf;
+
+    // 6. Set UTF-8 code point to (UTF-8 code point << 6) | (byte &
+    // 0x3F)
+    this.utf8CodePoint = (this.utf8CodePoint << 6) | (bite & 0x3f);
+
+    // 7. Increase utf-8 bytes seen by one.
+    this.utf8BytesSeen += 1;
+
+    // 8. If utf-8 bytes seen is not equal to utf-8 bytes needed,
+    // continue.
+    if (this.utf8BytesSeen !== this.utf8BytesNeeded) {
+      return null;
+    }
+
+    // 9. Let code point be utf-8 code point.
+    const code_point = this.utf8CodePoint;
+
+    // 10. Set utf-8 code point, utf-8 bytes needed, and utf-8 bytes
+    // seen to 0.
+    this.utf8CodePoint = 0;
+    this.utf8BytesNeeded = 0;
+    this.utf8BytesSeen = 0;
+
+    // 11. Return a code point whose value is code point.
+    return code_point;
+  }
+}
+
+// 8.1 Interface TextDecoder
+
+export class TextDecoder {
+  private _encoding: Encoding | null;
+  private _ignoreBOM: boolean;
+  private _errorMode: string;
+  private _BOMseen: boolean = false;
+  private _doNotFlush: boolean = false;
+  private _decoder: UTF8Decoder | null = null;
+
+  constructor(
+    label: string = "utf-8",
+    options: {
+      fatal?: boolean;
+      ignoreBOM?: boolean;
+    } = {}
+  ) {
+    // eslint-disable-next-line eqeqeq
+    if (options != null && typeof options !== "object") {
+      throw new TypeError(
+        "Second argument of TextDecoder must be undefined or an object, e.g. { fatal: true }"
+      );
+    }
+
+    const normalizedLabel = String(label).trim().toLowerCase();
+    const encoding = getEncoding(normalizedLabel);
+    if (encoding === null || encoding.name === "replacement") {
+      throw new RangeError(`Unknown encoding: ${label} (normalized: ${normalizedLabel})`);
+    }
+
+    if (!DECODERS[encoding.name]) {
+      throw new Error(`Decoder not present: ${encoding.name}`);
+    }
+
+    this._encoding = encoding;
+    this._ignoreBOM = !!options.ignoreBOM;
+    this._errorMode = options.fatal ? "fatal" : "replacement";
+  }
+
+  // Getter methods for encoding, fatal, and ignoreBOM
+  get encoding(): string {
+    return this._encoding?.name.toLowerCase() ?? "";
+  }
+
+  get fatal(): boolean {
+    return this._errorMode === "fatal";
+  }
+
+  get ignoreBOM(): boolean {
+    return this._ignoreBOM;
+  }
+
+  decode(input?: ArrayBuffer | DataView, options: { stream?: boolean } = {}): string {
+    const bytes = normalizeBytes(input);
+
+    // 1. If the do not flush flag is unset, set decoder to a new
+    // encoding's decoder, set stream to a new stream, and unset the
+    // BOM seen flag.
+    if (!this._doNotFlush) {
+      this._decoder = DECODERS[this._encoding!.name]({
+        fatal: this.fatal,
+      });
+      this._BOMseen = false;
+    }
+
+    // 2. If options's stream is true, set the do not flush flag, and
+    // unset the do not flush flag otherwise.
+    this._doNotFlush = Boolean(options["stream"]);
+
+    // 3. If input is given, push a copy of input to stream.
+    // TODO: Align with spec algorithm - maintain stream on instance.
+    const input_stream = new Stream(bytes);
+
+    // 4. Let output be a new stream.
+    const output: number[] = [];
+
+    while (true) {
+      const token = input_stream.read();
+
+      if (token === END_OF_STREAM) {
+        break;
+      }
+
+      const result = this._decoder!.handler(input_stream, token);
+
+      if (result === FINISHED) {
+        break;
+      }
+
+      if (result !== null) {
+        output.push(result);
+      }
+    }
+
+    if (!this._doNotFlush) {
+      do {
+        const result = this._decoder!.handler(input_stream, input_stream.read());
+        if (result === FINISHED) {
+          break;
+        }
+        if (result === null) {
+          continue;
+        }
+        if (Array.isArray(result)) {
+          output.push.apply(output, result);
+        } else {
+          output.push(result);
+        }
+      } while (!input_stream.endOfStream());
+      this._decoder = null;
+    }
+
+    return this.serializeStream(output);
+  }
+
+  // serializeStream method for converting code points to a string
+  private serializeStream(stream: number[]): string {
+    if (this._encoding!.name === "UTF-8") {
+      if (!this._ignoreBOM && !this._BOMseen && stream[0] === 0xfeff) {
+        // If BOM is detected at the start of the stream and we're not ignoring it
+        this._BOMseen = true;
+        stream.shift(); // Remove the BOM
+      } else if (stream.length > 0) {
+        this._BOMseen = true;
+      }
+    }
+
+    // Convert the stream of code points to a string
+    return codePointsToString(stream);
+  }
+}

--- a/packages/vscode-extension/src/network/components/PayloadTab.tsx
+++ b/packages/vscode-extension/src/network/components/PayloadTab.tsx
@@ -1,6 +1,6 @@
 import { NetworkLog } from "../hooks/useNetworkTracker";
 import IconButton from "../../webview/components/shared/IconButton";
-import { formatJSONBody, formatGETParams } from "../utils/requestFormatUtils";
+import { formatJSONBody, formatUrlParams } from "../utils/requestFormatUtils";
 
 interface PayloadTabProps {
   networkLog: NetworkLog;
@@ -14,10 +14,9 @@ const PayloadTab = ({ networkLog }: PayloadTabProps) => {
   const getPayloadData = () => {
     const { url, postData } = networkLog.request!;
 
-    const urlParams = formatGETParams(url);
+    const urlParams = formatUrlParams(url);
     const hasUrlParams = urlParams !== "{}";
 
-    // For requests with body data, show both URL params and body
     if (postData && postData !== "") {
       const bodyData = formatJSONBody(postData);
 
@@ -27,12 +26,10 @@ const PayloadTab = ({ networkLog }: PayloadTabProps) => {
       return bodyData;
     }
 
-    // For requests without body, show URL params if they exist
     if (hasUrlParams) {
       return urlParams;
     }
 
-    // No URL params and no body
     return "No request body";
   };
 

--- a/packages/vscode-extension/src/network/components/PayloadTab.tsx
+++ b/packages/vscode-extension/src/network/components/PayloadTab.tsx
@@ -11,10 +11,23 @@ const PayloadTab = ({ networkLog }: PayloadTabProps) => {
     return null;
   }
 
-  const payloadData =
-    networkLog.request.method === "GET"
-      ? formatGETParams(networkLog.request.url)
-      : formatJSONBody(networkLog.request.postData);
+  const getPayloadData = () => {
+    const { method, url, postData } = networkLog.request!;
+
+    if (method === "GET") {
+      return formatGETParams(url);
+    }
+
+    // Handle other requests with no body (HEAD, OPTIONS, etc.)
+    if (!postData || postData === "") {
+      return "No request body";
+    }
+
+    // Handle requests with body data
+    return formatJSONBody(postData);
+  };
+
+  const payloadData = getPayloadData();
 
   return (
     <>

--- a/packages/vscode-extension/src/network/components/PayloadTab.tsx
+++ b/packages/vscode-extension/src/network/components/PayloadTab.tsx
@@ -12,19 +12,28 @@ const PayloadTab = ({ networkLog }: PayloadTabProps) => {
   }
 
   const getPayloadData = () => {
-    const { method, url, postData } = networkLog.request!;
+    const { url, postData } = networkLog.request!;
 
-    if (method === "GET") {
-      return formatGETParams(url);
+    const urlParams = formatGETParams(url);
+    const hasUrlParams = urlParams !== "{}";
+
+    // For requests with body data, show both URL params and body
+    if (postData && postData !== "") {
+      const bodyData = formatJSONBody(postData);
+
+      if (hasUrlParams) {
+        return `URL Parameters:\n${urlParams}\n\nRequest Body:\n${bodyData}`;
+      }
+      return bodyData;
     }
 
-    // Handle other requests with no body (HEAD, OPTIONS, etc.)
-    if (!postData || postData === "") {
-      return "No request body";
+    // For requests without body, show URL params if they exist
+    if (hasUrlParams) {
+      return urlParams;
     }
 
-    // Handle requests with body data
-    return formatJSONBody(postData);
+    // No URL params and no body
+    return "No request body";
   };
 
   const payloadData = getPayloadData();

--- a/packages/vscode-extension/src/network/components/PayloadTab.tsx
+++ b/packages/vscode-extension/src/network/components/PayloadTab.tsx
@@ -1,36 +1,32 @@
 import { NetworkLog } from "../hooks/useNetworkTracker";
+import IconButton from "../../webview/components/shared/IconButton";
+import { formatJSONBody, formatGETParams } from "../utils/requestFormatUtils";
 
 interface PayloadTabProps {
   networkLog: NetworkLog;
 }
-
-const getParams = (url: string): Record<string, string> => {
-  try {
-    const urlObj = new URL(url);
-    const params: Record<string, string> = {};
-    urlObj.searchParams.forEach((value, key) => {
-      params[key] = value;
-    });
-    return params;
-  } catch {
-    return {};
-  }
-};
 
 const PayloadTab = ({ networkLog }: PayloadTabProps) => {
   if (!networkLog.request) {
     return null;
   }
 
-  const payloadData = JSON.stringify(
+  const payloadData =
     networkLog.request.method === "GET"
-      ? getParams(networkLog.request.url)
-      : JSON.parse(networkLog.request.postData || "{}"),
-    null,
-    2
-  );
+      ? formatGETParams(networkLog.request.url)
+      : formatJSONBody(networkLog.request.postData);
 
-  return <pre>{payloadData}</pre>;
+  return (
+    <>
+      <IconButton
+        className="response-tab-copy-button"
+        tooltip={{ label: "Copy to Clipboard", side: "bottom" }}
+        onClick={() => navigator.clipboard.writeText(payloadData)}>
+        <span className="codicon codicon-copy" />
+      </IconButton>
+      <pre className="response-tab-pre">{payloadData}</pre>
+    </>
+  );
 };
 
 export default PayloadTab;

--- a/packages/vscode-extension/src/network/components/ResponseTab.css
+++ b/packages/vscode-extension/src/network/components/ResponseTab.css
@@ -1,5 +1,11 @@
 .response-tab-copy-button {
   position: absolute;
-  top: 6px;
-  right: 12px;
+  top: 4px;
+  right: 14px;
+  background-color: var(--vscode-diffEditor-unchangedRegionBackground);
+}
+
+.response-tab-pre {
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/packages/vscode-extension/src/network/components/ResponseTab.tsx
+++ b/packages/vscode-extension/src/network/components/ResponseTab.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import IconButton from "../../webview/components/shared/IconButton";
 import { NetworkLog } from "../hooks/useNetworkTracker";
 import { useNetwork } from "../providers/NetworkProvider";
+import { formatJSONBody } from "../utils/requestFormatUtils";
 
 interface ResponseTabProps {
   networkLog: NetworkLog;
@@ -18,19 +19,7 @@ const ResponseTab = ({ networkLog }: ResponseTabProps) => {
     });
   }, [networkLog.requestId]);
 
-  const formatResponseBody = (body: unknown): string => {
-    if (typeof body !== "string") {
-      return "No response body";
-    }
-    try {
-      const parsed = JSON.parse(body);
-      return JSON.stringify(parsed, null, 2);
-    } catch {
-      return body;
-    }
-  };
-
-  const responseData = formatResponseBody(responseBody);
+  const responseData = formatJSONBody(responseBody);
 
   return (
     <>

--- a/packages/vscode-extension/src/network/hooks/useNetworkTracker.tsx
+++ b/packages/vscode-extension/src/network/hooks/useNetworkTracker.tsx
@@ -91,6 +91,7 @@ const useNetworkTracker = (): NetworkTracker => {
   const processServerMessage = (msg: string, newLogs: NetworkLog[]): void => {
     try {
       const parsedMsg: WebSocketMessage = JSON.parse(msg);
+
       const { method, params } = parsedMsg;
 
       if (!params?.requestId) {

--- a/packages/vscode-extension/src/network/utils/requestFormatUtils.ts
+++ b/packages/vscode-extension/src/network/utils/requestFormatUtils.ts
@@ -1,0 +1,28 @@
+function stringify(obj: unknown): string {
+  return JSON.stringify(obj, null, 2);
+}
+
+export function formatJSONBody(body: unknown): string {
+  if (typeof body !== "string") {
+    return "No response body";
+  }
+  try {
+    const parsed = JSON.parse(body);
+    return stringify(parsed);
+  } catch {
+    return body;
+  }
+}
+
+export function formatGETParams(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const params: Record<string, string> = {};
+    urlObj.searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+    return stringify(params);
+  } catch {
+    return stringify({});
+  }
+}

--- a/packages/vscode-extension/src/network/utils/requestFormatUtils.ts
+++ b/packages/vscode-extension/src/network/utils/requestFormatUtils.ts
@@ -14,7 +14,7 @@ export function formatJSONBody(body: unknown): string {
   }
 }
 
-export function formatGETParams(url: string): string {
+export function formatUrlParams(url: string): string {
   try {
     const urlObj = new URL(url);
     const params: Record<string, string> = {};

--- a/packages/vscode-extension/submodules-NOTICES.json
+++ b/packages/vscode-extension/submodules-NOTICES.json
@@ -44,6 +44,17 @@
           "text": "Copyright 2024 Aiden Bai, Million Software, Inc.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
         }
       ]
+    },
+    {
+      "package_name": "EvanBacon/text-decoder",
+      "repository": "https://github.com/EvanBacon/text-decoder",
+      "license": "MIT",
+      "licenses": [
+        {
+          "license": "MIT",
+          "text": "MIT License\n\nCopyright (c) 2022 evanbacon\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description

This PR fixes issues with Payload Tab in network inspector, which would cause error throws if the payload was not a proper JSON.

It also introduces:
- Refactors made to Payload Tab to be more in style of Response Tab, included *Copy to Clickboard* button as well
- Deserialising data in `Network plugin` for proper showcase of data sent as UInt8Array

<img width="1101" height="352" alt="Screenshot 2025-08-25 at 15 50 19" src="https://github.com/user-attachments/assets/a07bd548-99b9-47b6-840f-3209dbc20fc1" />

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, launch app on selected device, open network inspector
- **check if Payload and Response tabs in Network Inspector work correctly and do not cause crashes**

### How Has This Change Been Documented:

Not applicable.

