### PR TITLE
fix: dev plugins 

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -82,9 +82,9 @@ function transformWrapper({ filename, src, ...rest }) {
   ) {
     src = `module.exports = require("__RNIDE_lib__/preview.js");`;
   } else if (isTransforming("node_modules/@dev-plugins/react-native-mmkv/build/index.js")) {
-    src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
+    src = `require("__RNIDE_lib__/plugins/expo_dev_plugins.js").register("@dev-plugins/react-native-mmkv");${src}`;
   } else if (isTransforming("node_modules/redux-devtools-expo-dev-plugin/build/index.js")) {
-    src = `require("__RNIDE_lib__/expo_dev_plugins.js").register("redux-devtools-expo-dev-plugin");${src}`;
+    src = `require("__RNIDE_lib__/plugins/expo_dev_plugins.js").register("redux-devtools-expo-dev-plugin");${src}`;
   } else if (
     isTransforming(
       "node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js"

--- a/packages/vscode-extension/lib/plugins/react-query-devtools.js
+++ b/packages/vscode-extension/lib/plugins/react-query-devtools.js
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/query-core";
-import { register } from "../expo_dev_plugins";
+import { register } from "./expo_dev_plugins";
 import { PluginMessageBridge } from "./PluginMessageBridge";
 
 function broadcastQueryClient(queryClient) {


### PR DESCRIPTION
after recent clean up of the `/lib` dir file structure we left some devplugin related imports pointing to the wrong spot. This PR fixes that 

### How Has This Been Tested: 

- run expo-52-prebuild-with-plugins test app 
- it works

### How Has This Change Been Documented:

internal


