### PR TITLE
Queue up ProxyDebugAdapter events such that they are never sent before attach is complete

### DIFF
--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -117,7 +117,7 @@ export class ProxyDebugAdapter extends DebugSession {
     );
   }
 
-  private sendEvent(event: Event) {
+  public sendEvent(event: Event) {
     if (this.attached) {
       super.sendEvent(event);
     } else {


### PR DESCRIPTION
In #1580 we changed the attach logic in `ProxyDebugAdapter` such that it waits for the actual JS session to be initialized instead of the wrapper session that vscode-js-debug starts at first.

This revealed another issue under specific conditions:
1) our proxy delegate communicates with the proxy debug adapter in two ways: one is via events triggered by the vscode-js-debug debug adapter (specifically attach request that resolves startDebugging call), but also via the proxy delegate.
2) because of this, proxy delegate calls may come before the debug adapter is attached
3) this can happen because proxy delegate receives the events first and only then forwards them to the vscode-js-debug adapter
4) as a consequence, some code (i.e. in DebugSession) may skip certain events, because it'd receive events before it knows the sesion has started. When receiving events it checks if they are coming from session that it expects to start, but it only knows the session after the attach event is processed.

We don't have a direct way to fix this. Ideally we should only communicate with the ProxyDebugAdapter via DAP events, but this would require us to make significant changes to the vscode-js-debug. Instead, this PR proposes a change that prevents DAP events from being dispatched until the session attach response is sent. This way, the code that listens for events would never see an event happen for a session that hasn't yet been started.

This issue was a race/timing based problem and would only happen intermittently. I could reliably reproduce it on the expo-52-dev-client app for some reason. The issue may be amplified when source maps are small which makes the proxy delegate code that waits to fetch the maps much quicker.

The problem has been additionally amplified by the changes from #1580 because we sped up the source maps processing. Now we only read source map JSON looking at `sourceMapData.sources` instead of parsing the actual mappings. In addition, we delayed the `ProxyDebugAdapter` initialization by awaiting for the actual JS debug session to be ready.

### How Has This Been Tested: 
1) Add log statements in DebugSession before `this.jsDebugSession` is assigned and inside `onDidReceiveDebugSessionCustomEvent`.
2) On expo-52-dev-client (where I can reproduce this most reliably) run the app
3) Before this change you'd see `RNIDE_scriptParsed` event dispatched before the `jsDebugSession` is assigned – this caused the listener to ignore the event.
4) after this change the problem no longer happens


