### PR TITLE
Avoid showing multiple runtimes with colliding identifiers

### DIFF
--- a/packages/vscode-extension/src/utilities/iosRuntimes.ts
+++ b/packages/vscode-extension/src/utilities/iosRuntimes.ts
@@ -18,7 +18,7 @@ export async function getAvailableIosRuntimes(): Promise<IOSRuntimeInfo[]> {
   const result: { runtimes: RuntimeInfo[] } = JSON.parse(
     (await exec("xcrun", ["simctl", "list", "runtimes", "--json"])).stdout
   );
-  return result.runtimes
+  const runtimes = result.runtimes
     .filter((runtime) => runtime.platform === "iOS")
     .map((runtime) => ({
       platform: runtime.platform,
@@ -28,4 +28,16 @@ export async function getAvailableIosRuntimes(): Promise<IOSRuntimeInfo[]> {
       supportedDeviceTypes: runtime.supportedDeviceTypes,
       available: runtime.isAvailable,
     }));
+  // there can be multiple runtimes with the same identifier but different buildversion
+  // since the command we use never take build version, we can filter out duplicates and
+  // only show a single runtime for each identifier
+  const seenIdentifiers = new Set<string>();
+  const uniqueRuntimes = runtimes.filter((runtime) => {
+    if (seenIdentifiers.has(runtime.identifier)) {
+      return false;
+    }
+    seenIdentifiers.add(runtime.identifier);
+    return true;
+  });
+  return uniqueRuntimes;
 }


### PR DESCRIPTION
Users who had beta versions of Xcode installed, may end up with multiple iOS runtimes with exact same identifier but different buildversions. Since we only use the identifier for commands that we run (when building or creating devices), it seems sensible to ignore buildversion entirely which is what seems that Xcode is doing already, as multiple runtimes doesn't show up there.

Fixes #1548

### How Has This Been Tested: 
1) I already deleted the orphaned runtimes so just tested that this change didn't break the runtime selector from new device modal
2) I updated the code and hardcoded identifier to always be the same, and verified that only one runtime is listed then.
