### PR TITLE
fix: build stale errors when switching projects

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -62,7 +62,7 @@ export class DeviceSessionsManager implements Disposable {
     private readonly applicationContext: ApplicationContext,
     private readonly deviceManager: DeviceManager,
     private readonly devicesStateManager: StateManager<DevicesState>,
-    private readonly deviceSessionManagerDelegate: DeviceSessionsManagerDelegate,
+    private deviceSessionManagerDelegate: DeviceSessionsManagerDelegate,
     private readonly outputChannelRegistry: OutputChannelRegistry
   ) {
     this.disposables.push(
@@ -353,6 +353,15 @@ export class DeviceSessionsManager implements Disposable {
   }, SWITCH_DEVICE_THROTTLE_MS);
 
   dispose() {
-    disposeAll([...this.deviceSessions.values().toArray(), ...this.disposables]);
+    // NOTE: we overwrite the delegate to avoid calling it during/after dispose
+    this.deviceSessionManagerDelegate = {
+      onInitialized: () => {},
+      onDeviceSessionsManagerStateChange: (_state: DeviceSessionsManagerState) => {},
+      getDeviceRotation: () => DeviceRotation.Portrait,
+    };
+    const deviceSessions = this.deviceSessions.values().toArray();
+    this.deviceSessions.clear();
+    this.activeSessionId = undefined;
+    disposeAll([...deviceSessions, ...this.disposables]);
   }
 }


### PR DESCRIPTION
Fixes #1515

The issue was caused by the file watcher callback from the old `DeviceSession` reading the new `LaunchConfiguration` with the new app root, causing the fingerprints to mismatch. 
This resulted in a state change for the device session, which caused a state change for the (now disposed) previous `DeviceSessionsManager`, which triggered `Project`'s state change via the delegate method.
This PR fixes the issue by preventing a disposed `DeviceSessionsManager` from triggering state changes.

### How Has This Been Tested: 
- open a monorepo in Radon
- wait for the app to load
- switch approots
- the "Native dependencies changed" shouldn't trigger

### How Has This Change Been Documented:
bugfix


