### PR TITLE
Add flag to force custom JS debugger implementation (aka old debugger)

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -618,6 +618,10 @@
               "usePrebuild": {
                 "type": "boolean",
                 "description": "When set, Radon will run Expo Prebuild before building the application. Only applies to applications using Expo CLI."
+              },
+              "useCustomJSDebugger": {
+                "type": "boolean",
+                "description": "When set to true, Radon will use a custom implementation of the JavaScript debugger. This is an experimental feature, use with caution."
               }
             }
           }
@@ -840,6 +844,10 @@
               "usePrebuild": {
                 "type": "boolean",
                 "description": "When set, Radon will run Expo Prebuild before building the application. Only applies to applications using Expo CLI."
+              },
+              "useCustomJSDebugger": {
+                "type": "boolean",
+                "description": "When set to true, Radon will use a custom implementation of the JavaScript debugger. This is an experimental feature, use with caution."
               }
             }
           }

--- a/packages/vscode-extension/src/common/LaunchConfig.ts
+++ b/packages/vscode-extension/src/common/LaunchConfig.ts
@@ -29,6 +29,7 @@ export interface LaunchOptions {
     waitForAppLaunch?: boolean;
   };
   usePrebuild?: boolean;
+  useCustomJSDebugger?: boolean;
 }
 
 export const LAUNCH_OPTIONS_KEYS = [
@@ -45,6 +46,7 @@ export const LAUNCH_OPTIONS_KEYS = [
   "packageManager",
   "preview",
   "usePrebuild",
+  "useCustomJSDebugger",
 ] as const;
 
 type IsSuperTypeOf<Base, T extends Base> = T;

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -209,6 +209,7 @@ export class ApplicationSession implements Disposable {
       new DebugSessionImpl({
         displayName: this.device.deviceInfo.displayName,
         useParentDebugSession: true,
+        useCustomJSDebugger: this.applicationContext.launchConfig.useCustomJSDebugger,
       }),
       this.metro,
       this.devtoolsServer


### PR DESCRIPTION
Historically, we know that the vscode-js-debug implementation startup can be much slower (a few seconds) on large apps. We want to add a "hidden", experimental flag that would allow users to try the "old debugger" implementation to see if it improves things for them.

Since we still use our "old debugger", I decided to rename the constants as follows:
1) The old debugger is now called "custom JS debugger"
2) The new one that is backed by vscode-js-debug implementation is called "vscode JS debugger"

Summary of the changes:
1) We add a new optional configuration flag `useCustomJSDebugger` that forces the custom JS debugger to be enabled. The flag isn't exposed via the configuration UI and can only be set in the JSON file. This is by design as we don't want to advertise the use of it for the time being.
2) We update the debug session logic such that it considers the above flag when starting session
3) We rename constants to use new terms for VSCode JS debugger and Custom JS debugger.

### How Has This Been Tested: 
1) Run Expo 54 project
2) Place a conditional breakpoint with condition set to "false" -> see the debugger doesn't break
3) Add new launch configuration and enable `useCustomJSDebugger` in the `launch.json`
4) When launched from this configuration the debugger would pause on the conditional breakpoint and when you hover breakpoint you'll see an info that this breakpoint type isn't supported.

