### PR TITLE
fix: the close button for modals appears in bottom-left corner

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Modal.tsx
+++ b/packages/vscode-extension/src/webview/components/shared/Modal.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 
-import "./Modal.css";
 import IconButton from "./IconButton";
+import "./Modal.css";
 
 interface ModalProps {
   title: string;


### PR DESCRIPTION
Changes in #1534 caused the close button for modals to move to the bottom-left corner.
This was caused by the css files being loaded in a different order than before, making the rules for `icon-button` class override those for `modal-close-button` class.

Before:
<img width="579" height="480" alt="image" src="https://github.com/user-attachments/assets/79461e59-90a2-4e0a-b14d-53b37b62f40c" />

After:
<img width="581" height="518" alt="image" src="https://github.com/user-attachments/assets/01656d8e-9f05-4fed-9757-279214d380fa" />
