### PR TITLE
feat: implement connect and new devtools for custom debugger

### DIFF
--- a/packages/vscode-extension/src/connect/ConnectSession.ts
+++ b/packages/vscode-extension/src/connect/ConnectSession.ts
@@ -76,7 +76,7 @@ export default class ConnectSession implements Disposable {
       this.debugSession.onBindingCalled((event: unknown) => {
         this.inspectorBridge.onBindingCalled(event);
       }),
-      this.debugSession.onBundleParsed(({ isMainBundle }) => {
+      this.debugSession.onScriptParsed(({ isMainBundle }) => {
         if (isMainBundle) {
           this.setupRadonConnectRuntime();
         }

--- a/packages/vscode-extension/src/debugging/CDPSession.ts
+++ b/packages/vscode-extension/src/debugging/CDPSession.ts
@@ -107,7 +107,10 @@ export class CDPSession {
       await this.handleIncomingCDPMethodCalls(message);
     });
 
-    this.onScriptParsed(() => {
+    this.onScriptParsed(({ isMainBundle }) => {
+      if (!isMainBundle) {
+        return;
+      }
       this.debugSessionReady = true;
       this.flushEnqueuedConsoleAPICalls();
       this.delegate.onDebugSessionReady();

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -15,6 +15,8 @@ const VSCODE_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
 export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
 export const DEBUG_PAUSED = "RNIDE_paused";
 export const DEBUG_RESUMED = "RNIDE_continued";
+export const SCRIPT_PARSED = "RNIDE_bundleParsed";
+export const BINDING_CALLED = "RNIDE_bindingCalled";
 
 export interface JSDebugConfiguration {
   websocketAddress: string;
@@ -121,10 +123,10 @@ export class DebugSessionImpl implements DebugSession, Disposable {
           case "RNIDE_profilingCPUStopped":
             this.profilingCPUStoppedEventEmitter.fire(event);
             break;
-          case "RNIDE_bindingCalled":
+          case BINDING_CALLED:
             this.bindingCalledEventEmitter.fire(event.body);
             break;
-          case "RNIDE_bundleParsed":
+          case SCRIPT_PARSED:
             this.bundleParsedEventEmitter.fire(event.body);
             break;
           default:

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -15,7 +15,7 @@ const VSCODE_JS_DEBUGGER_TYPE = "com.swmansion.proxy-debugger";
 export const DEBUG_CONSOLE_LOG = "RNIDE_consoleLog";
 export const DEBUG_PAUSED = "RNIDE_paused";
 export const DEBUG_RESUMED = "RNIDE_continued";
-export const SCRIPT_PARSED = "RNIDE_bundleParsed";
+export const SCRIPT_PARSED = "RNIDE_scriptParsed";
 export const BINDING_CALLED = "RNIDE_bindingCalled";
 
 export interface JSDebugConfiguration {
@@ -65,7 +65,7 @@ export interface DebugSession {
   onProfilingCPUStarted(listener: DebugSessionCustomEventListener): Disposable;
   onProfilingCPUStopped(listener: DebugSessionCustomEventListener): Disposable;
   onBindingCalled(listener: (event: Cdp.Runtime.BindingCalledEvent) => void): Disposable;
-  onBundleParsed(listener: (event: { isMainBundle: boolean }) => void): Disposable;
+  onScriptParsed(listener: (event: { isMainBundle: boolean }) => void): Disposable;
   onDebugSessionTerminated(listener: () => void): Disposable;
 }
 
@@ -83,7 +83,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   private profilingCPUStoppedEventEmitter = new vscode.EventEmitter<DebugSessionCustomEvent>();
   private bindingCalledEventEmitter = new vscode.EventEmitter<Cdp.Runtime.BindingCalledEvent>();
   private debugSessionTerminatedEventEmitter = new vscode.EventEmitter<void>();
-  private bundleParsedEventEmitter = new vscode.EventEmitter<{ isMainBundle: boolean }>();
+  private scriptParsedEventEmitter = new vscode.EventEmitter<{ isMainBundle: boolean }>();
 
   public onConsoleLog = this.consoleLogEventEmitter.event;
   public onDebuggerPaused = this.debuggerPausedEventEmitter.event;
@@ -92,7 +92,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   public onProfilingCPUStopped = this.profilingCPUStoppedEventEmitter.event;
   public onBindingCalled = this.bindingCalledEventEmitter.event;
   public onDebugSessionTerminated = this.debugSessionTerminatedEventEmitter.event;
-  public onBundleParsed = this.bundleParsedEventEmitter.event;
+  public onScriptParsed = this.scriptParsedEventEmitter.event;
 
   constructor(private options: DebugSessionOptions = { displayName: "Radon IDE Debugger" }) {
     this.disposables.push(
@@ -127,7 +127,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
             this.bindingCalledEventEmitter.fire(event.body);
             break;
           case SCRIPT_PARSED:
-            this.bundleParsedEventEmitter.fire(event.body);
+            this.scriptParsedEventEmitter.fire(event.body);
             break;
           default:
             // ignore other events

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -7,7 +7,13 @@ import { Disposable } from "vscode";
 import { CDPProxy } from "./CDPProxy";
 import { RadonCDPProxyDelegate } from "./RadonCDPProxyDelegate";
 import { disposeAll } from "../utilities/disposables";
-import { DEBUG_CONSOLE_LOG, DEBUG_PAUSED, DEBUG_RESUMED } from "./DebugSession";
+import {
+  BINDING_CALLED,
+  DEBUG_CONSOLE_LOG,
+  DEBUG_PAUSED,
+  DEBUG_RESUMED,
+  SCRIPT_PARSED,
+} from "./DebugSession";
 import { CDPProfile } from "./cdp";
 import { annotateLocations, filePathForProfile } from "./cpuProfiler";
 import { SourceMapsRegistry } from "./SourceMapsRegistry";
@@ -110,13 +116,13 @@ export class ProxyDebugAdapter extends DebugSession {
 
     this.disposables.push(
       proxyDelegate.onBindingCalled(({ name, payload }) => {
-        this.sendEvent(new Event("RNIDE_bindingCalled", { name, payload }));
+        this.sendEvent(new Event(BINDING_CALLED, { name, payload }));
       })
     );
 
     this.disposables.push(
       proxyDelegate.onBundleParsed(({ isMainBundle }) => {
-        this.sendEvent(new Event("RNIDE_bundleParsed", { isMainBundle }));
+        this.sendEvent(new Event(SCRIPT_PARSED, { isMainBundle }));
       })
     );
   }

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -100,7 +100,7 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   public onProfilingCPUStarted = this.debugSession.onProfilingCPUStarted;
   public onProfilingCPUStopped = this.debugSession.onProfilingCPUStopped;
   public onBindingCalled = this.debugSession.onBindingCalled;
-  public onBundleParsed = this.debugSession.onBundleParsed;
+  public onScriptParsed = this.debugSession.onScriptParsed;
 
   public async startParentDebugSession(): Promise<void> {
     return this.debugSession.startParentDebugSession();

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -199,7 +199,7 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
   constructor(private readonly debugSession: DebugSession) {
     super();
     this.disposables.push(
-      debugSession.onBundleParsed(({ isMainBundle }) => {
+      debugSession.onScriptParsed(({ isMainBundle }) => {
         if (isMainBundle) {
           this.createConnection();
         }


### PR DESCRIPTION
Implements `addBinding` support for the custom JS debugger to allow it to work with Radon Connect and the new RDT-over-CDP implementation when configured.

### How Has This Been Tested: 
- add `"useCustomJSDebugger": true` to a launch configuration for an app running RN >=0.76
- open the app in Radon
- verify the app runs and devtools connect
