### PR TITLE
fix: lint 

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -19,7 +19,6 @@ import ReplayIcon from "../components/icons/ReplayIcon";
 import RecordingIcon from "../components/icons/RecordingIcon";
 import ToolsDropdown from "../components/ToolsDropdown";
 import AppRootSelect from "../components/AppRootSelect";
-import { vscode } from "../utilities/vscode";
 import RadonConnectView from "./RadonConnectView";
 import { useStore } from "../providers/storeProvider";
 import { useSelectedDeviceSessionState } from "../hooks/selectedSession";


### PR DESCRIPTION
This removes unused import introduced by #1612 that caused the Pipeline to fail.



