### PR TITLE
fix: initial locale device setting

### DIFF
--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -582,7 +582,7 @@ export const initialState: State = {
         isDisabled: true,
       },
       hasEnrolledBiometrics: false,
-      locale: "en-US",
+      locale: "en_US",
       replaysEnabled: false,
       showTouches: false,
       camera: {


### PR DESCRIPTION
This PR solves a problem with new iphones restarting after initial setup, this was causes by initial locale being equal to `en-US` instead of the correct `en_US` and change being detected by the device setting update system 

### How Has This Been Tested: 

- create a new ios device 
- wait utill it boots 
- change some setting like appearance 
- wait for the device to not restart 

### How Has This Change Been Documented:

internal


