### PR TITLE
Use latest version of source-map instead of beta published 7 years ago

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -106,7 +106,7 @@
         "semver": "^7.7.1",
         "shiki": "^3.12.2",
         "sinon": "^20.0.0",
-        "source-map": "^0.8.0-beta.0",
+        "source-map": "^0.7.6",
         "tar": "^7.4.3",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
@@ -26392,11 +26392,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "dev": true,
@@ -30804,14 +30799,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -30841,29 +30835,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map/node_modules/tr46": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/source-map/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/source-map/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/sourcemap-codec": {
@@ -31628,14 +31599,6 @@
       "peerDependencies": {
         "typescript": "*",
         "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/ts-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1086,7 +1086,7 @@
     "semver": "^7.7.1",
     "shiki": "^3.12.2",
     "sinon": "^20.0.0",
-    "source-map": "^0.8.0-beta.0",
+    "source-map": "^0.7.6",
     "tar": "^7.4.3",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",


### PR DESCRIPTION
For an unknown reason while updating the source-map module version, we installed version 0.8.0-beta.

This version turns out not to be actively maintained though and doesn't look like a successor of 0.7. The 0.8.0-beta.0 was published 7 years ago while 0.7 is actively maintained with fixes and improvements every month.

As we are experiencing some crashes in the source map code, I figured it'd be better that we are using a supported version instead of an abandoned beta.

Source maps are currently only used in our custom debugger implementation.

### How Has This Been Tested: 
1. Run the app with custom config and set `"useCustomJSDebugger": true` – this way the
2. Place some breakpoints to see them work, and check debug console for decpihered line numbers