### PR TITLE
Fix Expo 54 support by correcting the resolve paths for @expo/cli module

### DIFF
--- a/packages/vscode-extension/lib/expo_go_download.js
+++ b/packages/vscode-extension/lib/expo_go_download.js
@@ -1,6 +1,11 @@
-const { requireFromAppDir, appRoot } = require("./metro_helpers");
-const { getConfig } = requireFromAppDir("@expo/config/build/Config.js");
-const { downloadExpoGoAsync } = requireFromAppDir("@expo/cli/build/src/utils/downloadExpoGoAsync");
+const { requireFromAppDir, resolveFromAppDir, appRoot } = require("./metro_helpers");
+const expoInstallPath = resolveFromAppDir("expo");
+const { getConfig } = requireFromAppDir("@expo/config/build/Config.js", {
+  paths: [expoInstallPath],
+});
+const { downloadExpoGoAsync } = requireFromAppDir("@expo/cli/build/src/utils/downloadExpoGoAsync", {
+  paths: [expoInstallPath],
+});
 
 async function main() {
   let platform = process.argv[2]; // 'Android' or 'iOS'

--- a/packages/vscode-extension/lib/expo_go_project_tester.js
+++ b/packages/vscode-extension/lib/expo_go_project_tester.js
@@ -1,9 +1,12 @@
-const { requireFromAppDir, appRoot } = require("./metro_helpers");
-const { resolveOptionsAsync } = requireFromAppDir("@expo/cli/build/src/start/resolveOptions");
+const { requireFromAppDir, resolveFromAppDir, appRoot } = require("./metro_helpers");
+const expoInstallPath = resolveFromAppDir("expo");
+const { resolveOptionsAsync } = requireFromAppDir("@expo/cli/build/src/start/resolveOptions", {
+  paths: [expoInstallPath],
+});
 
 // This is a test script to ensure that the `expo-go-project` package can be imported and used in a project.
 // It is expected to fail either due to missing imports or because of devClient flag is set which indicates that the project
-// is not a Expo Go project.
+// is not an Expo Go project.
 async function main() {
   const { devClient } = await resolveOptionsAsync(appRoot, {});
   if (devClient) {

--- a/packages/vscode-extension/lib/expo_start.js
+++ b/packages/vscode-extension/lib/expo_start.js
@@ -1,6 +1,7 @@
 const {
   adaptMetroConfig,
   requireFromAppDir,
+  resolveFromAppDir,
   overrideModuleFromAppDir,
 } = require("./metro_helpers");
 
@@ -17,8 +18,14 @@ metroConfig.loadConfig = async function (...args) {
 // base terminal reporter class from metro that Expo CLI extends
 overrideModuleFromAppDir("metro/src/lib/TerminalReporter", require("./metro_reporter"));
 
-// since expo 54 this is the new path that the Terminal reporter is imported from, by expo
-overrideModuleFromAppDir("@expo/metro/metro/lib/TerminalReporter", require("./metro_reporter"));
+const expoInstallPath = resolveFromAppDir("expo");
 
-const { expoStart } = requireFromAppDir("@expo/cli/build/src/start/index");
+// since expo 54 this is the new path that the Terminal reporter is imported from, by expo
+overrideModuleFromAppDir("@expo/metro/metro/lib/TerminalReporter", require("./metro_reporter"), {
+  paths: [expoInstallPath],
+});
+
+const { expoStart } = requireFromAppDir("@expo/cli/build/src/start/index", {
+  paths: [expoInstallPath],
+});
 expoStart(process.argv.slice(2)); // pass argv but strip node and script name

--- a/packages/vscode-extension/lib/metro_helpers.js
+++ b/packages/vscode-extension/lib/metro_helpers.js
@@ -4,17 +4,19 @@ const appRoot = path.resolve();
 
 // Instead of using require in this code, we should use require_app, which will
 // resolve modules relative to the app root, not the extension lib root.
-function requireFromAppDir(module) {
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  const path = require.resolve(module, { paths: [appRoot] });
+function requireFromAppDir(module, options) {
+  const path = resolveFromAppDir(module, options);
   return require(path);
 }
 
-function overrideModuleFromAppDir(moduleName, exports) {
+function resolveFromAppDir(module, options) {
+  const paths = options && options.paths ? [...options.paths, appRoot] : [appRoot];
+  return require.resolve(module, { paths });
+}
+
+function overrideModuleFromAppDir(moduleName, exports, options) {
   try {
-    const moduleToOverride = require.resolve(moduleName, {
-      paths: [appRoot],
-    });
+    const moduleToOverride = resolveFromAppDir(moduleName, options);
     require.cache[moduleToOverride] = {
       exports,
     };
@@ -173,5 +175,6 @@ module.exports = {
   appRoot,
   adaptMetroConfig,
   requireFromAppDir,
+  resolveFromAppDir,
   overrideModuleFromAppDir,
 };

--- a/packages/vscode-extension/src/utilities/expoCli.ts
+++ b/packages/vscode-extension/src/utilities/expoCli.ts
@@ -23,9 +23,12 @@ export function shouldUseExpoCLI(launchConfig: ResolvedLaunchConfig) {
   let hasExpoConfigInAppJson = false;
   let hasExpoConfigInAppConfigJs = false;
   try {
+    const expoInstallPath = require.resolve("expo", {
+      paths: [appRoot],
+    });
     hasExpoCLIInstalled =
-      require.resolve("@expo/cli/build/src/start/index", {
-        paths: [appRoot],
+      require.resolve("@expo/cli", {
+        paths: [expoInstallPath],
       }) !== undefined;
   } catch (e) {}
 


### PR DESCRIPTION
After updating to expo 54 we noticed that the @expo/cli package no longer installs under `node_modules` but in the relative `node_modules/expo/node_modules` location. This change must've been introduced in between the latest Expo beta and the now public release.

While it isn't entirely clear why this is happening, `@expo/cli` has never been a direct app dependency anyway and has always be indirectly installed via `expo` package. 

This PR makes it so that when resolving `@expo/cli` package we always provide `expo` package location as the path. This results in the same behavior as if the `expo` package was importing `@expo/cli` and allows us to properly resolve the location of that package.

The "old" way of installing works as well, because node dependency resolution always perform lookup in parent directories too. This makes it possible for the `expo` package to import `@expo/cli` regardless whether the latter is installed under its isolated `node_modules` folder or somewhere up the directory hierarchy. 

### How Has This Been Tested: 
1) create new expo-54 project (expo go) and run it – see it loads up correctly
2) try prebuilding the project and running again
3) test expo 52 and expo 53 projects.

