### PR TITLE
feat: Add `enableExperimentalElementInspector` setting

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -305,11 +305,11 @@
           "default": true,
           "description": "Automatically starts the last used device when opening the IDE Panel."
         },
-        "RadonIDE.enableExperimentalInspector": {
+        "RadonIDE.enableExperimentalElementInspector": {
           "type": "boolean",
           "scope": "window",
           "default": false,
-          "description": "Enables experimental support of element inspector, which may cause visual issues on some of the applications."
+          "description": "Enables experimental support of element inspector for Non-Edge-to-Edge applications, which may cause visual issues."
         }
       }
     },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -304,6 +304,12 @@
           "scope": "window",
           "default": true,
           "description": "Automatically starts the last used device when opening the IDE Panel."
+        },
+        "RadonIDE.enableExperimentalInspector": {
+          "type": "boolean",
+          "scope": "window",
+          "default": false,
+          "description": "Enables experimental support of element inspector, which may cause visual issues on some of the applications."
         }
       }
     },

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -19,6 +19,7 @@ export type WorkspaceConfiguration = {
   inspectorExcludePattern: string | null;
   defaultMultimediaSavingLocation: string | null;
   startDeviceOnLaunch: boolean;
+  enableExperimentalInspector: boolean;
 };
 
 // #endregion Workspace Configuration
@@ -339,6 +340,7 @@ export const initialState: State = {
     inspectorExcludePattern: null,
     defaultMultimediaSavingLocation: null,
     startDeviceOnLaunch: true,
+    enableExperimentalInspector: false,
   },
 };
 

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -19,7 +19,7 @@ export type WorkspaceConfiguration = {
   inspectorExcludePattern: string | null;
   defaultMultimediaSavingLocation: string | null;
   startDeviceOnLaunch: boolean;
-  enableExperimentalInspector: boolean;
+  enableExperimentalElementInspector: boolean;
 };
 
 // #endregion Workspace Configuration
@@ -340,7 +340,7 @@ export const initialState: State = {
     inspectorExcludePattern: null,
     defaultMultimediaSavingLocation: null,
     startDeviceOnLaunch: true,
-    enableExperimentalInspector: false,
+    enableExperimentalElementInspector: false,
   },
 };
 

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -18,7 +18,8 @@ export class WorkspaceConfigController implements Disposable {
       stopPreviousDevices: configuration.get<boolean>("stopPreviousDevices")!,
       deviceRotation: configuration.get<DeviceRotation>("deviceRotation")!,
       startDeviceOnLaunch: configuration.get<boolean>("startDeviceOnLaunch") ?? true,
-      enableExperimentalInspector: configuration.get<boolean>("enableExperimentalInspector") ?? false,
+      enableExperimentalElementInspector:
+        configuration.get<boolean>("enableExperimentalElementInspector") ?? false,
     };
 
     this.stateManager.setState(workspaceConfig);
