### PR TITLE
fix: rotation on iOS 

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -357,6 +357,24 @@ export class IosSimulatorDevice extends DeviceBase {
       ],
       { reject: false }
     );
+
+    // Restarting SpringBoard process breaks the backboardd which in particular controls things like
+    // the rotation settings. We need to restart it following the cfprefsd springboard reset.
+    await exec(
+      "xcrun",
+      [
+        "simctl",
+        "--set",
+        deviceSetLocation,
+        "spawn",
+        this.deviceUDID,
+        "launchctl",
+        "kickstart",
+        "-k",
+        "system/com.apple.backboardd",
+      ],
+      { reject: false }
+    );
   }
 
   async terminateApp(bundleID: string) {


### PR DESCRIPTION
after #1545, we started experiencing issues with rotation not being applied to the device, this seems to be caused by `com.apple.backboardd` service not working properly after `SpringBoard` restart. To fix that we restart `backboardd` as well.

### How Has This Been Tested: 

- run ios device in the new setup and try rotation and appearance change 

### How Has This Change Been Documented:

internal


