### PR TITLE
fix: network inspector - filters being case sensitive

### DIFF
--- a/packages/vscode-extension/src/network/providers/NetworkFilterProvider.tsx
+++ b/packages/vscode-extension/src/network/providers/NetworkFilterProvider.tsx
@@ -113,7 +113,7 @@ export function NetworkFilterProvider({ children }: PropsWithChildren) {
 
     // AND between columns, OR within column values
     return NETWORK_LOG_COLUMNS.every((columnName) => {
-      const columnValue = getNetworkLogValue(log, columnName).toLowerCase();
+      const columnValueLowerCase = getNetworkLogValue(log, columnName).toLowerCase();
 
       // if there are no column filters of the type, leave early
       if (!badgeByColumnLookup[columnName] && !(inputTextBadge?.columnName === columnName)) {
@@ -122,14 +122,16 @@ export function NetworkFilterProvider({ children }: PropsWithChildren) {
 
       // try matching inputTextBadge (OR logic)
       if (inputTextBadge && inputTextBadge.columnName === columnName) {
-        if (columnValue.includes(inputTextBadge.value)) {
+        const inputTextBadgeValueLowerCase = inputTextBadge.value.toLowerCase();
+        if (columnValueLowerCase.includes(inputTextBadgeValueLowerCase)) {
           return true;
         }
       }
 
       // match filterBadges within column (OR logic)
       return badgeByColumnLookup[columnName]?.some((value) => {
-        if (columnValue.includes(value)) {
+        const valueLowerCase = value.toLowerCase();
+        if (columnValueLowerCase.includes(valueLowerCase)) {
           return true;
         }
       });
@@ -151,6 +153,7 @@ export function NetworkFilterProvider({ children }: PropsWithChildren) {
       NETWORK_LOG_COLUMNS.some((column) =>
         getNetworkLogValue(log, column).toLowerCase().includes(filterTextValue.toLowerCase())
       );
+    console.log(globalMatches);
 
     return globalMatches;
   };


### PR DESCRIPTION
### Description

This PR fixes problem with network log filters being case sensitive, which is unwanted behaviour.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- **apply filters, see if they are not case sensitive as expected** 

### How Has This Change Been Documented:

Not applicable.
