### PR TITLE
fix: switching to a device with bundle error fails to connect devtools

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -129,7 +129,7 @@
     },
     "../vscode-js-debug": {
       "name": "js-debug",
-      "version": "1.97.0",
+      "version": "1.104.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -153,7 +153,7 @@
         "inversify": "^6.0.2",
         "js-xxhash": "^3.0.1",
         "jsonc-parser": "^3.3.1",
-        "linkifyjs": "^4.1.3",
+        "linkifyjs": "^4.3.2",
         "micromatch": "^4.0.5",
         "npm-run-all2": "^7.0.1",
         "path-browserify": "^1.0.1",
@@ -230,7 +230,7 @@
         "sinon": "^17.0.1",
         "stream-buffers": "^3.0.2",
         "ts-node": "^10.9.2",
-        "tsx": "^4.7.0",
+        "tsx": "^4.20.3",
         "typescript": "^5.5.2",
         "vsce": "^2.7.0"
       },

--- a/packages/vscode-extension/src/debugging/DebugSession.ts
+++ b/packages/vscode-extension/src/debugging/DebugSession.ts
@@ -67,6 +67,7 @@ export interface DebugSession {
   onBindingCalled(listener: (event: Cdp.Runtime.BindingCalledEvent) => void): Disposable;
   onScriptParsed(listener: (event: { isMainBundle: boolean }) => void): Disposable;
   onDebugSessionTerminated(listener: () => void): Disposable;
+  onJSDebugSessionStarted(listener: () => void): Disposable;
 }
 
 export class DebugSessionImpl implements DebugSession, Disposable {
@@ -84,6 +85,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   private bindingCalledEventEmitter = new vscode.EventEmitter<Cdp.Runtime.BindingCalledEvent>();
   private debugSessionTerminatedEventEmitter = new vscode.EventEmitter<void>();
   private scriptParsedEventEmitter = new vscode.EventEmitter<{ isMainBundle: boolean }>();
+  private jsDebugSessionStartedEmitter = new vscode.EventEmitter<void>();
 
   public onConsoleLog = this.consoleLogEventEmitter.event;
   public onDebuggerPaused = this.debuggerPausedEventEmitter.event;
@@ -93,6 +95,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
   public onBindingCalled = this.bindingCalledEventEmitter.event;
   public onDebugSessionTerminated = this.debugSessionTerminatedEventEmitter.event;
   public onScriptParsed = this.scriptParsedEventEmitter.event;
+  public onJSDebugSessionStarted = this.jsDebugSessionStartedEmitter.event;
 
   constructor(private options: DebugSessionOptions = { displayName: "Radon IDE Debugger" }) {
     this.disposables.push(
@@ -265,6 +268,7 @@ export class DebugSessionImpl implements DebugSession, Disposable {
       debug.stopDebugging(this.jsDebugSession);
     }
     this.jsDebugSession = newDebugSession;
+    this.jsDebugSessionStartedEmitter.fire();
   }
 
   public resumeDebugger() {

--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -104,6 +104,7 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   public onProfilingCPUStopped = this.debugSession.onProfilingCPUStopped;
   public onBindingCalled = this.debugSession.onBindingCalled;
   public onScriptParsed = this.debugSession.onScriptParsed;
+  public onJSDebugSessionStarted = this.debugSession.onJSDebugSessionStarted;
 
   public async startParentDebugSession(): Promise<void> {
     return this.debugSession.startParentDebugSession();

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -31,6 +31,7 @@ import {
   NavigationHistoryItem,
   NavigationRoute,
   NavigationState,
+  REMOVE,
   StartupMessage,
 } from "../common/State";
 import { isAppSourceFile } from "../utilities/isAppSourceFile";
@@ -242,6 +243,10 @@ export class ApplicationSession implements Disposable {
       this.cdpDevtoolsServer.dispose();
       this.cdpDevtoolsServer = undefined;
     }
+    if (this.websocketDevtoolsServer === undefined) {
+      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
+      this.setupDevtoolsServer(this.cdpDevtoolsServer);
+    }
   }
 
   private async createDebugSession(): Promise<DebugSession & Disposable> {
@@ -376,6 +381,9 @@ export class ApplicationSession implements Disposable {
   //#region Metro event listeners
 
   private async onBundleError(message: string, source: DebugSource) {
+    if (!this.isActive) {
+      return;
+    }
     Logger.error("[Bundling Error]", message);
     this.stateManager.updateState({
       bundleError: {
@@ -407,9 +415,15 @@ export class ApplicationSession implements Disposable {
 
   public async deactivate(): Promise<void> {
     this.isActive = false;
-    // NOTE: we reset the state to "connecting" here to prevent showing the "disconnected" alert
-    // when switching between devices
-    this.stateManager.updateState({ inspectorBridgeStatus: InspectorBridgeStatus.Connecting });
+    this.stateManager.updateState({
+      // NOTE: we reset the state to "connecting" here to prevent showing the "disconnected" alert
+      // when switching between devices
+      inspectorBridgeStatus: InspectorBridgeStatus.Connecting,
+      // NOTE: we reset the bundle error here to prevent showing stale errors when switching between devices.
+      // If, after swithcing, the app still has a bundle error,
+      // the debugger connecting and fetching the source will cause it to appear again.
+      bundleError: REMOVE,
+    });
     this.toolsManager.deactivate();
     this.debugSessionEventSubscription?.dispose();
     this.debugSessionEventSubscription = undefined;
@@ -460,12 +474,6 @@ export class ApplicationSession implements Disposable {
       expoPreludeLineCount: this.metro.expoPreludeLineCount,
       sourceMapPathOverrides: this.metro.sourceMapPathOverrides,
     });
-    if (this.websocketDevtoolsServer === undefined) {
-      // NOTE: we only create the CDP devtools server when using the new debugger
-      this.cdpDevtoolsServer?.dispose();
-      this.cdpDevtoolsServer = new CDPDevtoolsServer(this.debugSession);
-      this.setupDevtoolsServer(this.cdpDevtoolsServer);
-    }
   }
 
   /**
@@ -572,7 +580,7 @@ export class ApplicationSession implements Disposable {
       expression: "void globalThis.__RADON_reloadJS()",
     });
     if (result.className === "Error") {
-      throw new Error("Reloading JS with the debugger failed: " + result.value.message);
+      throw new Error("Reloading JS failed.");
     }
   }
 


### PR DESCRIPTION
Another attempt at #1566 
Fixes an issue where the CDP devtools fail to connect when switching to a running device with broken code, which produces a bundle error.
The bundle error causes the source maps to not load correctly when reconnecting the debugger, which in turn means the `debugSession.onScriptParsed` event is never fired and the devtools server never establishes the connection with the application.

### How Has This Been Tested: 
- launch `react-native-81` test app
- launch 2 devices at the same time
- introduce an error in the code to force a bundle error
- switch to the other running device
- check that the devtools connect
- check that fixing the bundle error closes the error alert
- check that after switching to the other running device, the error alert disappears as well