### PR TITLE
docs: 1.12 docs misc updates

### DIFF
--- a/packages/docs/docs/features/network-inspector.md
+++ b/packages/docs/docs/features/network-inspector.md
@@ -30,7 +30,7 @@ You can customize the Network Inspector behaviour using the following buttons:
 
 1. **Toggle network activity recording** - starts or stops the capture of network requests made by your application.
 2. **Clear network log** - erases all currently displayed network requests displayed in a list.
-3. **Filter domains** - opens input field allowing for filtering the displayed logs. Read more about filters here.
+3. **Filter domains** - opens input field allowing for filtering the displayed logs.
  
 
 ## Filtering and sorting
@@ -63,3 +63,10 @@ The Network Inspector displays a log of all network requests made by your applic
 - **Time** - the total duration of the request.
 
 Clicking on the network log shows more details about the contents of the request. The details of the request are grouped into into Headers, Payload, Response, and Timing tabs.
+
+Right clicking on the network log opens **Context Menu**, allowing for sorting and filtering the logs, copying the request details, refetching and opening responses in the editor's tab.
+
+
+
+
+

--- a/packages/docs/docs/getting-started/compatibility.md
+++ b/packages/docs/docs/getting-started/compatibility.md
@@ -40,9 +40,9 @@ Radon IDE supports projects bootstrapped with the [React Native Community CLI](h
 
 <div className="compatibility">
 
-| 0.72  | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   |
-| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| <No/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
+| 0.72  | 0.73   | 0.74   | 0.75   | 0.76   | 0.77   | 0.78   | 0.79   | 0.80   | 0.81   | 0.82   |
+| ----- | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| <No/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> | <Yes/> |
 
 </div>
 
@@ -85,16 +85,30 @@ You can use Radon IDE on Windows and Linux using free Beta license.
 
 Radon IDE supports usage of iOS simulators and Android emulators, managing its instances separately from the ones you normally create with Xcode or Android Studio. [Learn more about Device Management.](/docs/guides/device-management)
 
-<div className="phone-table">
-
-| iOS                               | Android         |
-| --------------------------------- | --------------- |
-| iPhone 16 Pro                     | Google Pixel 9  |
-| iPhone 15 Pro                     | Google Pixel 8  |
-| iPhone SE (3rd generation)        | Google Pixel 7  |
-| iPad (A16)                        | Google Pixel 6a |
-| iPad Pro 11-inch (4th generation) |                 |
-
+<div className="phone-table-wrapper">
+    <div className="phone-table">
+    
+    | iOS                               |
+    | --------------------------------- |
+    | iPhone 16 Pro                     |
+    | iPhone 15 Pro                     |
+    | iPhone SE (3rd generation)        |
+    | iPhone 17 Pro                     |
+    | iPhone Air                        |
+    | iPad (A16)                        |
+    | iPad Pro 11-inch (4th generation) |
+    
+    </div>
+    <div className="phone-table">
+    
+    | Android         |
+    | --------------- |
+    | Google Pixel 9  |
+    | Google Pixel 8  |
+    | Google Pixel 7  |
+    | Google Pixel 6a |
+    
+    </div>
 </div>
 
 ### Connect Mode

--- a/packages/docs/docs/guides/troubleshooting.md
+++ b/packages/docs/docs/guides/troubleshooting.md
@@ -113,3 +113,7 @@ If you're using a theme that doesn't look good with Radon IDE, please open an is
 ### -sec-num- Node version is not supported
 
 Radon IDE uses node version inherited from a shell run in the application root, and checks if it satisfies `react-native` minimum requirements. If you have a specific setup that uses node version from outside this range or you want to narrow down the scope of compatible versions for your internal needs, you can do so by specifying `engines` field of your applications `package.json`. If you have a problem installing a compatible node version, we recommend using a tool like [nvm](https://github.com/nvm-sh/nvm).
+
+### -sec-num- Force-enabling Element Inspector
+
+[Element Inspector](/docs/features/element-inspector.md)  disabled by default in apps that don't support edge-to-edge mode due to inconsistent performance. If needed, the tool can be activated regardless of these limitations by setting `RadonIDE.enableExperimentalElementInspector` to true in the editor's settings. Note that while the tool will be operational, its behavior might be unpredictable.

--- a/packages/docs/docs/guides/troubleshooting.md
+++ b/packages/docs/docs/guides/troubleshooting.md
@@ -114,6 +114,6 @@ If you're using a theme that doesn't look good with Radon IDE, please open an is
 
 Radon IDE uses node version inherited from a shell run in the application root, and checks if it satisfies `react-native` minimum requirements. If you have a specific setup that uses node version from outside this range or you want to narrow down the scope of compatible versions for your internal needs, you can do so by specifying `engines` field of your applications `package.json`. If you have a problem installing a compatible node version, we recommend using a tool like [nvm](https://github.com/nvm-sh/nvm).
 
-### -sec-num- Force-enabling Element Inspector
+### -sec-num- Force-enable Element Inspector
 
 [Element Inspector](/docs/features/element-inspector.md)  disabled by default in apps that don't support edge-to-edge mode due to inconsistent performance. If needed, the tool can be activated regardless of these limitations by setting `RadonIDE.enableExperimentalElementInspector` to true in the editor's settings. Note that while the tool will be operational, its behavior might be unpredictable.

--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -68,15 +68,28 @@ table thead tr {
   margin-right: 1em;
 }
 
+.phone-table-wrapper {
+  display: flex;
+  justify-content: space-around;
+  align-items: flex-start;
+  width: 100%;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+  gap: 16px; 
+}
+
 .phone-table {
   display: flex;
   overflow-x: auto;
   justify-content: center;
   width: 100%;
+  min-width: 300px;
+  flex: 1 0 300px;
+  max-width: 500px; 
 }
 
 .phone-table table {
-  max-width: 600px;
+  max-width: 400px;
   table-layout: fixed;
   display: table;
 }


### PR DESCRIPTION
### Description

Added following things to docs:
- support for iPhone 17 Pro and iPhone Air
- separated the table with `Device Simulators and Emulators` into two tables
<img width="1344" height="870" alt="image" src="https://github.com/user-attachments/assets/1519b283-83f1-4e26-90b4-fad4c6e305a9" />
- added force-enabling element inspector section to `Troubleshooting`
- added info about context menu to Network Inspector
