### PR TITLE
fix: device session can be undefined 

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectOverlay.tsx
@@ -35,7 +35,7 @@ function InspectOverlay({
   const store$ = useStore();
   const selectedDeviceSessionState = useSelectedDeviceSessionState();
   const rotation = use$(store$.workspaceConfiguration.deviceRotation);
-  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation) ?? null;
+  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation);
 
   const { selectedDeviceSession } = useProject();
   if (selectedDeviceSession?.status !== "running") {

--- a/packages/vscode-extension/src/webview/components/InspectOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectOverlay.tsx
@@ -35,7 +35,7 @@ function InspectOverlay({
   const store$ = useStore();
   const selectedDeviceSessionState = useSelectedDeviceSessionState();
   const rotation = use$(store$.workspaceConfiguration.deviceRotation);
-  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation);
+  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation) ?? null;
 
   const { selectedDeviceSession } = useProject();
   if (selectedDeviceSession?.status !== "running") {

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -80,7 +80,7 @@ function Preview({
   const selectedDeviceSessionState = useSelectedDeviceSessionState();
 
   const rotation = use$(store$.workspaceConfiguration.deviceRotation);
-  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation);
+  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation) ?? null;
 
   const bundleError = use$(selectedDeviceSessionState.applicationSession.bundleError);
 
@@ -129,7 +129,7 @@ function Preview({
 
   useFatalErrorAlert(fatalErrorDescriptor);
 
-  const bundleErrorDescriptor = isRunning ? bundleError : null;
+  const bundleErrorDescriptor = isRunning ? (bundleError ?? null) : null;
   useBundleErrorAlert(bundleErrorDescriptor);
 
   const openRebuildAlert = useNativeRebuildAlert();

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -45,7 +45,7 @@ type Props = {
   onInspectorItemSelected: (item: InspectDataStackItem) => void;
   zoomLevel: ZoomLevelType;
   onZoomChanged: (zoomLevel: ZoomLevelType) => void;
-  replayData: MultimediaData | null;
+  replayData: MultimediaData | null | undefined;
   onReplayClose: () => void;
 };
 
@@ -80,7 +80,7 @@ function Preview({
   const selectedDeviceSessionState = useSelectedDeviceSessionState();
 
   const rotation = use$(store$.workspaceConfiguration.deviceRotation);
-  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation) ?? null;
+  const appOrientation = use$(selectedDeviceSessionState.applicationSession.appOrientation);
 
   const bundleError = use$(selectedDeviceSessionState.applicationSession.bundleError);
 
@@ -129,7 +129,7 @@ function Preview({
 
   useFatalErrorAlert(fatalErrorDescriptor);
 
-  const bundleErrorDescriptor = isRunning ? (bundleError ?? null) : null;
+  const bundleErrorDescriptor = isRunning ? bundleError : null;
   useBundleErrorAlert(bundleErrorDescriptor);
 
   const openRebuildAlert = useNativeRebuildAlert();

--- a/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/RenderOutlinesOverlay.tsx
@@ -60,9 +60,10 @@ function RenderOutlinesOverlay() {
 
   const { selectedDeviceSession } = useProject();
 
-  const appOrientation = use$(
+  const appOrientation = use$(() =>
     selectedDeviceSession?.status === "running"
-      ? selectedDeviceSessionState.applicationSession.appOrientation
+      ? (selectedDeviceSessionState.applicationSession.appOrientation.get() ??
+        DeviceRotation.Portrait)
       : DeviceRotation.Portrait
   );
 

--- a/packages/vscode-extension/src/webview/components/SendFilesOverlay.tsx
+++ b/packages/vscode-extension/src/webview/components/SendFilesOverlay.tsx
@@ -17,22 +17,22 @@ export function SendFilesOverlay() {
   const { project } = useProject();
   const [isDragging, setIsDragging] = useState(false);
   const store$ = useSelectedDeviceSessionState();
-  const sendingFiles = use$(store$.fileTransfer.sendingFiles);
-  const erroredFiles = use$(store$.fileTransfer.erroredFiles);
-  const sentFiles = use$(store$.fileTransfer.sentFiles);
-  const isLoading = sendingFiles.length > 0;
-  const isError = erroredFiles.length > 0;
-  const isSuccess = !isError && sentFiles.length > 0;
+  const sendingFiles = use$(store$?.fileTransfer.sendingFiles);
+  const erroredFiles = use$(store$?.fileTransfer.erroredFiles);
+  const sentFiles = use$(store$?.fileTransfer.sentFiles);
+  const isLoading = sendingFiles ? sendingFiles.length > 0 : false;
+  const isError = erroredFiles ? erroredFiles.length > 0 : false;
+  const isSuccess = !isError && sentFiles ? sentFiles.length > 0 : false;
   const isVisible = isDragging || isLoading || isError || isSuccess;
 
   const resetOverlayState = useCallback(() => {
-    store$.fileTransfer.erroredFiles.set([]);
-    store$.fileTransfer.sentFiles.set([]);
+    store$?.fileTransfer.erroredFiles.set([]);
+    store$?.fileTransfer.sentFiles.set([]);
   }, [store$]);
 
   // Hide overlay after success and error animations
   useEffect(() => {
-    if (!isLoading && (erroredFiles.length > 0 || sentFiles.length > 0)) {
+    if (!isLoading && ((erroredFiles?.length ?? 0) > 0 || (sentFiles?.length ?? 0) > 0)) {
       const timer = setTimeout(
         resetOverlayState,
         isSuccess ? RETAIN_SUCCESS_SCREEN_TIMEOUT : RETAIN_ERROR_SCREEN_TIMEOUT
@@ -49,8 +49,8 @@ export function SendFilesOverlay() {
       // NOTE: `arrayBuffer()` may fail when the file cannot be read.
       // Since we don't send anything to the extension in that case, we need to handle it here.
       console.error("Error when reading file:", file.name, e);
-      store$.fileTransfer.erroredFiles.set((prev) => [
-        ...prev,
+      store$?.fileTransfer.erroredFiles.set((prev) => [
+        ...(prev ?? []),
         { fileName: file.name, errorMessage: "Could not read the file." },
       ]);
       return;
@@ -99,7 +99,7 @@ export function SendFilesOverlay() {
 
   const getOverlayContent = () => {
     if (isLoading) {
-      const fileCount = sendingFiles.length;
+      const fileCount = sendingFiles?.length;
       return {
         icon: <VscodeProgressRing />,
         message: `Sending ${fileCount} file${fileCount !== 1 ? "s" : ""}...`,
@@ -114,12 +114,12 @@ export function SendFilesOverlay() {
           </div>
         ),
         message:
-          erroredFiles[0].errorMessage || "Failed to send some files. Check logs for details.",
+          erroredFiles?.[0]?.errorMessage || "Failed to send some files. Check logs for details.",
       };
     }
 
     if (isSuccess) {
-      const fileCount = sentFiles.length;
+      const fileCount = sentFiles?.length;
       return {
         icon: (
           <div className="success-icon-container">

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -93,18 +93,18 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
 
   const isRunning = selectedDeviceSession?.status === "running";
 
-  const profilingCPUState = use$(selectedDeviceSessionState.applicationSession.profilingCPUState);
+  const profilingCPUState = use$(selectedDeviceSessionState?.applicationSession.profilingCPUState);
   const profilingReactState = use$(
-    selectedDeviceSessionState.applicationSession.profilingReactState
+    selectedDeviceSessionState?.applicationSession.profilingReactState
   );
 
   const toolsState = use$(
     isRunning
-      ? selectedDeviceSessionState.applicationSession.toolsState
+      ? selectedDeviceSessionState?.applicationSession.toolsState
       : observable<ToolsState>({})
   );
 
-  const allTools = Object.entries(toolsState);
+  const allTools = Object.entries(toolsState ?? {});
   const panelTools = allTools.filter(([key, tool]) => tool.isPanelTool);
   const nonPanelTools = allTools.filter(([key, tool]) => !tool.isPanelTool);
 

--- a/packages/vscode-extension/src/webview/hooks/selectedSession.tsx
+++ b/packages/vscode-extension/src/webview/hooks/selectedSession.tsx
@@ -1,5 +1,7 @@
 import { use$ } from "@legendapp/state/react";
 import { useStore } from "../providers/storeProvider";
+import { Observable } from "@legendapp/state";
+import { DeviceSessionStore } from "../../common/State";
 
 export const useSelectedSessionId = () => {
   const store$ = useStore();
@@ -12,5 +14,5 @@ export const useSelectedDeviceSessionState = () => {
 
   const deviceSessionState = store$.projectState.deviceSessions[selectedSessionId!];
 
-  return deviceSessionState;
+  return deviceSessionState as Observable<DeviceSessionStore | undefined>;
 };

--- a/packages/vscode-extension/src/webview/hooks/useBundleErrorAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useBundleErrorAlert.tsx
@@ -34,6 +34,6 @@ export const bundleErrorAlert = {
   actions: <BundleErrorActions />,
 };
 
-export function useBundleErrorAlert(errorDescriptor: BundleErrorDescriptor | null) {
-  useToggleableAlert(errorDescriptor !== null, bundleErrorAlert);
+export function useBundleErrorAlert(errorDescriptor: BundleErrorDescriptor | null | undefined) {
+  useToggleableAlert(errorDescriptor !== null && errorDescriptor !== undefined, bundleErrorAlert);
 }

--- a/packages/vscode-extension/src/webview/utilities/transformAppCoordinates.ts
+++ b/packages/vscode-extension/src/webview/utilities/transformAppCoordinates.ts
@@ -94,7 +94,7 @@ function getOrientationPredicates(
  *  and app orientation - change, synchronizing the app's coordinate system with the preview's coordinate system.
  * */
 export function appToPreviewCoordinates(
-  appOrientation: DeviceRotation | null,
+  appOrientation: DeviceRotation | null | undefined,
   deviceOrientation: DeviceRotation,
   frameRect: NormalizedFrameRect
 ): NormalizedFrameRect {
@@ -185,7 +185,7 @@ export function appToPreviewCoordinates(
  *  and app orientation - change, synchronizing the preview's coordinate system with the app's coordinate system.
  * */
 export function previewToAppCoordinates(
-  appOrientation: DeviceRotation | null,
+  appOrientation: DeviceRotation | null | undefined,
   deviceOrientation: DeviceRotation,
   coords: NormalizedCoordinates
 ): NormalizedCoordinates {

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -104,12 +104,12 @@ function PreviewView() {
   const isRunning = selectedDeviceSession?.status === "running";
 
   const isRecording = use$(selectedDeviceSessionState.screenCapture.isRecording);
-  const recordingTime = use$(selectedDeviceSessionState.screenCapture.recordingTime);
-  const replayData = use$(selectedDeviceSessionState.screenCapture.replayData);
+  const recordingTime = use$(selectedDeviceSessionState.screenCapture.recordingTime) ?? 0;
+  const replayData = use$(selectedDeviceSessionState.screenCapture.replayData) ?? null;
 
-  const elementInspectorAvailability = use$(
-    selectedDeviceSessionState.applicationSession.elementInspectorAvailability
-  );
+  const elementInspectorAvailability =
+    use$(selectedDeviceSessionState.applicationSession.elementInspectorAvailability) ??
+    InspectorAvailabilityStatus.Available;
 
   const inspectorAvailabilityStatus = isRunning
     ? elementInspectorAvailability
@@ -229,10 +229,14 @@ function PreviewView() {
 
   const logCounter = use$(isRunning ? selectedDeviceSessionState.applicationSession.logCounter : 0);
   const profilingCPUState = use$(() =>
-    isRunning ? selectedDeviceSessionState.applicationSession.profilingCPUState.get() : "stopped"
+    isRunning
+      ? (selectedDeviceSessionState.applicationSession.profilingCPUState.get() ?? "stopped")
+      : "stopped"
   );
   const profilingReactState = use$(() =>
-    isRunning ? selectedDeviceSessionState.applicationSession.profilingReactState.get() : "stopped"
+    isRunning
+      ? (selectedDeviceSessionState.applicationSession.profilingReactState.get() ?? "stopped")
+      : "stopped"
   );
 
   return (

--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -105,7 +105,7 @@ function PreviewView() {
 
   const isRecording = use$(selectedDeviceSessionState.screenCapture.isRecording);
   const recordingTime = use$(selectedDeviceSessionState.screenCapture.recordingTime) ?? 0;
-  const replayData = use$(selectedDeviceSessionState.screenCapture.replayData) ?? null;
+  const replayData = use$(selectedDeviceSessionState.screenCapture.replayData);
 
   const elementInspectorAvailability =
     use$(selectedDeviceSessionState.applicationSession.elementInspectorAvailability) ??


### PR DESCRIPTION
This PR adds typing to the `useSelectedDeviceSessionState` to take in to account the fact that it can be undefined 

### How Has This Been Tested: 

- open app 
- kill the device it was running on 

### How Has This Change Been Documented:

internal 


