### PR TITLE
fix: syntax highlighting - increase max length limit and introduce throttle

### DIFF
--- a/packages/vscode-extension/src/network/components/Tabs/HighlightedCodeBlock.tsx
+++ b/packages/vscode-extension/src/network/components/Tabs/HighlightedCodeBlock.tsx
@@ -17,7 +17,8 @@ interface HighlightedCodeBlockProps {
  * Maximum content length (in characters) to apply syntax highlighting
  * For larger content, plain text will be displayed to avoid performance issues
  */
-const MAX_HIGHLIGHT_LENGTH = 50_000;
+const MAX_HIGHLIGHT_LENGTH = 100_000;
+const HIGHLIGHT_THROTTLE = 100; // milliseconds
 
 const HighlightedCodeBlock = ({
   content,
@@ -77,6 +78,7 @@ const HighlightedCodeBlock = ({
       language={language}
       showLanguage={false}
       addDefaultStyles={false}
+      delay={HIGHLIGHT_THROTTLE}
       className={className}>
       {content ?? placeholder}
     </ShikiHighlighter>


### PR DESCRIPTION
### Description

This PR changes highlight lenght limit to `100000` and introduces throttle between highlight operations to help performance.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- **test whether highlighter does not lag and behaves as expected**

### How Has This Change Been Documented:

Not applicable.
