### PR TITLE
fix: devtools disconnected alert does not appear

### DIFF
--- a/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
+++ b/packages/vscode-extension/src/debugging/ReconnectingDebugSession.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Disposable } from "vscode";
+import { Disposable } from "vscode";
 import { Cdp } from "vscode-cdp-proxy";
 import { CancelToken } from "../utilities/cancelToken";
 import { sleep } from "../utilities/retry";
@@ -13,11 +13,10 @@ const PING_TIMEOUT = 1000;
 export class ReconnectingDebugSession implements DebugSession, Disposable {
   private disposables: Disposable[] = [];
   private reconnectCancelToken: CancelToken | undefined;
-  private readonly sessionTerminatedEventEmitter = new EventEmitter<void>();
 
   private isRunning: boolean = false;
 
-  public readonly onDebugSessionTerminated = this.sessionTerminatedEventEmitter.event;
+  public readonly onDebugSessionTerminated = this.debugSession.onDebugSessionTerminated;
 
   constructor(
     private readonly debugSession: DebugSession & Partial<Disposable>,
@@ -94,8 +93,6 @@ export class ReconnectingDebugSession implements DebugSession, Disposable {
   async dispose() {
     disposeAll(this.disposables);
     this.reconnectCancelToken?.cancel();
-    this.sessionTerminatedEventEmitter.fire();
-    this.sessionTerminatedEventEmitter.dispose();
     await this.debugSession.dispose?.();
   }
 

--- a/packages/vscode-extension/src/webview/hooks/useApplicationDisconnectedAlert.tsx
+++ b/packages/vscode-extension/src/webview/hooks/useApplicationDisconnectedAlert.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect } from "react";
+import { VscodeButton as Button } from "@vscode-elements/react-elements";
 import { useAlert } from "../providers/AlertProvider";
 import { useProject } from "../providers/ProjectProvider";
-import { VscodeButton as Button } from "@vscode-elements/react-elements";
 
 const alertId = "devtools-disconnected-alert";
 
 export function useApplicationDisconnectedAlert(shouldShow: boolean) {
   const { project } = useProject();
-  const { openAlert } = useAlert();
+  const { openAlert, closeAlert } = useAlert();
 
   const open = useCallback(() => {
     openAlert({
@@ -35,7 +35,7 @@ export function useApplicationDisconnectedAlert(shouldShow: boolean) {
     if (shouldShow) {
       open();
     } else {
-      close();
+      closeAlert(alertId);
     }
   }, [shouldShow]);
 }


### PR DESCRIPTION
Fixes the "Application disconnected from Radon" warning alert not appearing when using the CDP implementation.
Also fixes a bug where the alert would not close automatically when the connection is reestablished.

### How Has This Been Tested: 
- open an app on Android
- go to the Android home screen and wait for the App to disconnect from the debugger
- the "Application disconnected" warning alert should appear
- refocus the application through the Task Manager
- the "Application disconnected" warning alert should disappear and devtools should work

