### PR TITLE
refactor: remove run command

### DIFF
--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -61,6 +61,13 @@ export enum DeviceRotationDirection {
   Anticlockwise = 1,
 }
 
+export const ROTATIONS: DeviceRotation[] = [
+  DeviceRotation.LandscapeLeft,
+  DeviceRotation.Portrait,
+  DeviceRotation.LandscapeRight,
+  DeviceRotation.PortraitUpsideDown,
+] as const;
+
 export type AppOrientation = DeviceRotation | "Landscape";
 
 export function isOfEnumDeviceRotation(value: any): value is DeviceRotation {
@@ -141,9 +148,9 @@ export interface ProjectInterface {
 
   runDependencyChecks(): Promise<void>;
 
+  rotateDevices(direction: DeviceRotationDirection): Promise<void>;
   getDeviceSettings(): Promise<DeviceSettings>;
   updateDeviceSettings(deviceSettings: DeviceSettings): Promise<void>;
-  runCommand(command: string): Promise<void>;
 
   updateToolEnabledState(toolName: keyof ToolsState, enabled: boolean): Promise<void>;
   openTool(toolName: keyof ToolsState): Promise<void>;
@@ -194,6 +201,10 @@ export interface ProjectInterface {
   dispatchWheel(point: TouchPoint, deltaX: number, deltaY: number): void;
   dispatchPaste(text: string): Promise<void>;
   dispatchCopy(): Promise<void>;
+  dispatchHomeButtonPress(): void;
+  dispatchAppSwitchButtonPress(): void;
+
+  sendBiometricAuthorization(isMatch: boolean): Promise<void>;
 
   reloadCurrentSession(type: ReloadAction): Promise<void>;
   startOrActivateSessionForDevice(deviceInfo: DeviceInfo): Promise<void>;
@@ -223,6 +234,7 @@ export interface ProjectInterface {
   openFileAt(filePath: string, line0Based: number, column0Based: number): Promise<void>;
   showDismissableError(errorMessage: string): Promise<void>;
   showToast(message: string, timeout: number): Promise<void>;
+  openLaunchConfigurationFile(): Promise<void>;
 
   reportIssue(): Promise<void>;
   sendTelemetry(eventName: string, properties?: TelemetryEventProperties): Promise<void>;

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -35,18 +35,10 @@ import { Connector } from "./connect/Connector";
 import { ReactDevtoolsEditorProvider } from "./react-devtools-profiler/ReactDevtoolsEditorProvider";
 import { launchConfigurationFromOptions } from "./project/launchConfigurationsManager";
 import { isIdeConfig } from "./utilities/launchConfiguration";
-import { DeviceRotation, PanelLocation } from "./common/State";
+import { PanelLocation } from "./common/State";
 import { DeviceRotationDirection, IDEPanelMoveTarget } from "./common/Project";
-import { updatePartialWorkspaceConfig } from "./utilities/updatePartialWorkspaceConfig";
 
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
-
-const ROTATIONS: DeviceRotation[] = [
-  DeviceRotation.LandscapeLeft,
-  DeviceRotation.Portrait,
-  DeviceRotation.LandscapeRight,
-  DeviceRotation.PortraitUpsideDown,
-] as const;
 
 function handleUncaughtErrors(context: ExtensionContext) {
   process.on("unhandledRejection", (error) => {
@@ -408,14 +400,12 @@ async function performFailedBiometricAuthorization() {
 
 async function deviceHomeButtonPress() {
   const project = IDE.getInstanceIfExists()?.project;
-  project?.dispatchButton("home", "Down");
-  project?.dispatchButton("home", "Up");
+  project?.dispatchHomeButtonPress();
 }
 
 async function deviceAppSwitchButtonPress() {
   const project = IDE.getInstanceIfExists()?.project;
-  project?.dispatchButton("appSwitch", "Down");
-  project?.dispatchButton("appSwitch", "Up");
+  project?.dispatchAppSwitchButtonPress();
 }
 
 async function deviceVolumeIncrease() {
@@ -448,16 +438,7 @@ async function rotateDevice(direction: DeviceRotationDirection) {
     throw new Error("Radon IDE is not initialized yet.");
   }
 
-  const configuration = workspace.getConfiguration("RadonIDE");
-
-  const currentRotation = configuration.get<DeviceRotation>("deviceRotation");
-  if (currentRotation === undefined) {
-    Logger.warn("[Radon IDE] Device rotation is not set in the configuration.");
-    return;
-  }
-  const currentIndex = ROTATIONS.indexOf(currentRotation);
-  const newIndex = (currentIndex - direction + ROTATIONS.length) % ROTATIONS.length;
-  await updatePartialWorkspaceConfig(configuration, ["deviceRotation", ROTATIONS[newIndex]]);
+  project.rotateDevices(direction);
 }
 
 async function rotateDeviceAnticlockwise() {

--- a/packages/vscode-extension/src/project/EditorBindings.ts
+++ b/packages/vscode-extension/src/project/EditorBindings.ts
@@ -108,4 +108,8 @@ export class EditorBindings {
       }
     );
   }
+
+  public async openLaunchConfigurationFile() {
+    commands.executeCommand("workbench.action.debug.configure");
+  }
 }

--- a/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceSettingsDropdown.tsx
@@ -13,12 +13,7 @@ import "./shared/SwitchGroup.css";
 
 import Label from "./shared/Label";
 import { useProject } from "../providers/ProjectProvider";
-import {
-  AppPermissionType,
-  DeviceRotationDirection,
-  DeviceSettings,
-  ProjectInterface,
-} from "../../common/Project";
+import { AppPermissionType, DeviceRotationDirection, DeviceSettings } from "../../common/Project";
 import { DeviceLocationView } from "../views/DeviceLocationView";
 import { useModal } from "../providers/ModalProvider";
 import { KeybindingInfo } from "./shared/KeybindingInfo";
@@ -88,25 +83,6 @@ const setOrientationOptions: Array<{
     value: DeviceRotation.LandscapeRight,
     icon: "device-mobile",
     rotation: "90deg",
-  },
-];
-const rotateOptions: Array<{
-  label: string;
-  value: DeviceRotationDirection;
-  icon: string;
-  commandName: string;
-}> = [
-  {
-    label: "Clockwise",
-    value: DeviceRotationDirection.Clockwise,
-    icon: "refresh",
-    commandName: "RNIDE.rotateDeviceClockwise",
-  },
-  {
-    label: "Anticlockwise",
-    value: DeviceRotationDirection.Anticlockwise,
-    icon: "refresh mirror",
-    commandName: "RNIDE.rotateDeviceAnticlockwise",
   },
 ];
 
@@ -207,14 +183,14 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
             <div className="device-settings-margin" />
           </form>
           <CommandItem
-            project={project}
+            onSelect={() => project.dispatchHomeButtonPress()}
             commandName="RNIDE.deviceHomeButtonPress"
             label="Press Home Button"
             icon="home"
             dataTest="press-home-button"
           />
           <CommandItem
-            project={project}
+            onSelect={() => project.dispatchAppSwitchButtonPress()}
             commandName="RNIDE.deviceAppSwitchButtonPress"
             label="Open App Switcher"
             icon="chrome-restore"
@@ -235,15 +211,20 @@ function DeviceSettingsDropdown({ children, disabled }: DeviceSettingsDropdownPr
                 sideOffset={2}
                 alignOffset={-5}>
                 <Label>Rotate</Label>
-                {rotateOptions.map((option) => (
-                  <CommandItem
-                    project={project}
-                    commandName={option.commandName}
-                    label={option.label}
-                    dataTest={`device-settings-set-orientation-${option.label.trim().toLowerCase().replace(/\s+/g, "-")}`}
-                    icon={option.icon}
-                  />
-                ))}
+                <CommandItem
+                  onSelect={() => project.rotateDevices(DeviceRotationDirection.Clockwise)}
+                  commandName={"RNIDE.rotateDeviceClockwise"}
+                  label={"Clockwise"}
+                  dataTest={`device-settings-set-orientation-${"Clockwise".trim().toLowerCase().replace(/\s+/g, "-")}`}
+                  icon={"refresh"}
+                />
+                <CommandItem
+                  onSelect={() => project.rotateDevices(DeviceRotationDirection.Anticlockwise)}
+                  commandName={"RNIDE.rotateDeviceAnticlockwise"}
+                  label={"Anticlockwise"}
+                  dataTest={`device-settings-set-orientation-${"Anticlockwise".trim().toLowerCase().replace(/\s+/g, "-")}`}
+                  icon={"refresh mirror"}
+                />
 
                 <div className="device-settings-margin" />
                 <Label>Set Orientation</Label>
@@ -386,14 +367,14 @@ const LocalizationItem = () => {
 };
 
 function CommandItem({
-  project,
+  onSelect,
   commandName,
   label,
   icon,
   disabled = false,
   dataTest,
 }: PropsWithDataTest<{
-  project: ProjectInterface;
+  onSelect: () => void;
   commandName: string;
   label: string;
   icon: string;
@@ -402,9 +383,7 @@ function CommandItem({
   return (
     <DropdownMenu.Item
       className="dropdown-menu-item"
-      onSelect={() => {
-        project.runCommand(commandName);
-      }}
+      onSelect={onSelect}
       disabled={disabled}
       data-testid={dataTest}>
       <span className="dropdown-menu-item-wraper">
@@ -446,14 +425,18 @@ const BiometricsItem = () => {
             )}
           </DropdownMenu.Item>
           <CommandItem
-            project={project}
+            onSelect={() => {
+              project.sendBiometricAuthorization(true);
+            }}
             commandName="RNIDE.performBiometricAuthorization"
             label="Matching ID"
             icon="layout-sidebar-left"
             disabled={!deviceSettings.hasEnrolledBiometrics}
           />
           <CommandItem
-            project={project}
+            onSelect={() => {
+              project.sendBiometricAuthorization(false);
+            }}
             commandName="RNIDE.performFailedBiometricAuthorization"
             label="Non-Matching ID"
             icon="layout-sidebar-left"

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -315,7 +315,7 @@ function LaunchConfigurationView({
           className="launch-configuration-text-button"
           role="button"
           onClick={() => {
-            project.runCommand("workbench.action.debug.configure");
+            project.openLaunchConfigurationFile();
             closeModal();
           }}>
           Edit in launch.json


### PR DESCRIPTION
In this PR we constrain the extension API to methods defined in `ProjectInterface` by removing an option to all a command directly from the webview side. 

### How Has This Been Tested: 
- run test up and check options that were previously command calls

### How Has This Change Been Documented:

internal


