### PR TITLE
fix: network inspector - android header case convention problems

### DIFF
--- a/packages/vscode-extension/lib/network/network.js
+++ b/packages/vscode-extension/lib/network/network.js
@@ -5,6 +5,7 @@ const {
   deserializeRequestData,
   mimeTypeFromResponseType,
   readResponseText,
+  ContentTypeHeader,
 } = require("./networkRequestParsers");
 
 let setupCompleted = false;
@@ -93,7 +94,10 @@ function enableNetworkInspect(networkProxy) {
           url: xhr._url,
           method: xhr._method,
           headers: xhr._headers,
-          postData: deserializeRequestData(data, xhr._headers["content-type"]),
+          postData: deserializeRequestData(
+            data,
+            xhr._headers[ContentTypeHeader.ANDROID] || xhr._headers[ContentTypeHeader.IOS]
+          ),
         },
         type: "XHR",
         initiator: {

--- a/packages/vscode-extension/lib/network/networkRequestParsers.ts
+++ b/packages/vscode-extension/lib/network/networkRequestParsers.ts
@@ -12,7 +12,7 @@ export type InternalResponseBodyData = {
 export const ContentTypeHeader = {
   IOS: "Content-Type",
   ANDROID: "content-type",
-};
+} as const;
 
 interface SerializedTypedArray {
   length: number;

--- a/packages/vscode-extension/lib/network/networkRequestParsers.ts
+++ b/packages/vscode-extension/lib/network/networkRequestParsers.ts
@@ -6,6 +6,14 @@ export type InternalResponseBodyData = {
   dataSize: number;
 };
 
+// Redeclared here from definition in
+// src/network/typesc/network.ts
+//  due to import conflicts from "src" directory
+export const ContentTypeHeader = {
+  IOS: "Content-Type",
+  ANDROID: "content-type",
+};
+
 interface SerializedTypedArray {
   length: number;
   [key: number]: number;
@@ -30,23 +38,23 @@ const PARSABLE_APPLICATION_CONTENT_TYPES = new Set([
   // Shell scripts
   "application/x-sh",
   "application/x-csh",
-  
+
   // JSON variants
   "application/json",
   "application/manifest+json",
   "application/ld+json",
-  
+
   // JavaScript variants
   "application/javascript",
   "application/ecmascript",
   "application/x-ecmascript",
   "application/x-javascript",
-  
+
   // XML variants
   "application/xml",
   "application/xhtml+xml",
   "application/xul",
-  
+
   // Other text-based formats
   "application/yaml",
   "application/rtf",
@@ -136,7 +144,10 @@ async function readResponseText(
     }
 
     if (responseType === "blob") {
-      const contentType = xhr.getResponseHeader("Content-Type") || "";
+      const contentType =
+        xhr.getResponseHeader(ContentTypeHeader.IOS) ||
+        xhr.getResponseHeader(ContentTypeHeader.ANDROID) ||
+        "";
       const isTextType = contentType.startsWith("text/");
       const isParsableApplicationType = Array.from(PARSABLE_APPLICATION_CONTENT_TYPES).some(
         (type) => contentType.startsWith(type)
@@ -253,4 +264,5 @@ module.exports = {
   readResponseText,
   deserializeRequestData,
   mimeTypeFromResponseType,
+  ContentTypeHeader
 };

--- a/packages/vscode-extension/src/network/components/Tabs/ResponseTab.tsx
+++ b/packages/vscode-extension/src/network/components/Tabs/ResponseTab.tsx
@@ -7,6 +7,7 @@ import { ResponseBodyData } from "../../types/network";
 import { NetworkLog } from "../../types/networkLog";
 import "./PayloadAndResponseTab.css";
 import { ThemeData } from "../../../common/theme";
+import { ContentTypeHeader } from "../../types/network";
 
 interface ResponseTabProps {
   networkLog: NetworkLog;
@@ -18,7 +19,10 @@ const ResponseTab = ({ networkLog, responseBodyData, editorThemeData }: Response
   const { fetchAndOpenResponseInEditor } = useNetwork();
   const { body = undefined, wasTruncated = false } = responseBodyData || {};
   const responseData = getFormattedRequestBody(body);
-  const contentType = networkLog.response?.headers?.["Content-Type"] || "";
+  const contentType =
+    networkLog.response?.headers?.[ContentTypeHeader.IOS] ||
+    networkLog.response?.headers?.[ContentTypeHeader.ANDROID] ||
+    "";
   const language = responseData ? determineLanguage(contentType, responseData) : "plaintext";
 
   return (

--- a/packages/vscode-extension/src/network/types/network.ts
+++ b/packages/vscode-extension/src/network/types/network.ts
@@ -39,3 +39,8 @@ export interface TimelineEvent {
   durationMs?: number;
   ttfb?: number;
 }
+
+export enum ContentTypeHeader {
+  IOS = "Content-Type",
+  ANDROID = "content-type",
+}

--- a/packages/vscode-extension/src/network/types/network.ts
+++ b/packages/vscode-extension/src/network/types/network.ts
@@ -40,6 +40,9 @@ export interface TimelineEvent {
   ttfb?: number;
 }
 
+// Declared here and re-declared as object inside
+// `lib/network/networkRequestParsers.ts` due to import conflicts
+// inside `lib` from "src" directory
 export enum ContentTypeHeader {
   IOS = "Content-Type",
   ANDROID = "content-type",

--- a/packages/vscode-extension/src/plugins/network/network-plugin.ts
+++ b/packages/vscode-extension/src/plugins/network/network-plugin.ts
@@ -8,7 +8,7 @@ import { NetworkDevtoolsWebviewProvider } from "./NetworkDevtoolsWebviewProvider
 import { disposeAll } from "../../utilities/disposables";
 import { openContentInEditor, showDismissableError } from "../../utilities/editorOpeners";
 
-import { RequestData, RequestOptions } from "../../network/types/network";
+import { ContentTypeHeader, RequestData, RequestOptions } from "../../network/types/network";
 import {
   WebviewMessage,
   CDPMessage,
@@ -89,7 +89,10 @@ export class NetworkPlugin implements ToolPlugin {
 
     try {
       const response = await this.fetchResponse(requestData);
-      const contentType = response.headers.get("content-type") || "";
+      const contentType =
+        response.headers.get(ContentTypeHeader.IOS) ||
+        response.headers.get(ContentTypeHeader.ANDROID) ||
+        "";
       const responseBody = await response.text();
 
       const language = determineLanguage(contentType, responseBody);


### PR DESCRIPTION
### Description

This PR fixes problems with Network Inspector elements dependent on header fields (i.e. syntax highlighting not working properly on android).

As it turns out, due to XHRInterceptor implementation differences, headers on IOS are written capitalised (`Content-Type`) and on android in lower case (`content-type`). This caused problems with Syntax Highlighting on android, no other issues have been found.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- **open network inspector on android and iOS, check whether every functionality works as expected (especially syntax highlighting)** 

### How Has This Change Been Documented:

Not applicable.
