### PR TITLE
feat: VSCode version for tests

### DIFF
--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -46,6 +46,10 @@ on:
         description: Space-separated list of test numbers to exclude (none excludes nothing)
         required: false
         default: ""
+      VSCodeVersion:
+        description: vscode version to use (e.g. "1.99.1")
+        required: true
+        default: "latest"
   schedule:
     - cron: "27 1 * * *"
 
@@ -59,6 +63,7 @@ jobs:
       IS_RECORDING: ${{ github.event.inputs.isRecording || 'true' }}
       TESTS_TO_RUN: ${{ github.event.inputs.testsToRun || '' }}
       TESTS_TO_EXCLUDE: ${{ github.event.inputs.testsToExclude || '' }}
+      CODE_VERSION: ${{ github.event.inputs.VSCodeVersion || 'latest' }}
       IS_GITHUB_ACTIONS: "true"
 
     steps:

--- a/packages/vscode-extension-tester/package.json
+++ b/packages/vscode-extension-tester/package.json
@@ -6,7 +6,7 @@
     "setup-dev": "extest setup-tests --extensions_dir ./data/vscode-extensions",
     "install-vsix": "extest install-vsix -f ./data/radon-ide.vsix --extensions_dir ./data/vscode-extensions",
     "build-vsix-package": "cd ../vscode-extension && vsce package --out ../vscode-extension-tester/data/radon-ide.vsix && cd ../vscode-extension-tester",
-    "setup": "extest get-vscode && extest get-chromedriver && npm run install-vsix",
+    "setup": "extest get-vscode --code_version ${CODE_VERSION:-latest} && extest get-chromedriver --code_version ${CODE_VERSION:-latest} && npm run install-vsix",
     "ui-tests": "./scripts/run_ui_tests.sh",
     "clean": "rm -rf ./data && mkdir data",
     "setup-run-tests": "npm run setup && npm run ui-tests -- ",

--- a/packages/vscode-extension-tester/scripts/run_tests_on_vm.sh
+++ b/packages/vscode-extension-tester/scripts/run_tests_on_vm.sh
@@ -89,7 +89,7 @@ echo "123456" | sudo -S pmset displaysleep 0
 cd "$REMOTE_PATH"
 npm install
 npm run get-test-app -- $APP
-PROJECT_NAME=$APP npm run setup-run-tests -- $@
+PROJECT_NAME=$APP CODE_VERSION=${CODE_VERSION:-latest} npm run setup-run-tests -- $@
 cd ..
 EOF
 


### PR DESCRIPTION
Adds the ability to choose the VS Code version used during tests. You can select the version by providing the appropriate input in GitHub Actions or by setting an environment variable when running tests locally. For example:
`CODE_VERSION=1.99.1 npm run prepare-and-run-tests` 


### How Has This Been Tested: 

tested locally and on GitHub Actions.

### How Has This Change Been Documented:

no documentation required.



