### PR TITLE
fix: cancel throttled functions in `DeviceSession`'s `dispose`, throttle element inspector calls correctly 

### DIFF
--- a/packages/vscode-extension/src/utilities/throttle.ts
+++ b/packages/vscode-extension/src/utilities/throttle.ts
@@ -1,35 +1,5 @@
-type AnyFn = (...args: any[]) => any;
-type ArgsWithForce<T extends AnyFn> = [...args: Parameters<T>, force?: boolean];
-type WithForce<T extends AnyFn> = (...args: ArgsWithForce<T>) => ReturnType<T>;
-
-export function throttle<T extends AnyFn>(func: T, limitMs: number): WithForce<T> {
-  let timeout: NodeJS.Timeout | null = null;
-  let recentArgs: any;
-
-  return function (...args: any) {
-    const force = args[args.length - 1] === true; // Check if the last argument is true (force flag)
-
-    if (force) {
-      if (timeout !== null) {
-        clearTimeout(timeout);
-      }
-      timeout = null;
-      func(...args);
-      return;
-    }
-
-    if (!timeout) {
-      timeout = setTimeout(() => {
-        timeout = null;
-        func(...recentArgs);
-        recentArgs = null;
-      }, limitMs);
-    }
-    recentArgs = args;
-  } as T;
-}
-
 type AsyncFn = (...args: any[]) => Promise<any>;
+type ThrottledAsyncFn<T extends AsyncFn> = T & { cancel: () => void };
 
 /**
  * Throttles the provided async function with the following restrictions:
@@ -39,21 +9,28 @@ type AsyncFn = (...args: any[]) => Promise<any>;
  *   arguments will be executed and that the function will run *after* the last
  *   call is made.
  */
-export function throttleAsync<T extends AsyncFn>(func: T, limitMs: number): T {
-  let isScheduled = false;
-  let recentArgs: any;
+export function throttleAsync<T extends AsyncFn>(
+  func: T,
+  limitMs: number
+): ThrottledAsyncFn<(...args: Parameters<T>) => Promise<void>> {
+  let timeoutId: NodeJS.Timeout | null = null;
+  let recentArgs: Parameters<T> | null;
   let callCount = 0;
 
-  return async function (...args: any) {
-    if (!isScheduled) {
+  const throttledFunction = async function (...args: Parameters<T>) {
+    if (timeoutId === null) {
       const execute = () => {
+        if (recentArgs === null) {
+          timeoutId = null;
+          return;
+        }
         const currentCallCount = callCount;
         const result = func(...recentArgs);
         result
           .catch(() => {})
           .then(() => {
             if (currentCallCount === callCount) {
-              isScheduled = false;
+              timeoutId = null;
               recentArgs = null;
             } else {
               // If call count has changed while the function was executing,
@@ -63,14 +40,23 @@ export function throttleAsync<T extends AsyncFn>(func: T, limitMs: number): T {
               // to ensure the function is not run more often than once every
               // `limitMs` milliseconds, we schedule it to run after the provided
               // limit.
-              setTimeout(execute, limitMs);
+              timeoutId = setTimeout(execute, limitMs);
             }
           });
       };
-      isScheduled = true;
-      setTimeout(execute, limitMs);
+      timeoutId = setTimeout(execute, limitMs);
     }
     recentArgs = args;
     callCount++;
-  } as T;
+  };
+
+  throttledFunction.cancel = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+      recentArgs = null;
+    }
+  };
+
+  return throttledFunction;
 }

--- a/packages/vscode-extension/src/webview/views/DeviceLocationView.tsx
+++ b/packages/vscode-extension/src/webview/views/DeviceLocationView.tsx
@@ -4,9 +4,9 @@ import "./DeviceLocationView.css";
 import "../components/shared/SwitchGroup.css";
 import * as Switch from "@radix-ui/react-switch";
 import CoordinateParser from "coordinate-parser";
+import { throttle } from "lodash";
 import Label from "../components/shared/Label";
 import Tooltip from "../components/shared/Tooltip";
-import { throttle } from "../../utilities/throttle";
 import { Input } from "../components/shared/Input";
 import { useStore } from "../providers/storeProvider";
 


### PR DESCRIPTION
- cancels any all throttled functions created by `DeviceSession` in its `dispose` method, preventing the throttled callbacks from accessing the disposed session's state.
- fixes the `throttle` function wrapper being created on each `Preview` component render, making the calls more frequent than desired