### PR TITLE
fix: device default locale 

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -360,7 +360,7 @@
         "RadonIDE.deviceSettings.locale": {
           "type": "string",
           "scope": "window",
-          "default": "en-US",
+          "default": "en_US",
           "description": "Controls the localization of the simulated device."
         },
         "RadonIDE.deviceSettings.replaysEnabled": {

--- a/packages/vscode-extension/src/utilities/workspaceConfiguration.ts
+++ b/packages/vscode-extension/src/utilities/workspaceConfiguration.ts
@@ -88,7 +88,7 @@ export function getCurrentWorkspaceConfiguration(config: WorkspaceConfiguration)
       hasEnrolledBiometrics:
         config.get<boolean>(WorkspaceConfigurationKeyMap.deviceSettings.hasEnrolledBiometrics) ??
         false,
-      locale: config.get<Locale>(WorkspaceConfigurationKeyMap.deviceSettings.locale) ?? "en-US",
+      locale: config.get<Locale>(WorkspaceConfigurationKeyMap.deviceSettings.locale) ?? "en_US",
       replaysEnabled:
         config.get<boolean>(WorkspaceConfigurationKeyMap.deviceSettings.replaysEnabled) ?? false,
       showTouches:


### PR DESCRIPTION
THis PR fixes the format of device locale in all places not only in the `state.ts` like #1607

### How Has This Been Tested: 

- run radon 
- create a new device 
- change its appearance
- make sure it does not reload after a while 

### How Has This Change Been Documented:

internal


