### PR TITLE
chore: import AppRegistry from react native instead from RN internals

### DIFF
--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.73.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.73.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.74.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.74.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.75.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.75.js
@@ -1,6 +1,5 @@
 module.exports =  {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.76.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.76.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.77.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.77.js
@@ -1,6 +1,5 @@
 module.exports =  {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.78.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.78.js
@@ -1,6 +1,5 @@
 module.exports =  {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack"),
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry"),
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.79.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.79.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack").default,
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry").default,
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.80.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.80.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack").default,
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry").AppRegistry,
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.81.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.81.js
@@ -1,6 +1,5 @@
 module.exports = {
   parseErrorStack: require("react-native/Libraries/Core/Devtools/parseErrorStack").default,
-  AppRegistry: require("react-native/Libraries/ReactNative/AppRegistry").AppRegistry,
   get LogBoxData() {
     return require("react-native/Libraries/LogBox/Data/LogBoxData");
   },

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -1,5 +1,5 @@
 const RNInternals = require("./rn-internals/rn-internals");
-const AppRegistry = RNInternals.AppRegistry;
+const { AppRegistry } = require("react-native");
 const parseErrorStack = RNInternals.parseErrorStack;
 
 // We add log this trace to diagnose issues with loading runtime in the IDE


### PR DESCRIPTION
This is the first step in our new quest to remove internal react native dependencies from our code base. 
This one is straight forward as `AppRegistry` already exists in stable exports. 

### How Has This Been Tested: 

- run `react-native-74` test app on android (the oldest I could make work) 
- check[ this branch ](https://github.com/facebook/react-native/blob/0.73-stable/packages/react-native/index.js) in react native repo to make sure that react native 73 has `AppRegistry` exported as well. 

### How Has This Change Been Documented:

internal change 


