### PR TITLE
fix: crashes due to missing fields in simctl output

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -40,7 +40,7 @@ interface SimulatorInfo {
   type?: "simulator" | "device" | "catalyst";
   booted?: boolean;
   lastBootedAt?: string;
-  deviceTypeIdentifier: string;
+  deviceTypeIdentifier?: string;
 }
 
 interface SimulatorData {
@@ -740,21 +740,26 @@ export async function listSimulators(location: SimulatorDeviceSet): Promise<IOSD
     .map(([runtimeID, devices]) => {
       const runtime = runtimes.find((item) => item.identifier === runtimeID);
 
-      return devices.map((device) => {
-        return {
-          id: `ios-${device.udid}`,
-          platform: DevicePlatform.IOS as const,
-          UDID: device.udid,
-          modelId: device.deviceTypeIdentifier,
-          systemName: runtime?.name ?? "Unknown",
-          displayName: device.name,
-          deviceType: device.deviceTypeIdentifier.includes("iPad")
-            ? DeviceType.Tablet
-            : DeviceType.Phone,
-          available: device.isAvailable ?? false,
-          runtimeInfo: runtime,
-        };
-      });
+      return devices
+        .map((device) => {
+          if (!device.deviceTypeIdentifier) {
+            return undefined;
+          }
+          return {
+            id: `ios-${device.udid}`,
+            platform: DevicePlatform.IOS as const,
+            UDID: device.udid,
+            modelId: device.deviceTypeIdentifier,
+            systemName: runtime?.name ?? "Unknown",
+            displayName: device.name,
+            deviceType: device.deviceTypeIdentifier.includes("iPad")
+              ? DeviceType.Tablet
+              : DeviceType.Phone,
+            available: device.isAvailable ?? false,
+            runtimeInfo: runtime,
+          };
+        })
+        .filter((e) => e !== undefined);
     })
     .flat();
   return simulators;


### PR DESCRIPTION
Fixes #1517

For older runtimes, the `deviceTypeIdentifier` field is missing in the output of `simctl`, causing crashes when trying to read the devices in the system-wide device set.
Previously this wasn't an issue, because we only accessed the devices created by us, which always included that information.
However, in #1471 we read the system-wide devices to choose a destination to pass to `xcodebuild`, resulting in build errors when trying to access the non-existent property.
This PR fixes that.
