### PR TITLE
fix: expo router integration

### DIFF
--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -327,6 +327,11 @@ export type NavigationRoute = {
   type: string;
 };
 
+export type NavigationState = {
+  navigationHistory: NavigationHistoryItem[];
+  navigationRouteList: NavigationRoute[];
+};
+
 // #endregion Navigation
 
 // #region Startup Messages
@@ -364,8 +369,7 @@ export type DeviceSessionStore = {
   deviceInfo: DeviceInfo;
   frameReporting: FrameReportingState;
   isUsingStaleBuild: boolean;
-  navigationHistory: NavigationHistoryItem[];
-  navigationRouteList: NavigationRoute[];
+  navigationState: NavigationState;
   previewURL: string | undefined;
   fileTransfer: FileTransferState;
   screenCapture: ScreenCaptureState;
@@ -511,8 +515,10 @@ const initialDeviceSessionStore: DeviceSessionStore = {
     frameReport: null,
   },
   isUsingStaleBuild: false,
-  navigationHistory: [],
-  navigationRouteList: [],
+  navigationState: {
+    navigationHistory: [],
+    navigationRouteList: [],
+  },
   previewURL: undefined,
   screenCapture: {
     isRecording: false,

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -26,8 +26,6 @@ import {
   DeviceSessionStore,
   DeviceSettings,
   InstallationError,
-  NavigationHistoryItem,
-  NavigationRoute,
   NavigationState,
   RecursivePartial,
   REMOVE,

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -41,8 +41,8 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
     store$.projectState.applicationContext.applicationDependencies.expoRouter
   );
 
-  const navigationHistory = use$(selectedDeviceSessionState.navigationHistory);
-  const navigationRouteList = use$(selectedDeviceSessionState.navigationRouteList);
+  const navigationHistory = use$(selectedDeviceSessionState.navigationState.navigationHistory);
+  const navigationRouteList = use$(selectedDeviceSessionState.navigationState.navigationRouteList);
 
   const disabledAlsoWhenStarting = disabled || selectedDeviceSessionStatus === "starting";
   const isExpoRouterProject = !expoRouterStatus?.isOptional;


### PR DESCRIPTION
After #1497 we moved the navigation listener setup to "after" the communication with the application is established, which caused the expo router to integration to not capture information about paths existing in the application. 

This PR fixes it by moving the listeners initialization to application session 

### How Has This Been Tested: 

- run expo-53 test app
- check out the navigation list 
- navigate 
- go home 

### How Has This Change Been Documented:

internal 


