### PR TITLE
fix: switching to a device with bundle error fails to connect devtools

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -67,6 +67,7 @@ export interface DebugSession {
   onBindingCalled(listener: (event: Cdp.Runtime.BindingCalledEvent) => void): Disposable;
   onScriptParsed(listener: (event: { isMainBundle: boolean }) => void): Disposable;
   onDebugSessionTerminated(listener: () => void): Disposable;
+  onJSDebugSessionStarted(listener: () => void): Disposable;
 }
 
 export class DebugSessionImpl implements DebugSession, Disposable {
@@ -84,6 +85,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   private bindingCalledEventEmitter = new vscode.EventEmitter<Cdp.Runtime.BindingCalledEvent>();
   private debugSessionTerminatedEventEmitter = new vscode.EventEmitter<void>();
   private scriptParsedEventEmitter = new vscode.EventEmitter<{ isMainBundle: boolean }>();
+  private jsDebugSessionStartedEmitter = new vscode.EventEmitter<void>();
 
   public onConsoleLog = this.consoleLogEventEmitter.event;
   public onDebuggerPaused = this.debuggerPausedEventEmitter.event;
@@ -93,6 +95,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   public onBindingCalled = this.bindingCalledEventEmitter.event;
   public onDebugSessionTerminated = this.debugSessionTerminatedEventEmitter.event;
   public onScriptParsed = this.scriptParsedEventEmitter.event;
+  public onJSDebugSessionStarted = this.jsDebugSessionStartedEmitter.event;
 
   constructor(private options: DebugSessionOptions = { displayName: "Radon IDE Debugger" }) {
     this.disposables.push(
@@ -265,6 +268,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
       debug.stopDebugging(this.jsDebugSession);
     }
     this.jsDebugSession = newDebugSession;
+    this.jsDebugSessionStartedEmitter.fire();
   }
 
   public resumeDebugger() {

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -107,6 +107,7 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   public onProfilingCPUStopped = this.debugSession.onProfilingCPUStopped;
   public onBindingCalled = this.debugSession.onBindingCalled;
   public onScriptParsed = this.debugSession.onScriptParsed;
+  public onJSDebugSessionStarted = this.debugSession.onJSDebugSessionStarted;
 
   public async startParentDebugSession(): Promise<void> {
     return this.debugSession.startParentDebugSession();

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -232,6 +232,10 @@ export class ApplicationSession implements Disposable {
       this.cdpDevtoolsServer.dispose();
       this.cdpDevtoolsServer = undefined;
     }
+    if (this.websocketDevtoolsServer === undefined) {
+      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
+      this.setupDevtoolsServer(this.cdpDevtoolsServer);
+    }
   }
 
   private async createDebugSession(): Promise<DebugSession & Disposable> {
@@ -450,12 +454,6 @@ export class ApplicationSession implements Disposable {
       expoPreludeLineCount: this.metro.expoPreludeLineCount,
       sourceMapPathOverrides: this.metro.sourceMapPathOverrides,
     });
-    if (this.websocketDevtoolsServer === undefined) {
-      // NOTE: we only create the CDP devtools server when using the new debugger
-      this.cdpDevtoolsServer?.dispose();
-      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
-      this.setupDevtoolsServer(this.cdpDevtoolsServer);
-    }
   }
 
   /**


### PR DESCRIPTION
Fixes an issue where the CDP devtools fail to connect when switching to a running device with broken code, which produces a bundle error.
The bundle error causes the source maps to not load correctly when reconnecting the debugger, which in turn means the `debugSession.onScriptParsed` event is never fired and the devtools server never establishes the connection with the application. 

### How Has This Been Tested: 
- launch `react-native-81` test app
- launch 2 devices at the same time
- introduce an error in the code to force a bundle error
- switch to the other running device
- check that the devtools connect
- check that fixing the bundle error closes the error alert
- check that after switching to the other running device, the error alert disappears as well ()
