### PR TITLE
Remove the need to process source maps in extension code

### DIFF
--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -26,21 +26,6 @@ export class ProxyDebugSessionAdapterDescriptorFactory
   }
 }
 
-// strip the wildcard `*` from the sourceMapPathOverrides before passing them to the SourceMapsRegistry
-function sourceMapAliasesFromPathOverrides(
-  sourceMapPathOverrides: Record<string, string>
-): [string, string][] {
-  return Object.entries(sourceMapPathOverrides).map(([key, value]): [string, string] => {
-    if (key.endsWith("*")) {
-      key = key.slice(0, -1);
-    }
-    if (value.endsWith("*")) {
-      value = value.slice(0, -1);
-    }
-    return [key, value];
-  });
-}
-
 const CHILD_SESSION_TYPE = "radon-pwa-node";
 
 export class ProxyDebugAdapter extends DebugSession {
@@ -52,10 +37,6 @@ export class ProxyDebugAdapter extends DebugSession {
 
   constructor(private session: vscode.DebugSession) {
     super();
-
-    const sourceMapAliases = sourceMapAliasesFromPathOverrides(
-      this.session.configuration.sourceMapPathOverrides
-    );
 
     const proxyDelegate = new RadonCDPProxyDelegate();
 
@@ -96,8 +77,8 @@ export class ProxyDebugAdapter extends DebugSession {
     );
 
     this.disposables.push(
-      vscode.debug.onDidTerminateDebugSession((session) => {
-        if (session.parentSession?.id === this.session.id) {
+      vscode.debug.onDidTerminateDebugSession((terminatedSession) => {
+        if (terminatedSession.parentSession?.id === this.session.id) {
           this.terminate();
         }
       })

--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -1,9 +1,7 @@
-import fs from "fs";
-import assert from "assert";
 import { DebugSession, ErrorDestination, Event } from "@vscode/debugadapter";
 import * as vscode from "vscode";
 import { DebugProtocol } from "@vscode/debugprotocol";
-import { Disposable } from "vscode";
+import { Disposable, debug } from "vscode";
 import { CDPProxy } from "./CDPProxy";
 import { RadonCDPProxyDelegate } from "./RadonCDPProxyDelegate";
 import { disposeAll } from "../utilities/disposables";
@@ -14,11 +12,9 @@ import {
   DEBUG_RESUMED,
   SCRIPT_PARSED,
 } from "./DebugSession";
-import { CDPProfile } from "./cdp";
-import { annotateLocations, filePathForProfile } from "./cpuProfiler";
-import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { startDebugging } from "./startDebugging";
 import { Logger } from "../Logger";
+import { CancelToken } from "../utilities/cancelToken";
 
 export class ProxyDebugSessionAdapterDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory
@@ -50,9 +46,9 @@ const CHILD_SESSION_TYPE = "radon-pwa-node";
 export class ProxyDebugAdapter extends DebugSession {
   private cdpProxy: CDPProxy;
   private disposables: Disposable[] = [];
-  private nodeDebugSession: vscode.DebugSession | null = null;
+  private childDebugSession: vscode.DebugSession | null = null;
+  private attachCancelToken = new CancelToken();
   private terminated: boolean = false;
-  private sourceMapRegistry: SourceMapsRegistry;
 
   constructor(private session: vscode.DebugSession) {
     super();
@@ -60,15 +56,8 @@ export class ProxyDebugAdapter extends DebugSession {
     const sourceMapAliases = sourceMapAliasesFromPathOverrides(
       this.session.configuration.sourceMapPathOverrides
     );
-    this.sourceMapRegistry = new SourceMapsRegistry(
-      this.session.configuration.expoPreludeLineCount,
-      sourceMapAliases
-    );
 
-    const proxyDelegate = new RadonCDPProxyDelegate(
-      this.sourceMapRegistry,
-      this.session.configuration.skipFiles
-    );
+    const proxyDelegate = new RadonCDPProxyDelegate();
 
     this.cdpProxy = new CDPProxy(
       "127.0.0.1",
@@ -107,8 +96,8 @@ export class ProxyDebugAdapter extends DebugSession {
     );
 
     this.disposables.push(
-      vscode.debug.onDidTerminateDebugSession(({ id }) => {
-        if (id === this.nodeDebugSession?.id) {
+      vscode.debug.onDidTerminateDebugSession((session) => {
+        if (session.parentSession?.id === this.session.id) {
           this.terminate();
         }
       })
@@ -171,7 +160,7 @@ export class ProxyDebugAdapter extends DebugSession {
     await this.cdpProxy.initializeServer();
 
     try {
-      this.nodeDebugSession = await startDebugging(
+      const vscDebugSession = await startDebugging(
         undefined,
         {
           type: CHILD_SESSION_TYPE,
@@ -181,9 +170,7 @@ export class ProxyDebugAdapter extends DebugSession {
           continueOnAttach: true,
           sourceMapPathOverrides: args.sourceMapPathOverrides,
           resolveSourceMapLocations: ["**", "!**/node_modules/!(expo)/**"],
-          // NOTE: setting skipFiles increases startup time _significantly_, so we omit them until we figure out
-          // how to work around this problem
-          skipFiles: [],
+          skipFiles: this.session.configuration.skipFiles,
           outFiles: [],
         },
         {
@@ -195,8 +182,43 @@ export class ProxyDebugAdapter extends DebugSession {
           consoleMode: vscode.DebugConsoleMode.MergeWithParent,
           lifecycleManagedByParent: true,
           compact: true,
-        }
+        },
+        this.attachCancelToken
       );
+
+      // vscode-js-debug spawns another child session that corresponds to the actual
+      // CDP debugger session. We need to use that session to send commands to control
+      // the profiling.
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      this.attachCancelToken.onCancel(reject);
+      const onDidStartDisposable = debug.onDidStartDebugSession((session) => {
+        if (session.parentSession?.id === vscDebugSession.id) {
+          this.childDebugSession = session;
+          resolve();
+        }
+      });
+      promise.finally(() => onDidStartDisposable.dispose());
+
+      this.disposables.push(
+        debug.onDidReceiveDebugSessionCustomEvent((event) => {
+          console.log("Custom event", event);
+          if (event.session.id !== this.childDebugSession?.id) {
+            return;
+          }
+          switch (event.event) {
+            case "profileStarted":
+              this.sendEvent(new Event("RNIDE_profilingCPUStarted"));
+              break;
+            case "profilerStateUpdate":
+              if (event.body.running === false) {
+                this.sendEvent(new Event("RNIDE_profilingCPUStopped"));
+              }
+              break;
+          }
+        })
+      );
+
+      await promise;
       this.sendResponse(response);
     } catch (e) {
       Logger.error("Error starting proxy debug adapter child session", e);
@@ -215,11 +237,11 @@ export class ProxyDebugAdapter extends DebugSession {
     args: DebugProtocol.ContinueArguments,
     request?: DebugProtocol.Request
   ): void {
-    if (!this.nodeDebugSession) {
+    if (!this.childDebugSession) {
       return;
     }
     vscode.commands.executeCommand("workbench.action.debug.continue", undefined, {
-      sessionId: this.nodeDebugSession.id,
+      sessionId: this.childDebugSession.id,
     });
   }
 
@@ -239,6 +261,7 @@ export class ProxyDebugAdapter extends DebugSession {
     if (this.terminated) {
       return;
     }
+    this.attachCancelToken.cancel();
     this.terminated = true;
     await this.cdpProxy.stopServer();
     disposeAll(this.disposables);
@@ -248,22 +271,11 @@ export class ProxyDebugAdapter extends DebugSession {
   }
 
   private async startProfiling() {
-    await this.cdpProxy.injectDebuggerCommand({ method: "Profiler.start", params: {} });
-    this.sendEvent(new Event("RNIDE_profilingCPUStarted"));
+    await this.childDebugSession?.customRequest("startProfile", { type: "cpu" });
   }
 
   private async stopProfiling() {
-    const result = await this.cdpProxy.injectDebuggerCommand({
-      method: "Profiler.stop",
-      params: {},
-    });
-
-    assert("profile" in result, "Profiler.stop response should contain a profile");
-
-    const profile = annotateLocations(result.profile as CDPProfile, this.sourceMapRegistry);
-    const filePath = filePathForProfile();
-    await fs.promises.writeFile(filePath, JSON.stringify(profile));
-    this.sendEvent(new Event("RNIDE_profilingCPUStopped", { filePath }));
+    await this.childDebugSession?.customRequest("stopProfile");
   }
 
   private async dispatchRadonAgentMessage(args: any) {

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from "vscode";
 import { Minimatch } from "minimatch";
 import _ from "lodash";
 import { CDPProxyDelegate, ProxyTunnel } from "./CDPProxy";
-import { SourceMapsRegistry } from "./SourceMapsRegistry";
 import { Logger } from "../Logger";
 
 export class RadonCDPProxyDelegate implements CDPProxyDelegate {
@@ -12,7 +11,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   private consoleAPICalledEmitter = new EventEmitter();
   private bindingCalledEmitter = new EventEmitter<Cdp.Runtime.BindingCalledEvent>();
   private bundleParsedEmitter = new EventEmitter<{ isMainBundle: boolean }>();
-  private ignoredPatterns: Minimatch[] = [];
 
   private justCalledStepOver = false;
   private resumeEventTimeout: NodeJS.Timeout | undefined;
@@ -22,15 +20,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   public onConsoleAPICalled = this.consoleAPICalledEmitter.event;
   public onBindingCalled = this.bindingCalledEmitter.event;
   public onBundleParsed = this.bundleParsedEmitter.event;
-
-  constructor(
-    private sourceMapRegistry: SourceMapsRegistry,
-    skipFiles: string[]
-  ) {
-    this.ignoredPatterns = skipFiles.map(
-      (pattern) => new Minimatch(pattern, { flipNegate: true, dot: true })
-    );
-  }
 
   public async handleApplicationCommand(
     applicationCommand: IProtocolCommand,
@@ -52,23 +41,8 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       case "Debugger.scriptParsed": {
         return this.handleScriptParsed(applicationCommand);
       }
-      case "Runtime.executionContextsCleared": {
-        this.sourceMapRegistry.clearSourceMaps();
-        return applicationCommand;
-      }
     }
     return applicationCommand;
-  }
-
-  private shouldSkipFile(sourceURL: string): boolean {
-    return this.ignoredPatterns.reduce((shouldSkip, p) => {
-      if (p.negate) {
-        // don't skip the file if some negated pattern matches it
-        return shouldSkip && !p.match(sourceURL);
-      } else {
-        return shouldSkip || p.match(sourceURL);
-      }
-    }, false);
   }
 
   private shouldResumeImmediately(params: Cdp.Debugger.PausedEvent): boolean {
@@ -89,13 +63,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       return true;
     }
 
-    const { scriptId, lineNumber, columnNumber } = params.callFrames[0].location;
-    const { sourceURL } = this.sourceMapRegistry.findOriginalPosition(
-      scriptId,
-      lineNumber + 1,
-      columnNumber ?? 0
-    );
-    return this.shouldSkipFile(sourceURL);
+    return false;
   }
 
   private handleDebuggerResumed(command: IProtocolCommand, tunnel: ProxyTunnel) {
@@ -287,8 +255,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         source.includes("__prelude__")
       );
 
-      this.sourceMapRegistry.registerSourceMap(sourceMapData, url, scriptId, isMainBundle);
-
       this.bundleParsedEmitter.fire({ isMainBundle });
     } catch (e) {
       Logger.error("Could not process the source map", e);
@@ -330,23 +296,6 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
       });
 
       stackTrace?.callFrames.splice(0, originalCallFrameIndex);
-    }
-
-    if (stackTrace) {
-      const filteredCallFrames = stackTrace?.callFrames.filter((frame) => {
-        const { scriptId, lineNumber, columnNumber } = frame;
-        const { sourceURL } = this.sourceMapRegistry.findOriginalPosition(
-          scriptId,
-          lineNumber + 1,
-          columnNumber ?? 0
-        );
-        return !this.shouldSkipFile(sourceURL);
-      });
-      if (filteredCallFrames.length > 0) {
-        // we only filter frames if there's at least one frame left, otherwise we would still
-        // want some location information to be available so we keep the original one.
-        stackTrace.callFrames = filteredCallFrames;
-      }
     }
 
     this.consoleAPICalledEmitter.fire({});

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -1,6 +1,5 @@
 import { IProtocolCommand, IProtocolSuccess, IProtocolError, Cdp } from "vscode-cdp-proxy";
 import { EventEmitter } from "vscode";
-import { Minimatch } from "minimatch";
 import _ from "lodash";
 import { CDPProxyDelegate, ProxyTunnel } from "./CDPProxy";
 import { Logger } from "../Logger";
@@ -244,7 +243,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   }
 
   private async handleScriptParsed(command: IProtocolCommand): Promise<IProtocolCommand> {
-    const { sourceMapURL, url, scriptId } = command.params as Cdp.Debugger.ScriptParsedEvent;
+    const { sourceMapURL } = command.params as Cdp.Debugger.ScriptParsedEvent;
     if (!sourceMapURL) {
       return command;
     }


### PR DESCRIPTION
With some client's apps, we found that very large source maps may crash the wasm based source maps library that we currently use. After investigating, we found that we don't actually need to process source maps at all, and only rely on the vscode-js-debug implementation (with some modifications: https://github.com/software-mansion-labs/vscode-js-debug/pull/8)

1) we used source map to resume breakpoints on skipped files (i.e. in node_modules). This behavior work when skipFiles are provided but only after https://github.com/software-mansion-labs/vscode-js-debug/pull/8 the skipFiles can work reliably well
2) we also used source maps to annotate CPU profile with file location metadata. This is something that vscode-js-debug does already but we just needed to find a way to utilize the built-in profiling mechanism.

This PR, updates the `ProxyDebugAdapter` implementation, such that it no longer use source map manager and doesn't feed source maps into it. Instead, we pass `skipFiles` flag directly to the `vscode-js-debug` session (assuming the mentioned fix is in place).

For the profile annotation to work, we actually change a few more things:
1) we capture the child debug session that vscode-js-debug spawns. Only that session can receive custom start/stop profiler commands
2) we listen to custom profiler events to propagate the profiler state back to the UI
3) we delete all the code responsible for annotating, saving and opening the file, vscode-js-debug already does this.

The only side effect is that we no longer can control the location and file name of the profile file. However, vscode-js-debug already places the file in the same location, only prefixes the file with `vscode-profile-${date}` which is acceptable. If we need more control in the future we'd need to patch `vscode-js-debug` as it doesn't provide any way to customize the profile saving process.

### How Has This Been Tested: 
1) run bsky app w/o https://github.com/software-mansion-labs/vscode-js-debug/pull/8 but with this change
2) set some breakpoint before the app is loaded -> notice that it takes looong time for the breakpoint to turn "red" (activate). This is because the source map processing takes ages
3) with https://github.com/software-mansion-labs/vscode-js-debug/pull/8 this problem no longer occurs and the breakpoints load almost instantly
4) with all the changes in: test setting breakpoints, put some breakpoints under node_modules (for example in alter implementation for RN, then trigger alert), for the breakpoints see that the debugger wouldn't stop there. Also test console.log from that place, see that the log link will show place in app code that triggered the internal method (alert call in this example)
5) test CPU profiler.

