### PR TITLE
fix: device sessions appear active after app root switch

### DIFF
--- a/packages/vscode-extension/src/project/DeviceSessionsManager.ts
+++ b/packages/vscode-extension/src/project/DeviceSessionsManager.ts
@@ -356,7 +356,7 @@ export class DeviceSessionsManager implements Disposable {
     const deviceSessions = this.deviceSessions.values().toArray();
     this.deviceSessions.clear();
     this.activeSessionId = undefined;
-    disposeAll([...deviceSessions, ...this.disposables]);
     this.clearState();
+    disposeAll([...deviceSessions, ...this.disposables]);
   }
 }


### PR DESCRIPTION
Fixes the #1559 fix unfixing the #1555 fix.

### How Has This Been Tested: 
- open a monorepo in Radon
- open multiple devices
- switch app roots
- verify all devices but the selected one don't appear as "Running" after switching

### How Has This Change Been Documented:
internal
