### PR TITLE
fix: debugger overlay not showing while status not running

### DIFF
--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -549,9 +549,9 @@ export class DeviceSession implements Disposable {
       this.device.setUpKeyboard();
       this.setupInspectorBridgeListeners(applicationSession.inspectorBridge);
 
-      // this.stateManager.updateState({
-      //   status: "running",
-      // });
+      this.stateManager.updateState({
+        status: "running",
+      });
 
       const launchDurationSec = (Date.now() - launchRequestTime) / 1000;
       Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -549,9 +549,9 @@ export class DeviceSession implements Disposable {
       this.device.setUpKeyboard();
       this.setupInspectorBridgeListeners(applicationSession.inspectorBridge);
 
-      this.stateManager.updateState({
-        status: "running",
-      });
+      // this.stateManager.updateState({
+      //   status: "running",
+      // });
 
       const launchDurationSec = (Date.now() - launchRequestTime) / 1000;
       Logger.info("App launched in", launchDurationSec.toFixed(2), "sec.");

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -101,6 +101,11 @@ function Preview({
   const [anchorPoint, setAnchorPoint] = useState<Point>({ x: 0.5, y: 0.5 });
   const previewRef = useRef<HTMLCanvasElement>(null);
   const [showPreviewRequested, setShowPreviewRequested] = useState(false);
+
+  useEffect(() => {
+    setShowPreviewRequested(false);
+  }, [selectedDeviceSessionStatus]);
+
   const [inspectorUnavailableBoxPosition, setInspectorUnavailableBoxPosition] =
     useState<Point | null>(null);
   const { dispatchKeyPress, clearPressedKeys } = useKeyPresses();
@@ -120,7 +125,9 @@ function Preview({
     isRunning ? selectedDeviceSessionState.applicationSession.isRefreshing.get() : false
   );
   const debugPaused = use$(() =>
-    isRunning ? selectedDeviceSessionState.applicationSession.isDebuggerPaused.get() : false
+    isRunning || showPreviewRequested
+      ? selectedDeviceSessionState.applicationSession.isDebuggerPaused.get()
+      : false
   );
 
   const previewURL = use$(selectedDeviceSessionState.previewURL);


### PR DESCRIPTION
This solves an issue that could happen if the user forces the preview screen while debugger was enabled, not allowing to continue the debugger in any way. 

This PR also resets the `showPreviewRequested` flag on every status change which makes it go away on reloads. 

### How Has This Been Tested: 

- run radon on test commit (c278d25f3a977f5aff5fb4d21e384d1488ea9406) with information about the device session status obscured and check if debugger works correctly 

### How Has This Change Been Documented:

internal


