### PR TITLE
fix: dropdown submenu animation issue fix

### DIFF
--- a/packages/vscode-extension/src/webview/components/shared/Dropdown.css
+++ b/packages/vscode-extension/src/webview/components/shared/Dropdown.css
@@ -18,6 +18,7 @@ button {
   overflow-y: auto;
 
   --menu-item-padding: 0 6px;
+  --base-transform: translateX(0) translateY(0);
 }
 
 .dropdown-menu-subcontent {
@@ -117,27 +118,59 @@ button {
 @keyframes slideUpAndFade {
   from {
     opacity: 0;
-    transform: translateY(3px);
+    transform: var(--base-transform) translateY(3px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: var(--base-transform) translateY(0);
   }
 }
 
 @keyframes slideDownAndFade {
   from {
     opacity: 0;
-    transform: translateY(-3px);
+    transform: var(--base-transform) translateY(-3px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: var(--base-transform) translateY(0);
+  }
+}
+
+@keyframes slideRightAndFade {
+  from {
+    opacity: 0;
+    transform: var(--base-transform) translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: var(--base-transform) translateX(0);
+  }
+}
+
+@keyframes slideLeftAndFade {
+  from {
+    opacity: 0;
+    transform: var(--base-transform) translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: var(--base-transform) translateX(0);
   }
 }
 
 @media (max-width: 460px) {
   .dropdown-menu-subcontent {
-    transform: translateX(85%) translateY(28px);
+    --base-transform: translateX(85%) translateY(28px);
+    transform: var(--base-transform);
+  }
+
+  .dropdown-menu-content[data-side="left"],
+  .dropdown-menu-subcontent[data-side="left"] {
+    animation-name: slideUpAndFade;
+  }
+  .dropdown-menu-content[data-side="right"],
+  .dropdown-menu-subcontent[data-side="right"] {
+    animation-name: slideUpAndFade;
   }
 }


### PR DESCRIPTION
### Description

This PR fixes issue with the submenu styling, causing it to appear in the wrong place when screen is too small and then snap to the correct position. The issue was introduced in #1557 and was present because animation did not take the media-query transform into account.

The fix corrects the transform, so the animation now plays correctly. Another solution could also bo to disable animation of submenus altogether, can be discussed here.

https://github.com/user-attachments/assets/4982cadc-87c5-4a0e-8caa-cf7357f98c5c

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, and launch app in selected device, uncheck `Show Device Frame` mode
- **open submenus in settings dropdowns, see if everything behaves as expected**

### How Has This Change Been Documented:

Not applicable.

