### PR TITLE
Revert: "fix: switching to a device with bundle error fails to connect devtools"

### DIFF
--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -67,7 +67,6 @@ export interface DebugSession {
   onBindingCalled(listener: (event: Cdp.Runtime.BindingCalledEvent) => void): Disposable;
   onScriptParsed(listener: (event: { isMainBundle: boolean }) => void): Disposable;
   onDebugSessionTerminated(listener: () => void): Disposable;
-  onJSDebugSessionStarted(listener: () => void): Disposable;
 }
 
 export class DebugSessionImpl implements DebugSession, Disposable {
@@ -85,7 +84,6 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   private bindingCalledEventEmitter = new vscode.EventEmitter<Cdp.Runtime.BindingCalledEvent>();
   private debugSessionTerminatedEventEmitter = new vscode.EventEmitter<void>();
   private scriptParsedEventEmitter = new vscode.EventEmitter<{ isMainBundle: boolean }>();
-  private jsDebugSessionStartedEmitter = new vscode.EventEmitter<void>();
 
   public onConsoleLog = this.consoleLogEventEmitter.event;
   public onDebuggerPaused = this.debuggerPausedEventEmitter.event;
@@ -95,7 +93,6 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   public onBindingCalled = this.bindingCalledEventEmitter.event;
   public onDebugSessionTerminated = this.debugSessionTerminatedEventEmitter.event;
   public onScriptParsed = this.scriptParsedEventEmitter.event;
-  public onJSDebugSessionStarted = this.jsDebugSessionStartedEmitter.event;
 
   constructor(private options: DebugSessionOptions = { displayName: "Radon IDE Debugger" }) {
     this.disposables.push(
@@ -268,7 +265,6 @@ export class DebugSessionImpl implements DebugSession, Disposable {
       debug.stopDebugging(this.jsDebugSession);
     }
     this.jsDebugSession = newDebugSession;
-    this.jsDebugSessionStartedEmitter.fire();
   }
 
   public resumeDebugger() {

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -107,7 +107,6 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   public onProfilingCPUStopped = this.debugSession.onProfilingCPUStopped;
   public onBindingCalled = this.debugSession.onBindingCalled;
   public onScriptParsed = this.debugSession.onScriptParsed;
-  public onJSDebugSessionStarted = this.debugSession.onJSDebugSessionStarted;
 
   public async startParentDebugSession(): Promise<void> {
     return this.debugSession.startParentDebugSession();

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -232,10 +232,6 @@ export class ApplicationSession implements Disposable {
       this.cdpDevtoolsServer.dispose();
       this.cdpDevtoolsServer = undefined;
     }
-    if (this.websocketDevtoolsServer === undefined) {
-      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
-      this.setupDevtoolsServer(this.cdpDevtoolsServer);
-    }
   }
 
   private async createDebugSession(): Promise<DebugSession & Disposable> {
@@ -454,6 +450,12 @@ export class ApplicationSession implements Disposable {
       expoPreludeLineCount: this.metro.expoPreludeLineCount,
       sourceMapPathOverrides: this.metro.sourceMapPathOverrides,
     });
+    if (this.websocketDevtoolsServer === undefined) {
+      // NOTE: we only create the CDP devtools server when using the new debugger
+      this.cdpDevtoolsServer?.dispose();
+      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
+      this.setupDevtoolsServer(this.cdpDevtoolsServer);
+    }
   }
 
   /**

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -199,24 +199,27 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
   constructor(private readonly debugSession: DebugSession) {
     super();
     this.disposables.push(
-      debugSession.onJSDebugSessionStarted(() => {
-        this.createConnection();
+      debugSession.onScriptParsed(({ isMainBundle }) => {
+        if (isMainBundle) {
+          this.createConnection();
+        }
       })
     );
   }
 
   private async createConnection() {
     const debugSession = this.debugSession;
-    if (this.connection) {
-      // NOTE: a single `DebugSession` only supports a single devtools connection at a time
-      return;
-    }
-
-    // NOTE: the binding survives JS reloads, and the Devtools frontend will reconnect automatically
+    // NOTE: the binding survives JS reloads, and the Devtools frontend will reconnect automatically,
+    // so this should not be needed, but because the debugger on Expo Go + Android can break on reloads,
+    // this is sadly necessary.
     debugSession.addBinding(BINDING_NAME);
     debugSession.evaluateExpression({
       expression: `void ${DISPATCHER_GLOBAL}.initializeDomain("${DEVTOOLS_DOMAIN_NAME}")`,
     });
+    if (this.connection) {
+      // NOTE: a single `DebugSession` only supports a single devtools connection at a time
+      return;
+    }
 
     const wall: Wall = {
       listen(fn) {


### PR DESCRIPTION
It cause app stucking on `waiting for app to load` step during clean build.