### PR TITLE
Fix 'open channel' flow after #1386

### DIFF
--- a/packages/vscode-extension/src/project/OutputChannelRegistry.ts
+++ b/packages/vscode-extension/src/project/OutputChannelRegistry.ts
@@ -2,16 +2,12 @@ import { Disposable } from "vscode";
 import { Output } from "../common/OutputChannel";
 import { createReadableOutputChannel, ReadableLogOutputChannel } from "./ReadableLogOutputChannel";
 
+type OutputExceptIde = Exclude<Output, Output.Ide>;
+
 export class OutputChannelRegistry implements Disposable {
-  private channelByName = new Map<Output, ReadableLogOutputChannel>();
+  private channelByName = new Map<OutputExceptIde, ReadableLogOutputChannel>();
 
-  getOrCreateOutputChannel(channel: Output): ReadableLogOutputChannel {
-    if (channel === Output.Ide) {
-      throw Error(
-        "Output.Ide output channel cannot be accessed through OutputChannelRegistry. Use Logger instead."
-      );
-    }
-
+  getOrCreateOutputChannel(channel: OutputExceptIde): ReadableLogOutputChannel {
     const logOutput = this.channelByName.get(channel);
 
     if (logOutput) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -745,7 +745,11 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
   // #region Logging
 
   public async focusOutput(channel: Output): Promise<void> {
-    this.outputChannelRegistry.getOrCreateOutputChannel(channel).show();
+    if (channel === Output.Ide) {
+      Logger.openOutputPanel();
+    } else {
+      this.outputChannelRegistry.getOrCreateOutputChannel(channel).show();
+    }
   }
 
   public async log(type: "info" | "error" | "warn" | "log", message: string, ...args: unknown[]) {


### PR DESCRIPTION
In  #1386 we accidently broke focusOutput method because we added a `throw` statement whenever the main logger output channel is requested.

This PR fixes that code by:
1) removing the throw statement from output registry. We change the types such that the main logger output type is excluded since it isn't managed by the registry anyway.
2) we add a check in focusOutput method to conditionally call into Logger.openOutputPanel

### How Has This Been Tested: 
1) use the output channel button to reveal IDE logs
2) it should work now
