### PR TITLE
Pass port number to expo start to fix Expo 54 dev client

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -396,12 +396,13 @@ export class MetroLauncher extends Metro implements Disposable {
 
   private launchExpoMetro(
     appRootFolder: string,
+    port: number,
     libPath: string,
     resetCache: boolean,
     expoStartExtraArgs: string[] | undefined,
     metroEnv: typeof process.env
   ) {
-    const args = [path.join(libPath, "expo_start.js")];
+    const args = [path.join(libPath, "expo_start.js"), "--port", `${port}`];
     if (resetCache) {
       args.push("--clear");
     }
@@ -504,6 +505,7 @@ export class MetroLauncher extends Metro implements Disposable {
     if (shouldUseExpoCLI(launchConfiguration)) {
       bundlerProcess = this.launchExpoMetro(
         appRoot,
+        port,
         libPath,
         resetCache,
         launchConfiguration.expoStartArgs,


### PR DESCRIPTION
In earlier versions we'd rely on `RCT_METRO_PORT` env variable in order to control custom port with `expo start` command. Apparently, with Expo 54 some parts of the dev server reads from that variable while others expect the `--port` variable to be set.

When building with dev-client, the deeplink generated by the expo server would correctly contain the custom port, but when the app would fetch the manifest, it'd point to the default 8081 port. Given we now know the port beforeahead we can pass that to expo_start process.

Weirdly enough, the above still wasn't an issue with expo go based setups.

### How Has This Been Tested: 
1) create new Expo 54 devclient project and test it – it should boot up correctly
2) test Expo go and Expo dev client on SDK 52 to make sure the port argument didn't break older setups.

