### PR TITLE
Add actionable error for node version mismatch

### DIFF
--- a/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
@@ -165,12 +165,10 @@ export class ApplicationDependencyManager implements Disposable {
     if (!requiredNodeInstalled) {
       if (installedVersion) {
         throw new Error(
-          `Node.js version mismatch: Found version ${installedVersion} but minimum required is ${minimumVersion}`
+          `Node.js version mismatch: Found version ${installedVersion} but minimum required is ${minimumVersion}.`
         );
       }
-      throw new Error(
-        "Node.js was not found, or the version in the PATH does not satisfy minimum version requirements."
-      );
+      throw new Error("Node.js executable was not found in the PATH.");
     }
   }
 
@@ -183,9 +181,6 @@ export class ApplicationDependencyManager implements Disposable {
       this.stateManager.setState({
         nodeVersion: {
           status: isMinimumNodeVersion ? "installed" : "notInstalled",
-          details: isMinimumNodeVersion
-            ? undefined
-            : `Found version ${nodeVersion} but minimum required is ${minimumNodeVersion}`,
           isOptional: false,
         },
       });
@@ -198,7 +193,6 @@ export class ApplicationDependencyManager implements Disposable {
       this.stateManager.setState({
         nodeVersion: {
           status: "notInstalled",
-          details: "Node.js installation not found in the path",
           isOptional: false,
         },
       });


### PR DESCRIPTION
Currently, the node version check returns a vague information that node is missing or the version is too low. It could be tricky for people to tell especially that the RN project template doesn't contain the node engine requirements and only react-native package.json has.

This PR, adds a better error for this case:
1) when node is not detected at all, we say it is not found in path
2) when node is too low we print the version that Radon detects and the minimum version.

<img width="431" height="294" alt="image" src="https://github.com/user-attachments/assets/6c0f6fa1-47f7-4c7d-bec9-57d17c554096" />

### How Has This Been Tested: 
1) change node version with nvm to some old one
2) run any project 
3) see the new error
4) to test the node missing I renamed `node` exec to some different name such that the exec crashes