### PR TITLE
Fix missing tooltip lables in Radon UI

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/IconButton.tsx
@@ -91,7 +91,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, PropsWithDataTest<IconBut
     return (
       <Tooltip
         label={label}
-        disabled={shouldDisplayLabelWhileDisabled && disabled}
+        disabled={disabled && !shouldDisplayLabelWhileDisabled}
         side={tooltipSide}
         type={tooltipType ?? type}>
         {button}


### PR DESCRIPTION
In #1399 we accidently broke toltips by adding invalid condition that'd disable tooltips by default unless the newly added flag `shouldDisplayLabelWhileDisabled` was set.

This PR fixes the condition by honoring the flag only when `disabled` flag is set.

Before: we were disabling the tooltip always unless `shouldDisplayLabelWhileDisabled=true` was specified for icon button
Now: when `disabled=true` is set, only then we check `shouldDisplayLabelWhileDisabled` flag. When it is set, the tooltip will be disabled, otherwise the tooltip will show.

### How Has This Been Tested: 
1) open IDE, see that the tooltips are showing on buttons
2) disabled buttons (i.e. back button) won't show the tooltip
