### PR TITLE
Fix back and home behavior in UrlBar

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -53,7 +53,10 @@ overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-self", {
   visitor: {},
 });
 
-overrideModuleFromAppDir("@react-native/babel-preset/src/plugin-warn-on-deep-imports.js", buildPluginWarnOnDeeImports(process.env.RADON_IDE_LIB_PATH))
+overrideModuleFromAppDir(
+  "@react-native/babel-preset/src/plugin-warn-on-deep-imports.js",
+  buildPluginWarnOnDeeImports(process.env.RADON_IDE_LIB_PATH)
+);
 
 function transformWrapper({ filename, src, ...rest }) {
   function isTransforming(unixPath) {
@@ -79,7 +82,7 @@ function transformWrapper({ filename, src, ...rest }) {
     isTransforming("node_modules/react-native-ide/index.js") || // using react-native-ide for compatibility with old NPM package name
     isTransforming("node_modules/radon-ide/index.js")
   ) {
-    src = `${src};preview = require("__RNIDE_lib__/preview.js").preview;`;
+    src = `module.exports = { preview: require("__RNIDE_lib__/preview.js").preview };`;
   } else if (isTransforming("node_modules/@dev-plugins/react-native-mmkv/build/index.js")) {
     src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
   } else if (isTransforming("node_modules/redux-devtools-expo-dev-plugin/build/index.js")) {

--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -53,10 +53,7 @@ overrideModuleFromAppDir("@babel/plugin-transform-react-jsx-self", {
   visitor: {},
 });
 
-overrideModuleFromAppDir(
-  "@react-native/babel-preset/src/plugin-warn-on-deep-imports.js",
-  buildPluginWarnOnDeeImports(process.env.RADON_IDE_LIB_PATH)
-);
+overrideModuleFromAppDir("@react-native/babel-preset/src/plugin-warn-on-deep-imports.js", buildPluginWarnOnDeeImports(process.env.RADON_IDE_LIB_PATH))
 
 function transformWrapper({ filename, src, ...rest }) {
   function isTransforming(unixPath) {
@@ -82,7 +79,7 @@ function transformWrapper({ filename, src, ...rest }) {
     isTransforming("node_modules/react-native-ide/index.js") || // using react-native-ide for compatibility with old NPM package name
     isTransforming("node_modules/radon-ide/index.js")
   ) {
-    src = `module.exports = { preview: require("__RNIDE_lib__/preview.js").preview };`;
+    src = `${src};preview = require("__RNIDE_lib__/preview.js").preview;`;
   } else if (isTransforming("node_modules/@dev-plugins/react-native-mmkv/build/index.js")) {
     src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
   } else if (isTransforming("node_modules/redux-devtools-expo-dev-plugin/build/index.js")) {

--- a/packages/vscode-extension/lib/expo_router/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_helpers.js
@@ -7,6 +7,9 @@ export function computeRouteIdentifier(pathname, params) {
 }
 
 export function checkNavigationDescriptorsEqual(a, b) {
+  if (!a || !b) {
+    return a === b;
+  }
   if (a.pathname !== b.pathname || Object.keys(a.params).length !== Object.keys(b.params).length) {
     return false;
   }
@@ -20,11 +23,7 @@ export function sendNavigationChange(previousRouteInfo, routeInfo, onNavigationC
   const displayParams = new URLSearchParams(filteredParams).toString();
   const displayName = `${pathname}${displayParams ? `?${displayParams}` : ""}`;
 
-  if (
-    pathname &&
-    previousRouteInfo.current &&
-    !checkNavigationDescriptorsEqual(previousRouteInfo.current, routeInfo)
-  ) {
+  if (pathname && !checkNavigationDescriptorsEqual(previousRouteInfo.current, routeInfo)) {
     onNavigationChange({
       name: displayName,
       pathname,

--- a/packages/vscode-extension/lib/expo_router/expo_router_helpers.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_helpers.js
@@ -16,7 +16,7 @@ export function checkNavigationDescriptorsEqual(a, b) {
   return Object.keys(a).every((key) => deepEqual(a[key], b[key]));
 }
 
-export function sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange) {
+export function sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange, canGoBack) {
   const pathname = routeInfo?.pathname;
   const params = routeInfo?.params;
   const filteredParams = getParamsWithoutDynamicSegments(routeInfo);
@@ -29,6 +29,7 @@ export function sendNavigationChange(previousRouteInfo, routeInfo, onNavigationC
       pathname,
       params,
       id: computeRouteIdentifier(pathname, params),
+      canGoBack,
     });
   }
   previousRouteInfo.current = routeInfo;

--- a/packages/vscode-extension/lib/expo_router/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_plugin.js
@@ -28,7 +28,7 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   }, [store.routeNode]);
 
   useEffect(() => {
-    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange);
+    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange, router.canGoBack());
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {

--- a/packages/vscode-extension/lib/expo_router/expo_router_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_plugin.js
@@ -1,10 +1,10 @@
 import { useSyncExternalStore, useEffect, useRef } from "react";
 import { useRouter } from "expo-router";
 import { store } from "expo-router/build/global-state/router-store.js";
-import { 
+import {
   computeRouteIdentifier,
   extractNestedRouteList,
-  sendNavigationChange
+  sendNavigationChange,
 } from "./expo_router_helpers.js";
 
 function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
@@ -36,6 +36,11 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
       if (router.canGoBack()) {
         router.back();
       }
+      return;
+    } else if (pathname === "__HOME__") {
+      router.dismissAll();
+      // we still need to navigate to / in case the root navigator is a tab navigator
+      router.navigate("/");
       return;
     }
     router.navigate(pathname);

--- a/packages/vscode-extension/lib/expo_router/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_v2_plugin.js
@@ -1,10 +1,10 @@
 import { useSyncExternalStore, useEffect, useRef } from "react";
 import { useRouter } from "expo-router";
 import { store } from "expo-router/src/global-state/router-store";
-import { 
+import {
   computeRouteIdentifier,
   extractNestedRouteList,
-  sendNavigationChange
+  sendNavigationChange,
 } from "./expo_router_helpers.js";
 
 function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
@@ -36,6 +36,11 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
       if (router.canGoBack()) {
         router.back();
       }
+      return;
+    } else if (pathname === "__HOME__") {
+      router.dismissAll();
+      // we still need to navigate to / in case the root navigator is a tab navigator
+      router.navigate("/");
       return;
     }
     router.push(pathname);

--- a/packages/vscode-extension/lib/expo_router/expo_router_v2_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_v2_plugin.js
@@ -28,7 +28,7 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   }, [store.routeNode]);
 
   useEffect(() => {
-    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange);
+    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange, router.canGoBack());
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {

--- a/packages/vscode-extension/lib/expo_router/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_v5_plugin.js
@@ -28,7 +28,7 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
   }, [store.routeNode]);
 
   useEffect(() => {
-    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange);
+    sendNavigationChange(previousRouteInfo, routeInfo, onNavigationChange, router.canGoBack());
   }, [pathname, params]);
 
   function requestNavigationChange({ pathname, params }) {

--- a/packages/vscode-extension/lib/expo_router/expo_router_v5_plugin.js
+++ b/packages/vscode-extension/lib/expo_router/expo_router_v5_plugin.js
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useRouter } from "expo-router";
 import { store, useRouteInfo } from "expo-router/build/global-state/router-store.js";
-import { 
+import {
   computeRouteIdentifier,
   extractNestedRouteList,
-  sendNavigationChange
+  sendNavigationChange,
 } from "./expo_router_helpers.js";
 
 function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
@@ -36,6 +36,13 @@ function useRouterPluginMainHook({ onNavigationChange, onRouteListChange }) {
       if (router.canGoBack()) {
         router.back();
       }
+      return;
+    } else if (pathname === "__HOME__") {
+      // we use dismissTo instead of dismissAll, as it optimistically navigates to / already
+      // in which case the following navigate call would be ignored and won't trigger two events
+      router.dismissTo("/");
+      // we still need to navigate to / in case the root navigator is a tab navigator
+      router.navigate("/");
       return;
     }
     router.navigate(pathname);

--- a/packages/vscode-extension/lib/preview.js
+++ b/packages/vscode-extension/lib/preview.js
@@ -5,8 +5,8 @@ export const PREVIEW_APP_KEY = "RNIDE_preview";
 
 global.__RNIDE_previews ||= new Map();
 
-export function Preview({ previewKey }) {
-  const previewData = global.__RNIDE_previews.get(previewKey);
+export function Preview({ __radon_previewKey }) {
+  const previewData = global.__RNIDE_previews.get(__radon_previewKey);
   if (!previewData || !previewData.component) {
     return null;
   }

--- a/packages/vscode-extension/lib/runtime.js
+++ b/packages/vscode-extension/lib/runtime.js
@@ -33,8 +33,8 @@ function wrapConsole(logFunctionKey) {
 
   if (parseErrorStack === undefined) {
     // This is a dummy evaluation to ensure that the parseErrorStack function is available
-    // before the new console function is returned. This is seeden becae since RN 0.80 
-    // a "metroRequire" function that is called the first time an import is used 
+    // before the new console function is returned. This is seeden becae since RN 0.80
+    // a "metroRequire" function that is called the first time an import is used
     // is may call a "conosole.warn", whitch would trigger an infinite loop
   }
 
@@ -87,7 +87,7 @@ AppRegistry.setWrapperComponentProvider((appParameters) => {
 });
 
 // Some apps may use AppRegistry.setWrapperComponentProvider to provide a custom wrapper component.
-// Apparenlty, this method only supports one provided per app. In order for this to work, we
+// Apparenlty, this method only supports one provider per app. In order for this to work, we
 // overwrite the method to wrap the custom wrapper component with the app wrapper that IDE uses
 // from the wrapper.js file.
 const origSetWrapperComponentProvider = AppRegistry.setWrapperComponentProvider;

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -72,7 +72,7 @@ function getCurrentScene() {
   return RNInternals.SceneTracker.getActiveScene().name;
 }
 
-function noopNavigationHook({ onNavigationChange }) {
+function noopNavigationHook() {
   return {
     getCurrentNavigationDescriptor: () => undefined,
     requestNavigationChange: () => {},
@@ -219,6 +219,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
       data: {
         displayName: navigationDescriptor.name,
         id: navigationDescriptor.id,
+        canGoBack: navigationDescriptor.canGoBack,
       },
     });
   });
@@ -259,7 +260,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
         fabric,
       });
       const urlPrefix = previewKey.startsWith("sb://") ? "sb:" : "preview:";
-      handleNavigationChange({ id: previewKey, name: urlPrefix + preview.name });
+      handleNavigationChange({ id: previewKey, name: urlPrefix + preview.name, canGoBack: true });
     },
     [rootTag, handleNavigationChange, initialProps, fabric]
   );

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -81,8 +81,9 @@ function defaultNavigationHook({ onNavigationChange }) {
     requestNavigationChange: (navigationDescriptor) => {
       if (navigationDescriptor.id === "__BACK__" || navigationDescriptor.id === "__HOME__") {
         // default navigator doesn't support back, for back/home navigation we send empty navigation
-        // descriptor which is interpreted as initial navigation state
-        onNavigationChange({});
+        // descriptor which is interpreted as initial navigation state. Using undefined for the
+        // name will result in the Url bar showing the default starting label ("/")
+        onNavigationChange({ id: "__HOME__", name: undefined, canGoBack: false });
       } else {
         onNavigationChange(navigationDescriptor);
       }

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -1,7 +1,5 @@
 "use no memo";
 
-import { noop } from "lodash";
-
 const { useContext, useState, useEffect, useRef, useCallback } = require("react");
 const {
   LogBox,

--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -283,9 +283,9 @@ export function AppWrapper({ children, initialProps, fabric }) {
 
   const openMainApp = useCallback(
     (nextNavigationDescriptor, forceRerender) => {
-      let closePromiseResolve;
+      let appOpenPromiseResolve;
       const appOpenPromise = new Promise((resolve) => {
-        closePromiseResolve = resolve;
+        appOpenPromiseResolve = resolve;
       });
 
       const mainAppKey = mainApplicationKey ?? "main";
@@ -295,7 +295,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
             rootTag,
             initialProps: {
               ...initialProps,
-              __radon_onLayout: closePromiseResolve,
+              __radon_onLayout: appOpenPromiseResolve,
               __radon_nextNavigationDescriptor: nextNavigationDescriptor,
               __radon_previewKey: undefined,
             },
@@ -309,7 +309,7 @@ export function AppWrapper({ children, initialProps, fabric }) {
         }
       } else {
         nextNavigationDescriptor && requestNavigationChange(nextNavigationDescriptor);
-        closePromiseResolve();
+        appOpenPromiseResolve();
       }
       return appOpenPromise;
     },

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -323,6 +323,7 @@ export type ScreenCaptureState = {
 export type NavigationHistoryItem = {
   displayName: string;
   id: string;
+  canGoBack: boolean;
 };
 
 export type NavigationRoute = {

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -321,7 +321,7 @@ export type ScreenCaptureState = {
 // #region Navigation
 
 export type NavigationHistoryItem = {
-  displayName: string;
+  displayName: string | undefined;
   id: string;
   canGoBack: boolean;
 };

--- a/packages/vscode-extension/src/project/bridge.ts
+++ b/packages/vscode-extension/src/project/bridge.ts
@@ -5,7 +5,7 @@ import { InspectorAvailabilityStatus, NavigationRoute } from "../common/State";
 
 export interface RadonInspectorBridgeEvents {
   appReady: [];
-  navigationChanged: [{ displayName: string; id: string }];
+  navigationChanged: [{ displayName: string; id: string; canGoBack: boolean }];
   navigationRouteListUpdated: [NavigationRoute[]];
   fastRefreshStarted: [];
   fastRefreshComplete: [];

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -74,7 +74,6 @@ export class DeviceSession implements Disposable {
   private screenCapture: ScreenCapture;
 
   private isActive = false;
-  private navigationHomeTarget: NavigationHistoryItem | undefined;
 
   public fileTransfer: FileTransfer;
 
@@ -171,7 +170,6 @@ export class DeviceSession implements Disposable {
   }
 
   private resetStartingState(startupMessage: StartupMessage = StartupMessage.Restarting) {
-    this.navigationHomeTarget = undefined;
     this.stateManager.updateState({
       isUsingStaleBuild: false,
       status: "starting",
@@ -234,9 +232,6 @@ export class DeviceSession implements Disposable {
     // of the devtools instance, which is disposed when we recreate the devtools or
     // when the device session is disposed
     devtools.onEvent("navigationChanged", (payload: NavigationHistoryItem) => {
-      if (!this.navigationHomeTarget) {
-        this.navigationHomeTarget = payload;
-      }
       const navigationHistory = [
         payload,
         ...this.stateManager
@@ -848,9 +843,9 @@ export class DeviceSession implements Disposable {
   }
 
   public navigateHome() {
-    if (this.navigationHomeTarget) {
-      this.inspectorBridge?.sendOpenNavigationRequest(this.navigationHomeTarget.id);
-    }
+    // going home resets the navigation history
+    this.stateManager.updateState({ navigationHistory: [] });
+    this.inspectorBridge?.sendOpenNavigationRequest("__HOME__");
   }
 
   public navigateBack() {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -352,28 +352,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     getTelemetryReporter().sendTelemetryEvent("url-bar:go-home", {
       platform: this.deviceSession?.platform,
     });
-
-    if (this.applicationContext.applicationDependencyManager === undefined) {
-      Logger.error(
-        "[PROJECT] Dependency manager not initialized. this code should be unreachable."
-      );
-      throw new Error("[PROJECT] Dependency manager not initialized");
-    }
-
-    if (await this.applicationContext.applicationDependencyManager.checkProjectUsesExpoRouter()) {
-      await this.deviceSession?.navigateHome();
-    } else {
-      await this.reloadMetro();
-    }
-  }
-
-  private async reloadMetro() {
-    try {
-      await this.deviceSession?.performReloadAction("reloadJs");
-      return true;
-    } catch {
-      return false;
-    }
+    this.deviceSession?.navigateHome();
   }
 
   public async removeNavigationHistoryEntry(id: string): Promise<void> {

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -45,6 +45,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const navigationRouteList = use$(selectedDeviceSessionState.navigationRouteList);
 
   const disabledAlsoWhenStarting = disabled || selectedDeviceSessionStatus === "starting";
+  const canGoBack = navigationHistory?.[0]?.canGoBack;
   const isExpoRouterProject = !expoRouterStatus?.isOptional;
 
   return (
@@ -54,7 +55,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={disabledAlsoWhenStarting || (navigationHistory?.length ?? 0) < 1}
+        disabled={disabledAlsoWhenStarting || !canGoBack}
         onClick={() => project.navigateBack()}>
         <span className="codicon codicon-arrow-left" />
       </IconButton>

--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -54,9 +54,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={
-          disabledAlsoWhenStarting || !isExpoRouterProject || (navigationHistory?.length ?? 0) < 2
-        }
+        disabled={disabledAlsoWhenStarting || (navigationHistory?.length ?? 0) < 1}
         onClick={() => project.navigateBack()}>
         <span className="codicon codicon-arrow-left" />
       </IconButton>

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -14,7 +14,10 @@ import { useSelectedDeviceSessionState } from "../hooks/selectedSession";
 
 export type UrlSelectFocusable = HTMLDivElement | HTMLInputElement;
 
-export type RemovableHistoryItem = NavigationHistoryItem & {
+export type RemovableHistoryItem = {
+  displayName: string;
+  id: string;
+  dynamic: boolean;
   removable?: boolean;
 };
 
@@ -157,13 +160,15 @@ function UrlSelect({
     // Items from navigation history can be removed except the current one,
     // but all extracted routes should always be present in the dropdown.
     const navigationHistoryWithRemovable = navigationHistory.map((item, index) => ({
-      ...item,
+      id: item.id,
+      displayName: item.displayName,
+      dynamic: false,
       removable: index !== 0,
     }));
     const routesNotInHistory = differenceBy(
       routeItems,
       navigationHistory,
-      (item: NavigationHistoryItem) => item.displayName
+      (item) => item.displayName
     );
     return [...navigationHistoryWithRemovable, ...routesNotInHistory];
   }, [navigationHistory, routeItems]);
@@ -266,6 +271,7 @@ function UrlSelect({
                 closeDropdownWithValue({
                   id: textfieldRef.current?.value ?? "",
                   displayName: textfieldRef.current?.value ?? "",
+                  canGoBack: false,
                 });
               }
               if (e.key === "Escape") {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -14,9 +14,12 @@ import { useSelectedDeviceSessionState } from "../hooks/selectedSession";
 
 export type UrlSelectFocusable = HTMLDivElement | HTMLInputElement;
 
-export type RemovableHistoryItem = {
+export type HistoryItemMetadata = {
   displayName: string;
   id: string;
+};
+
+export type RemovableHistoryItem = HistoryItemMetadata & {
   dynamic: boolean;
   removable?: boolean;
 };
@@ -75,7 +78,7 @@ function UrlSelect({
     project.removeNavigationHistoryEntry(id);
   };
 
-  const findDynamicSegments = (item: NavigationHistoryItem) => {
+  const findDynamicSegments = (item: HistoryItemMetadata) => {
     const matchingRoute = routeList.find((route) => route.path === item.id);
     if (matchingRoute && matchingRoute.dynamic) {
       return matchingRoute.dynamic.map((segment) => segment.name);
@@ -83,7 +86,7 @@ function UrlSelect({
     return null;
   };
 
-  const closeDropdownWithValue = (item: NavigationHistoryItem) => {
+  const closeDropdownWithValue = (item: HistoryItemMetadata) => {
     const dynamicSegments = findDynamicSegments(item);
     if (dynamicSegments && dynamicSegments.length > 0) {
       editDynamicPath(item, dynamicSegments);
@@ -97,7 +100,7 @@ function UrlSelect({
     setTimeout(() => textfieldRef.current?.blur(), 0);
   };
 
-  const editDynamicPath = (item: NavigationHistoryItem, segmentNames: string[]) => {
+  const editDynamicPath = (item: HistoryItemMetadata, segmentNames: string[]) => {
     setInputValue(item.displayName);
     setDynamicSegmentNames(segmentNames);
     setCurrentDynamicSegment(0);
@@ -271,7 +274,6 @@ function UrlSelect({
                 closeDropdownWithValue({
                   id: textfieldRef.current?.value ?? "",
                   displayName: textfieldRef.current?.value ?? "",
-                  canGoBack: false,
                 });
               }
               if (e.key === "Escape") {

--- a/packages/vscode-extension/src/webview/components/UrlSelect.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelect.tsx
@@ -15,7 +15,7 @@ import { useSelectedDeviceSessionState } from "../hooks/selectedSession";
 export type UrlSelectFocusable = HTMLDivElement | HTMLInputElement;
 
 export type HistoryItemMetadata = {
-  displayName: string;
+  displayName: string | undefined;
   id: string;
 };
 
@@ -71,7 +71,7 @@ function UrlSelect({
     if (!itemForID) {
       return id;
     }
-    return itemForID.displayName;
+    return itemForID.displayName ?? "/";
   };
 
   const removeHistoryEntry = (id: string) => {
@@ -92,7 +92,7 @@ function UrlSelect({
       editDynamicPath(item, dynamicSegments);
       return;
     }
-    setInputValue(item.displayName);
+    setInputValue(item.displayName ?? "/");
     onValueChange(item.id);
     setIsDropdownOpen(false);
     setDynamicSegmentNames([]);
@@ -101,7 +101,7 @@ function UrlSelect({
   };
 
   const editDynamicPath = (item: HistoryItemMetadata, segmentNames: string[]) => {
-    setInputValue(item.displayName);
+    setInputValue(item.displayName ?? "/");
     setDynamicSegmentNames(segmentNames);
     setCurrentDynamicSegment(0);
     setTimeout(() => {

--- a/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren } from "react";
 import { UrlSelectFocusable, RemovableHistoryItem } from "./UrlSelect";
-import { NavigationHistoryItem } from "../../common/State";
 
 interface UrlSelectItemProps {
   item: RemovableHistoryItem;

--- a/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItem.tsx
@@ -9,7 +9,7 @@ interface UrlSelectItemProps {
   itemList: UrlSelectFocusable[];
   refIndex: number;
   textfieldRef: React.RefObject<HTMLInputElement>;
-  onConfirm: (item: NavigationHistoryItem) => void;
+  onConfirm: (item: RemovableHistoryItem) => void;
   onArrowPress: (
     e: React.KeyboardEvent,
     prev?: UrlSelectFocusable,

--- a/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
@@ -9,7 +9,7 @@ interface UrlSelectItemGroupProps {
   refIndexOffset?: number;
   textfieldRef: React.RefObject<HTMLInputElement>;
   width: number;
-  onConfirm: (item: NavigationHistoryItem) => void;
+  onConfirm: (item: RemovableHistoryItem) => void;
   onArrowPress: (
     e: React.KeyboardEvent,
     prev?: UrlSelectFocusable,

--- a/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlSelectItemGroup.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import UrlSelectItem from "./UrlSelectItem";
 import { RemovableHistoryItem, UrlSelectFocusable } from "./UrlSelect";
-import { NavigationHistoryItem } from "../../common/State";
 
 interface UrlSelectItemGroupProps {
   items: RemovableHistoryItem[];


### PR DESCRIPTION
This PR changes the logic behind integration with URL bar, back and home buttons in order to address multiple issues that we have:
1) Currently, the back button is completely disabled in non expo-router projects, it still occupies the UI.
2) Home button reloads the app, which just isn't intuitive. On top of that it also leaves the history polluted which also isn't what people expect from the browser.
3) Back button doesn't work when preview is opened (doesn't navigate back)
4) The preview URL is displayed in the URL bar after "home" button gets pressed and despite the app showing the main screen not the preview.

### Top-level approach for addressing these points:
1) We should use the back button to allow for going back from preview mode.
2) Home button should just wind back the navigation stack, and on non-router apps it should reset the app to initial screen instead of reloading JS which sometimes takes a while. Finally, home button should reset navigation history and give you a fresh start.
3) Using back on preview should go back in the history (to previous preview or to the app in its last state ideally)

### Fundamental issues in current approach
While investigating the url handling logic I found out about a couple of fundamental issues that this PR fixes first:
1) when opening previews, because expo router is registered as navigation plugin, the preview container would try to use expo router plugin for handling navigation events.
2) using navigate("/") in expo router would in certain setting perform a push transition which just look very weird when you want to go "HOME".

### Notable changes in this PR
Below I document the key changes made in this PR:
1) Changing the logic in `sendNavigationChange:` before it'd only trigger a change if there was already some previous route set. This led to the initial routes not being reported. Because of other issues that eventually triggered following updates, we missed this problem before.
2) expo router plugins now have special handling for __HOME__ event. In v5 and v6 we use new `dismissTo` method as it optimistically allows us to go back to "/" with a single command. On older versions we use `dismissAll` which always require a follow up `navigate("/")` call.
3) We change the `initialProps` keys to always use radon specific prefixes (i.e. `__radon_previewKey`) – this is needed as we read and propagate initial props down to app components. This way we avoid name collision with apps
4) In wrapper, we capture the initial `appKey` (scene name). This is needed such that we can actually close the preview. Before we were using "main" which is the key used in expo-router apps, but we needed this to work on non-expo-router apps too.
5) We delete `__RNIDE_onMount` initial prop handling as it wasn't being used anywhere.
6) The goHome handling in project now always sends "openNavigation" request. We use special key `__HOME__` similarily to how we use `__BACK__`. Home handling is moved from extension logic into the wrapper and plugins. In addition, we clear the history when "home" is requested.
7) We extend `NavigationItem` type to include `canGoBack` flag. In expo-router plugins, the flag is propagated based on `router.canGoBack()` call, we also set it to `true` for previews. Later, this flag is used to determine whether back arrow next to the Url bar is active or not. We further extend the type to also accept undefined as display name, in that case the frontend will show the default home route label (it is "/" in our case now but it is spread all over the codebase right now and didn't want to change that)
8) We add special-handling for the case when HOME is requested from non-expo-router app. In that scenario we force re-render the application using a dummy component that is rendered in between. Apparently AppRegistry doesn't have a method to force re-mounting.

### Unsolved problems in this area
Some problems that are still unsolved but out of scope for this change:
1) when opening two previews one after another, back button would still just go to the main app and not the the last preview.
2) using modal routes from the history would often push a new one instead of navigating back to one that is already open on the stack.
3) if we open preview after navigating first to some non-root route, back button from preview should get us back to that route while it takes us to the root route now.
4) When you use "home" on react-conf-app it results in the url bar dropdown presenting multiple "/" routes. This is a bug in our route resolution code which for some reason returns multiple "/" routes but doesn't show some legal routes like "/info". This problem was mitigated before, because there was always a "/" route in the history which was causing these invalid routes to be filtered out before presenting.

### How Has This Been Tested: 
1) I used react-conf-app to test expo router integrations, in particular: back button after opening preview, home button after opening preview, home button after navigating deep into router hierarchy, back button at different stages
2) I used react-native-81 to test non-expo router setup in particular: going back from preview, home button from preview, home button after changing the screen

