### PR TITLE
Fix Websocket is not defined crash

### DIFF
--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import stripAnsi from "strip-ansi";
+import WebSocket from "ws";
 import { Disposable, EventEmitter, ExtensionMode, Uri, workspace } from "vscode";
 import _ from "lodash";
 import { DebugSource } from "../debugging/DebugSession";


### PR DESCRIPTION
In #1550 we broke metro.ts by deleting Websocket import. The imports are needed because in extension environment, unlike in web, WebSocket is not defined globally. Apparently typescript seems to be misconfigured and didn't yield an error in this case (I haven't had time to investigate but created #1586)

This PR adds the missing import.

### How Has This Been Tested: 
1) use "Open dev menu" option -> get WebSocket is not defined error
2) with these changes in, the "Open dev menu" works correctly.