@@ -39,7 +40,8 @@ export class WorkspaceConfigController implements Disposable {
         defaultMultimediaSavingLocation:
           config.get<string>("defaultMultimediaSavingLocation") ?? null,
         startDeviceOnLaunch: config.get<boolean>("startDeviceOnLaunch") ?? true,
-        enableExperimentalInspector: config.get<boolean>("enableExperimentalInspector") ?? false,
+        enableExperimentalElementInspector:
+          config.get<boolean>("enableExperimentalElementInspector") ?? false,
       };
 
       for (const partialStateEntry of partialStateEntries) {
@@ -62,7 +64,6 @@ export class WorkspaceConfigController implements Disposable {
   }
 
   private onConfigurationChange = (event: ConfigurationChangeEvent) => {
-    
     if (!event.affectsConfiguration("RadonIDE")) {
       return;
     }
@@ -77,7 +78,8 @@ export class WorkspaceConfigController implements Disposable {
       defaultMultimediaSavingLocation:
         config.get<string>("defaultMultimediaSavingLocation") ?? null,
       startDeviceOnLaunch: config.get<boolean>("startDeviceOnLaunch") ?? true,
-      enableExperimentalInspector: config.get<boolean>("enableExperimentalInspector") ?? false,
+      enableExperimentalElementInspector:
+        config.get<boolean>("enableExperimentalInspector") ?? false,
     };
 
     const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -18,6 +18,7 @@ export class WorkspaceConfigController implements Disposable {
       stopPreviousDevices: configuration.get<boolean>("stopPreviousDevices")!,
       deviceRotation: configuration.get<DeviceRotation>("deviceRotation")!,
       startDeviceOnLaunch: configuration.get<boolean>("startDeviceOnLaunch") ?? true,
+      enableExperimentalInspector: configuration.get<boolean>("enableExperimentalInspector") ?? false,
     };
 
     this.stateManager.setState(workspaceConfig);
@@ -38,6 +39,7 @@ export class WorkspaceConfigController implements Disposable {
         defaultMultimediaSavingLocation:
           config.get<string>("defaultMultimediaSavingLocation") ?? null,
         startDeviceOnLaunch: config.get<boolean>("startDeviceOnLaunch") ?? true,
+        enableExperimentalInspector: config.get<boolean>("enableExperimentalInspector") ?? false,
       };
 
       for (const partialStateEntry of partialStateEntries) {
@@ -60,6 +62,7 @@ export class WorkspaceConfigController implements Disposable {
   }
 
   private onConfigurationChange = (event: ConfigurationChangeEvent) => {
+    
     if (!event.affectsConfiguration("RadonIDE")) {
       return;
     }
@@ -74,6 +77,7 @@ export class WorkspaceConfigController implements Disposable {
       defaultMultimediaSavingLocation:
         config.get<string>("defaultMultimediaSavingLocation") ?? null,
       startDeviceOnLaunch: config.get<boolean>("startDeviceOnLaunch") ?? true,
+      enableExperimentalInspector: config.get<boolean>("enableExperimentalInspector") ?? false,
     };
 
     const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>

--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -79,7 +79,7 @@ export class WorkspaceConfigController implements Disposable {
         config.get<string>("defaultMultimediaSavingLocation") ?? null,
       startDeviceOnLaunch: config.get<boolean>("startDeviceOnLaunch") ?? true,
       enableExperimentalElementInspector:
-        config.get<boolean>("enableExperimentalInspector") ?? false,
+        config.get<boolean>("enableExperimentalElementInspector") ?? false,
     };
 
     const index = this.workspaceConfigurationUpdatesToIgnore.findIndex((cfg) =>

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -81,7 +81,7 @@ export class ApplicationContext implements Disposable {
 
   constructor(
     private readonly stateManager: StateManager<ApplicationContextState>,
-    private readonly workspaceConfigState: StateManager<WorkspaceConfiguration>, // owned by `Project`, do not dispose
+    public readonly workspaceConfigState: StateManager<WorkspaceConfiguration>, // owned by `Project`, do not dispose
     launchConfig: LaunchConfiguration,
     fingerprintProvider: FingerprintProvider
   ) {

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -415,6 +415,10 @@ export class ApplicationSession implements Disposable {
     });
   }
 
+  /**
+   * Determine availability of the element inspector taking the
+   * enableExperimentalElementInspector setting (force-enable) into account.
+   */
   private determineInspectorAvailability(
     status: InspectorAvailabilityStatus
   ): InspectorAvailabilityStatus {
@@ -433,6 +437,7 @@ export class ApplicationSession implements Disposable {
 
   private registerConfigurationChangeListeners() {
     const subscriptions = [
+      // react to enableExperimentalElementInspector setting changes
       this.applicationContext.workspaceConfigState.onSetState(() => {
         const status = this.determineInspectorAvailability(
           this.lastRegisteredInspectorAvailability

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -192,8 +192,7 @@ export class ApplicationSession implements Disposable {
     this.inspectorBridge = devtoolsInspectorBridge;
     const inspectorBridgeSubscriptions =
       this.registerInspectorBridgeEventListeners(devtoolsInspectorBridge);
-    const configurationChangeSubscriptions =
-      this.registerConfigurationChangeListeners(devtoolsInspectorBridge);
+    const configurationChangeSubscriptions = this.registerConfigurationChangeListeners();
     this.disposables.push(
       devtoolsInspectorBridge,
       ...inspectorBridgeSubscriptions,
@@ -432,11 +431,13 @@ export class ApplicationSession implements Disposable {
     return newAvailabilityStatus;
   }
 
-  private registerConfigurationChangeListeners(inspectorBridge: RadonInspectorBridge) {
+  private registerConfigurationChangeListeners() {
     const subscriptions = [
-      this.applicationContext.workspaceConfigState.onSetState((config) => {
-        console.log("mleko", config);
-        inspectorBridge.emitInspectorAvailabilityUpdate(this.lastRegisteredInspectorAvailability);
+      this.applicationContext.workspaceConfigState.onSetState(() => {
+        const status = this.determineInspectorAvailability(
+          this.lastRegisteredInspectorAvailability
+        );
+        this.stateManager.setState({ elementInspectorAvailability: status });
       }),
     ];
     return subscriptions;

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -420,7 +420,7 @@ export class ApplicationSession implements Disposable {
     status: InspectorAvailabilityStatus
   ): InspectorAvailabilityStatus {
     const experimentalInspectorEnabled =
-      this.applicationContext.workspaceConfiguration.enableExperimentalInspector;
+      this.applicationContext.workspaceConfiguration.enableExperimentalElementInspector;
     const isStatusUnavailableEdgeToEdge =
       status === InspectorAvailabilityStatus.UnavailableEdgeToEdge;
 

--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -23,7 +23,6 @@ export interface RadonInspectorBridge {
   sendOpenNavigationRequest(id: string): void;
   sendOpenPreviewRequest(previewId: string): void;
   sendShowStorybookStoryRequest(componentTitle: string, storyName: string): void;
-  emitInspectorAvailabilityUpdate(status: InspectorAvailabilityStatus): void;
   onEvent<K extends keyof RadonInspectorBridgeEvents>(
     event: K,
     listener: (...payload: RadonInspectorBridgeEvents[K]) => void
@@ -119,14 +118,5 @@ export abstract class BaseInspectorBridge implements RadonInspectorBridge {
       type: "showStorybookStory",
       data: { componentTitle, storyName },
     });
-  }
-
-  emitInspectorAvailabilityUpdate(status: InspectorAvailabilityStatus): void {
-    //@ts-ignore - FIXME, consider how to type this properly, as
-    // all the events through inspector-bridge are sent as a single argument
-    // (see ConnectionSession.ts or devtools.ts emitEvent calls - the data is typed as an array or any
-    // but sent argument is value, not an array). Despite that, emitEvent expects the array,
-    // which comes from RadonInspectorBridgeEvents.
-    this.emitEvent("inspectorAvailabilityChanged", status);
   }
 }

--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -23,6 +23,7 @@ export interface RadonInspectorBridge {
   sendOpenNavigationRequest(id: string): void;
   sendOpenPreviewRequest(previewId: string): void;
   sendShowStorybookStoryRequest(componentTitle: string, storyName: string): void;
+  emitInspectorAvailabilityUpdate(status: InspectorAvailabilityStatus): void;
   onEvent<K extends keyof RadonInspectorBridgeEvents>(
     event: K,
     listener: (...payload: RadonInspectorBridgeEvents[K]) => void
@@ -118,5 +119,14 @@ export abstract class BaseInspectorBridge implements RadonInspectorBridge {
       type: "showStorybookStory",
       data: { componentTitle, storyName },
     });
+  }
+
+  emitInspectorAvailabilityUpdate(status: InspectorAvailabilityStatus): void {
+    //@ts-ignore - FIXME, consider how to type this properly, as
+    // all the events through inspector-bridge are sent as a single argument
+    // (see ConnectionSession.ts or devtools.ts emitEvent calls - the data is typed as an array or any
+    // but sent argument is value, not an array). Despite that, emitEvent expects the array, 
+    // which comes from RadonInspectorBridgeEvents.
+    this.emitEvent("inspectorAvailabilityChanged", status);
   }
 }

--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -125,7 +125,7 @@ export abstract class BaseInspectorBridge implements RadonInspectorBridge {
     //@ts-ignore - FIXME, consider how to type this properly, as
     // all the events through inspector-bridge are sent as a single argument
     // (see ConnectionSession.ts or devtools.ts emitEvent calls - the data is typed as an array or any
-    // but sent argument is value, not an array). Despite that, emitEvent expects the array, 
+    // but sent argument is value, not an array). Despite that, emitEvent expects the array,
     // which comes from RadonInspectorBridgeEvents.
     this.emitEvent("inspectorAvailabilityChanged", status);
   }


### PR DESCRIPTION
### Description

This PR introduces `enableExperimentalElementInspector` vscode setting, which allows for force-enabling element inspector on Edge-to-Edge apps.

<img width="1562" height="394" alt="image" src="https://github.com/user-attachments/assets/da322bde-f6f1-47c0-ac01-7c71f5ac80c0" />

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **toggle setting on / off, see if Element Inspector behaves as expected (in normal and non-edge-to-edge apps)**

### How Has This Change Been Documented:

Not applicable.
