### PR TITLE
fix: devices are displayed as "Running" after switching app roots

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -341,6 +341,12 @@ export class DeviceSessionsManager implements Disposable {
     this.updateSelectedSession(this.deviceSessions.get(runningSessions[nextSessionIndex]));
   }, SWITCH_DEVICE_THROTTLE_MS);
 
+  clearState() {
+    const currentState = this.stateManager.getState();
+    const newState = _.mapValues(currentState, (): typeof REMOVE => REMOVE);
+    this.stateManager.updateState(newState);
+  }
+
   dispose() {
     // NOTE: we overwrite the delegate to avoid calling it during/after dispose
     this.deviceSessionManagerDelegate = {
@@ -351,5 +357,6 @@ export class DeviceSessionsManager implements Disposable {
     this.deviceSessions.clear();
     this.activeSessionId = undefined;
     disposeAll([...deviceSessions, ...this.disposables]);
+    this.clearState();
   }
 }

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -265,7 +265,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     // NOTE: we reset the device sessions manager to close all the running sessions
     // and restart the current device with new config. In the future, we might want to keep the devices running
     // and only close the applications, but the API we have right now does not allow that.
-    const oldDeviceSessionsManager = this.deviceSessionsManager;
+    this.deviceSessionsManager.dispose();
     this.deviceSessionsManager = new DeviceSessionsManager(
       this.stateManager.getDerived("deviceSessions"),
       this.stateManager,
@@ -275,7 +275,6 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
       this,
       this.outputChannelRegistry
     );
-    oldDeviceSessionsManager.dispose();
     this.maybeStartInitialDeviceSession();
 
     this.launchConfigsManager.saveInitialLaunchConfig(launchConfig);


### PR DESCRIPTION
Fixes devices appearing as "running" in the UI when switching AppRoots, despite being stopped.

### How Has This Been Tested: 
- open a monorepo in Radon
- open multiple devices
- switch app roots
- verify all devices but the selected one don't appear as "Running" after switching

### How Has This Change Been Documented:
internal