### PR TITLE
fix: screen recording works only once

### DIFF
--- a/packages/vscode-extension/src/project/ScreenCapture.ts
+++ b/packages/vscode-extension/src/project/ScreenCapture.ts
@@ -87,6 +87,9 @@ export class ScreenCapture implements Disposable {
     clearTimeout(this.recordingTimeout);
     clearInterval(this.recordingTimer);
 
+    this.recordingTimeout = undefined;
+    this.recordingTimer = undefined;
+
     this.stateManager.setState({ isRecording: false, recordingTime: 0 });
 
     return this.device.captureAndStopRecording(


### PR DESCRIPTION
Fixes a regression from #1474 

### How Has This Been Tested: 
- open an app in Radon
- start and stop recording screen
- start and stop recording screen

### How Has This Change Been Documented:
bugfix


