### PR TITLE
Fix crash on IDE.dispose

### DIFF
--- a/packages/vscode-extension/src/project/ReadableLogOutputChannel.ts
+++ b/packages/vscode-extension/src/project/ReadableLogOutputChannel.ts
@@ -15,11 +15,26 @@ export interface ReadableLogOutputChannel extends LogOutputChannel {
   isEmpty: () => boolean;
 }
 
-function createMockOutputChannel(channel: Output): LogOutputChannel {
-  // All five functions required for writing, reading and clearing logs are already implemented by `createReadableOutputChannel`.
-  // Remaining functions provided by `window.createOutputChannel` are never used within our codebase, and thus don't have to be present.
-  // LogLevel.Info is the default log level for any newly initialized output channel.
-  return { name: channel, logLevel: LogLevel.Info } as LogOutputChannel;
+function createMockOutputChannel(channel: Output) {
+  return {
+    name: channel,
+    logLevel: LogLevel.Info,
+    dispose: () => {},
+    onDidChangeLogLevel: () => {
+      return { dispose: () => {} };
+    },
+    trace: (message: string, ...args: any[]) => {},
+    debug: (message: string, ...args: any[]) => {},
+    info: (message: string, ...args: any[]) => {},
+    warn: (message: string, ...args: any[]) => {},
+    error: (message: string, ...args: any[]) => {},
+    append: (value: string) => {},
+    appendLine: (value: string) => {},
+    clear: () => {},
+    show: () => {},
+    hide: () => {},
+    replace: () => {},
+  };
 }
 
 export function createReadableOutputChannel(channel: Output): ReadableLogOutputChannel {


### PR DESCRIPTION
After #1386 the IDE.dispose method started throwing an error that c.dispose is not a function.

The issue was in the "mock" channel introduced in that PR. The code used `as` operator to cast incomplete type into channel, but it was missing a lot of methods (including the dispose method) that some parts of the codebase could use.

This PR adds a complete LogChannel prototype for the mock implementation.

### How Has This Been Tested: 
1) Open IDE panel
2) Use the "switch off" button to turn off the panel when in sidebar mode or just close it the tab in the "tab mode"
3) Before this change we'd get an error that c.dispose is not a function, now this error is gone