### PR TITLE
fix: radon connect 

### DIFF
--- a/packages/vscode-extension/src/connect/Scanner.ts
+++ b/packages/vscode-extension/src/connect/Scanner.ts
@@ -57,7 +57,7 @@ export class Scanner implements Disposable {
   }
 
   private async verifyAndConnect(port: number, projectRoot: string) {
-    const metro = new Metro(port, projectRoot);
+    const metro = new Metro(port, projectRoot, [projectRoot]);
 
     const timeoutCancelToken = new CancelToken();
     setTimeout(() => timeoutCancelToken.cancel(), DEBUGGER_LOOKUP_TIMEOUT_MS);

--- a/packages/vscode-extension/src/project/metro.ts
+++ b/packages/vscode-extension/src/project/metro.ts
@@ -258,7 +258,7 @@ async function launchMetro({
 
 export class Metro implements MetroSession, Disposable {
   protected _expoPreludeLineCount = 0;
-  protected _watchFolders: string[] | undefined = undefined;
+  protected _watchFolders: string[] | undefined;
   protected readonly metroOutputChannel;
 
   protected readonly bundleErrorEventEmitter = new EventEmitter<BundleErrorEvent>();
@@ -274,8 +274,11 @@ export class Metro implements MetroSession, Disposable {
 
   constructor(
     public readonly port: number,
-    protected readonly appRoot: string
+    protected readonly appRoot: string,
+    watchFolders: string[] | undefined = undefined
   ) {
+    this._watchFolders = watchFolders;
+
     const metroOutputChannel =
       IDE.getInstanceIfExists()?.outputChannelRegistry.getOrCreateOutputChannel(
         Output.MetroBundler


### PR DESCRIPTION
This PR fixes a regression introduced in #1550 which removed an option to pass `watchFolders` to the metro class directly. Normally we really on metro process handing as this information during the set up process, but when we use radon connect we do not have an option of capturing metro config like in a normal case, so we need to add the  `watchFolders` information by hand. 

### How Has This Been Tested: 

- run expo 54 test app from terminal 
- use radon connect 

### How Has This Change Been Documented:

internal


