### PR TITLE
fix: throw error when JS reload fails

### DIFF
--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -182,10 +182,16 @@ export type InstallationErrorDescriptor = {
   reason: InstallationErrorReason;
 };
 
+export type ReloadErrorDescriptor = {
+  kind: "reload";
+  message: string;
+};
+
 export type FatalErrorDescriptor =
   | BuildErrorDescriptor
   | DeviceErrorDescriptor
-  | InstallationErrorDescriptor;
+  | InstallationErrorDescriptor
+  | ReloadErrorDescriptor;
 
 export type DeviceSessionStatus = "starting" | "running" | "fatalError";
 

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -314,13 +314,6 @@ export class ApplicationSession implements Disposable {
       debugSession.onDebuggerResumed(this.onDebuggerResumed),
       debugSession.onProfilingCPUStarted(this.onProfilingCPUStarted),
       debugSession.onProfilingCPUStopped(this.onProfilingCPUStopped),
-      // debugSession.onScriptParsed(({ isMainBundle }) => {
-      //   // NOTE: if the scriptParsed event is received for the main bundle,
-      //   // it must have loaded successfully, so we clear any existing bundle error
-      //   if (isMainBundle) {
-      //     this.stateManager.updateState({ bundleError: null });
-      //   }
-      // }),
     ];
     return new Disposable(() => {
       disposeAll(subscriptions);

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -24,7 +24,7 @@ import { ApplicationContext } from "./ApplicationContext";
 import { watchProjectFiles } from "../utilities/watchProjectFiles";
 import { OutputChannelRegistry } from "./OutputChannelRegistry";
 import { Output } from "../common/OutputChannel";
-import { ApplicationSession } from "./applicationSession";
+import { ApplicationSession, ReloadJSError } from "./applicationSession";
 import {
   DevicePlatform,
   DeviceRotation,
@@ -286,6 +286,17 @@ export class DeviceSession implements Disposable {
             message: e.message,
             platform: this.stateManager.getState().deviceInfo.platform,
             reason: e.reason,
+          },
+        });
+        return;
+      } else if (e instanceof ReloadJSError) {
+        this.stateManager.updateState({
+          status: "fatalError",
+          error: {
+            message: e.message,
+            platform: this.stateManager.getState().deviceInfo.platform,
+            kind: "build",
+            buildType: null,
           },
         });
         return;

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -294,9 +294,7 @@ export class DeviceSession implements Disposable {
           status: "fatalError",
           error: {
             message: e.message,
-            platform: this.stateManager.getState().deviceInfo.platform,
-            kind: "build",
-            buildType: null,
+            kind: "reload",
           },
         });
         return;


### PR DESCRIPTION
Fixes hanging on "Waiting for app to load...." due to unhandled errors when reloading JS

### How Has This Been Tested: 
- open app
- introduce a bundle error
- trigger reload JS a couple times
- check radon doesn't get stuck, just shows error alerts



