### PR TITLE
fix: unhandled exeptions

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -82,9 +82,9 @@ function transformWrapper({ filename, src, ...rest }) {
   ) {
     src = `module.exports = require("__RNIDE_lib__/preview.js");`;
   } else if (isTransforming("node_modules/@dev-plugins/react-native-mmkv/build/index.js")) {
-    src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
+    src = `require("__RNIDE_lib__/plugins/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
   } else if (isTransforming("node_modules/redux-devtools-expo-dev-plugin/build/index.js")) {
-    src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("redux-devtools-expo-dev-plugin");${src}`;
+    src = `require("__RNIDE_lib__/plugins/expo_dev_plugins.js").register("redux-devtools-expo-dev-plugin");${src}`;
   } else if (
     isTransforming(
       "node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js"

--- a/packages/vscode-extension/lib/plugins/react-query-devtools.js
+++ b/packages/vscode-extension/lib/plugins/react-query-devtools.js
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/query-core";
-import { register } from "../expo_dev_plugins";
+import { register } from "./expo_dev_plugins";
 import { PluginMessageBridge } from "./PluginMessageBridge";
 
 function broadcastQueryClient(queryClient) {

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -250,6 +250,9 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
 
     try {
       const sourceMapData = await this.getSourceMapData(sourceMapURL);
+      if (sourceMapData.sources === undefined) {
+        return command;
+      }
       const isMainBundle = sourceMapData.sources.some((source: string) =>
         source.includes("__prelude__")
       );

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -57,15 +57,11 @@ interface LaunchApplicationSessionDeps {
   devtoolsPort?: number;
 }
 
-function waitForAppReady(
-  inspectorBridge: RadonInspectorBridge,
-  cancelToken?: CancelToken,
-  message?: string
-) {
+function waitForAppReady(inspectorBridge: RadonInspectorBridge, cancelToken?: CancelToken) {
   // set up `appReady` promise
   const { promise, resolve, reject } = Promise.withResolvers<void>();
   cancelToken?.onCancel(() => {
-    reject(new CancelError("Cancelled while waiting for the app to be ready." + message));
+    reject(new CancelError("Cancelled while waiting for the app to be ready."));
   });
   const appReadyListener = inspectorBridge.onEvent("appReady", resolve);
   promise

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -233,7 +233,7 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
   private maybeInitializeConnection() {
     if (this.connection) {
       // NOTE: a single `DebugSession` only supports a single devtools connection at a time
-      return Promise.reject("[Devtools] Connection already established.");
+      return Promise.reject(new Error("[Devtools] Connection already established."));
     }
     const initializeInternal = () => {
       const initializePromise = this.initializeConnection();

--- a/packages/vscode-extension/src/project/devtools.ts
+++ b/packages/vscode-extension/src/project/devtools.ts
@@ -206,11 +206,25 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
     super();
     this.disposables.push(
       debugSession.onJSDebugSessionStarted(() => {
-        this.maybeInitializeConnection();
+        this.maybeInitializeConnection()
+          .then(() => {
+            Logger.debug(
+              "[Devtools] Devtools connection initialized after JS Debug session started"
+            );
+          })
+          .catch(() => {
+            // we expect the method might fail to initialize the connection
+          });
       }),
       debugSession.onScriptParsed(({ isMainBundle }) => {
         if (isMainBundle) {
-          this.maybeInitializeConnection();
+          this.maybeInitializeConnection()
+            .then(() => {
+              Logger.debug("[Devtools] Devtools connection initialized after main bundle loaded");
+            })
+            .catch(() => {
+              // we expect the method might fail to initialize the connection
+            });
         }
       })
     );
@@ -219,16 +233,20 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
   private maybeInitializeConnection() {
     if (this.connection) {
       // NOTE: a single `DebugSession` only supports a single devtools connection at a time
-      return;
+      return Promise.reject("[Devtools] Connection already established.");
     }
     const initializeInternal = () => {
       const initializePromise = this.initializeConnection();
-      initializePromise.catch((error) => {
-        Logger.error("Failed to initialize devtools connection", error);
-      });
-      initializePromise.then(() => {
-        this.initializeConnectionPromise = undefined;
-      });
+      initializePromise
+        .then(() => {
+          this.initializeConnectionPromise = undefined;
+        })
+        .catch(() => {
+          // we expect the method might fail to initialize the connection
+          // as the app might not be ready to connect yet
+          Logger.debug("[Devtools] Failed to initialize devtools connection");
+        });
+
       return initializePromise;
     };
 
@@ -242,6 +260,8 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
     } else {
       this.initializeConnectionPromise = initializeInternal();
     }
+
+    return this.initializeConnectionPromise;
   }
 
   private async initializeConnection() {
@@ -274,9 +294,14 @@ export class CDPDevtoolsServer extends DevtoolsServer implements Disposable {
       },
       send(event, payload, _transferable) {
         const serializedMessage = JSON.stringify({ event, payload });
-        debugSession.evaluateExpression({
-          expression: `void ${DISPATCHER_GLOBAL}.sendMessage("${DEVTOOLS_DOMAIN_NAME}", '${serializedMessage}')`,
-        });
+        debugSession
+          .evaluateExpression({
+            expression: `void ${DISPATCHER_GLOBAL}.sendMessage("${DEVTOOLS_DOMAIN_NAME}", '${serializedMessage}')`,
+          })
+          .catch(() => {
+            // this method might be used by the devtools bridge implementation while JS Debugger
+            // is disconnected so we just ignore any errors here
+          });
       },
     };
 

--- a/packages/vscode-extension/src/webview/components/DeviceRenameDialog.tsx
+++ b/packages/vscode-extension/src/webview/components/DeviceRenameDialog.tsx
@@ -25,7 +25,7 @@ function DeviceRenameDialog({
     return () => {
       showHeader(true);
     };
-  });
+  }, [showHeader]);
 
   const handleDisplayNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const text = formatDisplayName(event.target.value);

--- a/packages/vscode-extension/src/webview/providers/ModalProvider.tsx
+++ b/packages/vscode-extension/src/webview/providers/ModalProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useState } from "react";
+import React, { createContext, useCallback, useMemo, useState } from "react";
 import Modal from "../components/shared/Modal";
 
 interface ModalState {
@@ -29,7 +29,7 @@ const ModalContext = createContext<ModalContextProps>({
 export default function ModalProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<ModalState | null>(null);
 
-  const openModal = (modalComponent: React.ReactNode, options?: ModalOptions) => {
+  const openModal = useCallback((modalComponent: React.ReactNode, options?: ModalOptions) => {
     setState({
       title: options?.title ?? "",
       component: modalComponent,
@@ -37,24 +37,28 @@ export default function ModalProvider({ children }: { children: React.ReactNode 
       headerShown: true,
       fullscreen: options?.fullscreen || false,
     });
-  };
+  }, []);
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setState(null);
-  };
+  }, []);
 
-  const showHeader = useCallback(
-    (value: boolean) => {
-      if (state === null) {
-        return;
+  const showHeader = useCallback((value: boolean) => {
+    setState((prevState) => {
+      if (prevState === null) {
+        return null;
       }
-      setState({ ...state, headerShown: value });
-    },
-    [state]
+      return { ...prevState, headerShown: value };
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ openModal, closeModal, showHeader }),
+    [openModal, closeModal, showHeader]
   );
 
   return (
-    <ModalContext.Provider value={{ openModal, closeModal, showHeader }}>
+    <ModalContext.Provider value={value}>
       {children}
       {state !== null && (
         <Modal


### PR DESCRIPTION
After recent changes to the boot up system we had a lot of unhandled exceptions flying on loads and reloads this PR solves the following: 
1) `devdools` initilization failed - we had a los promise that was unhandled 
2) sourceMap parseing failed - turns out source maps can come to us without the sources filed causing us to log unnecessary error.
3) wait for an app to load canceled - because of how the application is initialized we need to set up the `appReadyPromise` before performing actions like `reloadWithDebugger` those actions can fail tho before we would normally await `appReadyPromise` making it reject outside of the try catch scope on the next reload when it was cancelled. 

### How Has This Been Tested: 

- run expo 54 test app 
- perform reloads bundle errors and reloads during bundelle errors 

### How Has This Change Been Documented:

internal 


