### PR TITLE
fix: reloading on bundle error shows phone screen early

### DIFF
--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -147,9 +147,8 @@ export class ApplicationSession implements Disposable {
         await cancelToken.adapt(Promise.race([activatePromise, bundleErrorPromise]));
       }
 
-      const hasBundleError = stateManager.getState().bundleError !== null;
-      if (!hasBundleError && getIsActive()) {
-        await cancelToken.adapt(appReadyPromise);
+      if (getIsActive()) {
+        await cancelToken.adapt(Promise.race([appReadyPromise, bundleErrorPromise]));
       }
 
       return session;


### PR DESCRIPTION
Fixes an issue where auto reloading an application with a bundle error would display the phone's screen while the app was still starting.
The issue was caused by `ApplicationSession.launch` resolving early due to checking if bundle error occurred by reading from `ApplicationState`, which is not reset on reloads.
This PR fixes it by instead waiting for the `bundleErrorPromise` to resolve.

### How Has This Been Tested: 
- open the Expo 54 test app
- create a bundle error
- press "Reload"
- wait for the app to relaunch and display the bundle error RedBox 
- press "Reload" again
- the Preview should display the loading screen until the app restarts into the RedBox again



