### PR TITLE
fix: loading of new runtimes 

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -128,7 +128,7 @@
     },
     "../vscode-js-debug": {
       "name": "js-debug",
-      "version": "1.104.0",
+      "version": "1.97.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,7 +152,7 @@
         "inversify": "^6.0.2",
         "js-xxhash": "^3.0.1",
         "jsonc-parser": "^3.3.1",
-        "linkifyjs": "^4.3.2",
+        "linkifyjs": "^4.1.3",
         "micromatch": "^4.0.5",
         "npm-run-all2": "^7.0.1",
         "path-browserify": "^1.0.1",
@@ -229,7 +229,7 @@
         "sinon": "^17.0.1",
         "stream-buffers": "^3.0.2",
         "ts-node": "^10.9.2",
-        "tsx": "^4.20.3",
+        "tsx": "^4.7.0",
         "typescript": "^5.5.2",
         "vsce": "^2.7.0"
       },

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -128,7 +128,7 @@
     },
     "../vscode-js-debug": {
       "name": "js-debug",
-      "version": "1.97.0",
+      "version": "1.104.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,7 +152,7 @@
         "inversify": "^6.0.2",
         "js-xxhash": "^3.0.1",
         "jsonc-parser": "^3.3.1",
-        "linkifyjs": "^4.1.3",
+        "linkifyjs": "^4.3.2",
         "micromatch": "^4.0.5",
         "npm-run-all2": "^7.0.1",
         "path-browserify": "^1.0.1",
@@ -229,7 +229,7 @@
         "sinon": "^17.0.1",
         "stream-buffers": "^3.0.2",
         "ts-node": "^10.9.2",
-        "tsx": "^4.7.0",
+        "tsx": "^4.20.3",
         "typescript": "^5.5.2",
         "vsce": "^2.7.0"
       },

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -189,6 +189,7 @@ export interface ProjectInterface {
     displayName: string,
     runtime: IOSRuntimeInfo
   ): Promise<DeviceInfo>;
+  loadInstalledImages(): void;
   renameDevice(device: DeviceInfo, newDisplayName: string): Promise<void>;
   removeDevice(device: DeviceInfo): Promise<void>;
 

--- a/packages/vscode-extension/src/devices/DeviceManager.ts
+++ b/packages/vscode-extension/src/devices/DeviceManager.ts
@@ -46,16 +46,7 @@ export class DeviceManager implements Disposable {
     private readonly outputChannelRegistry: OutputChannelRegistry
   ) {
     this.loadDevicesIntoState();
-    this.listInstalledIOSRuntimes().then((runtimes) => {
-      this.stateManager.updateState({
-        iOSRuntimes: runtimes,
-      });
-    });
-    this.listInstalledAndroidImages().then((images) => {
-      this.stateManager.updateState({
-        androidImages: images,
-      });
-    });
+    this.loadInstalledImages();
 
     this.disposables.push(this.stateManager);
   }
@@ -206,6 +197,19 @@ export class DeviceManager implements Disposable {
     );
     await this.loadDevices(true);
     return simulator;
+  }
+
+  public loadInstalledImages() {
+    this.listInstalledIOSRuntimes().then((runtimes) => {
+      this.stateManager.updateState({
+        iOSRuntimes: runtimes,
+      });
+    });
+    this.listInstalledAndroidImages().then((images) => {
+      this.stateManager.updateState({
+        androidImages: images,
+      });
+    });
   }
 
   public async renameDevice(device: DeviceInfo, newDisplayName: string) {

--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -625,6 +625,10 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
     return this.deviceManager.createIOSDevice(deviceType, displayName, runtime);
   }
 
+  public loadInstalledImages(): void {
+    this.deviceManager.loadInstalledImages();
+  }
+
   public removeDevice(device: DeviceInfo): Promise<void> {
     return this.deviceManager.removeDevice(device);
   }

--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -1,5 +1,5 @@
 import "./ManageDevicesView.css";
-import { MouseEventHandler, useState } from "react";
+import { MouseEventHandler, useEffect, useState } from "react";
 import * as Switch from "@radix-ui/react-switch";
 import { use$ } from "@legendapp/state/react";
 import IconButton from "../components/shared/IconButton";
@@ -141,6 +141,8 @@ function DeviceRow({
 }
 
 function ManageDevicesView() {
+  const { project } = useProject();
+
   const store$ = useStore();
   const selectedDeviceSessionState = useSelectedDeviceSessionState();
   const deviceSessions = use$(store$.projectState.deviceSessions);
@@ -162,6 +164,10 @@ function ManageDevicesView() {
   const androidDevices = (devices ?? []).filter(
     ({ platform, modelId }) => platform === DevicePlatform.Android && modelId.length > 0
   );
+
+  useEffect(() => {
+    project.loadInstalledImages();
+  }, []);
 
   const handleDeviceRename = (device: DeviceInfo) => {
     setSelectedDevice(device);


### PR DESCRIPTION
This PR forces a reload of available ios/android sytem images when the `ManageDevicesView` so before the user will open `createNewDeviceView` to prevent a scenario in which the user can not choose a runtime that was added while Radon was running. 

### How Has This Been Tested: 

- open radon 
- add a new runtime in xcode ( I added 18.4 )
- wait until it is installed and without closing radon open "menage devices" and the "create a new device" 
 - try selecting the runtime and check if the new one is on the list  

### How Has This Change Been Documented:

internal


