### PR TITLE
feat: Change files upload in `Build VSIX nightly`

### DIFF
--- a/.github/workflows/build-vsix-nightly.yaml
+++ b/.github/workflows/build-vsix-nightly.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.prepare_name.outputs.package_name }}-win32-x64.vsix
-          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*win*.vsix
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*win32*.vsix
           retention-days: 7
 
       - name: upload linux

--- a/.github/workflows/build-vsix-nightly.yaml
+++ b/.github/workflows/build-vsix-nightly.yaml
@@ -1,4 +1,4 @@
-name: Build VSIX and Run Tests (macOS)
+name: Build VSIX Nightly
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     - cron: "10 12 * * *"
 
 jobs:
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -74,8 +74,30 @@ jobs:
           done
           echo "output_paths=$output_paths" >> $GITHUB_OUTPUT
 
-      - name: Upload extension artifacts
+      - name: upload mac arm
         uses: actions/upload-artifact@v4
         with:
-          name: radon-ide-extensions
-          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*.vsix
+          name: ${{ steps.prepare_name.outputs.package_name }}-darwin-arm64.vsix
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*darwin-arm64*.vsix
+          retention-days: 7
+
+      - name: upload mac x64
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.prepare_name.outputs.package_name }}-darwin-x64.vsix
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*darwin-x64*.vsix
+          retention-days: 7
+
+      - name: upload windows
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.prepare_name.outputs.package_name }}-win32-x64.vsix
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*win*.vsix
+          retention-days: 7
+
+      - name: upload linux
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.prepare_name.outputs.package_name }}-linux-x64.vsix
+          path: /tmp/${{ steps.prepare_name.outputs.package_name }}-*linux*.vsix
+          retention-days: 7

--- a/.github/workflows/build-vsix-nightly.yaml
+++ b/.github/workflows/build-vsix-nightly.yaml
@@ -3,7 +3,7 @@ name: Build VSIX Nightly
 on:
   workflow_dispatch:
   schedule:
-    - cron: "10 12 * * *"
+    - cron: "47 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Changes files upload in `Build VSIX nightly` workflow.

### How Has This Been Tested: 

Tested manually on GitHub Actions.

<img width="1114" height="281" alt="Screenshot 2025-09-18 at 16 43 24" src="https://github.com/user-attachments/assets/8c57de2a-9a1f-41eb-8e1b-9d636732022a" />


### How Has This Change Been Documented:

no documentation.



