### PR TITLE
feat: make `usePrebuild` option more important then automatic heuristic 

### DIFF
--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -112,6 +112,7 @@ export function createBuildConfig(
           configuration: ios?.configuration,
           fingerprintCommand,
           runtimeId: runtime.identifier,
+          usePrebuild,
         };
       } else {
         return {
@@ -122,6 +123,7 @@ export function createBuildConfig(
           productFlavor: android?.productFlavor,
           buildType: android?.buildType,
           fingerprintCommand,
+          usePrebuild,
         };
       }
     }

--- a/packages/vscode-extension/src/builders/BuildManager.ts
+++ b/packages/vscode-extension/src/builders/BuildManager.ts
@@ -77,7 +77,7 @@ export function createBuildConfig(
           scheme: ios?.scheme,
           configuration: ios?.configuration,
           fingerprintCommand,
-          usePrebuild,
+          usePrebuild: usePrebuild ?? false,
           runtimeId: runtime.identifier,
         };
       } else {
@@ -89,7 +89,7 @@ export function createBuildConfig(
           productFlavor: android?.productFlavor,
           buildType: android?.buildType,
           fingerprintCommand,
-          usePrebuild,
+          usePrebuild: usePrebuild ?? false,
         };
       }
     }
@@ -112,7 +112,7 @@ export function createBuildConfig(
           configuration: ios?.configuration,
           fingerprintCommand,
           runtimeId: runtime.identifier,
-          usePrebuild,
+          usePrebuild: usePrebuild ?? true,
         };
       } else {
         return {
@@ -123,7 +123,7 @@ export function createBuildConfig(
           productFlavor: android?.productFlavor,
           buildType: android?.buildType,
           fingerprintCommand,
-          usePrebuild,
+          usePrebuild: usePrebuild ?? true,
         };
       }
     }

--- a/packages/vscode-extension/src/common/BuildConfig.ts
+++ b/packages/vscode-extension/src/common/BuildConfig.ts
@@ -39,7 +39,7 @@ export type EasLocalBuildConfig = {
 export type AndroidLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.Android;
-  usePrebuild: boolean;
+  usePrebuild?: boolean;
   buildType?: string;
   productFlavor?: string;
 } & BuildConfigCommon;
@@ -47,7 +47,7 @@ export type AndroidLocalBuildConfig = {
 export type IOSLocalBuildConfig = {
   type: BuildType.Local;
   platform: DevicePlatform.IOS;
-  usePrebuild: boolean;
+  usePrebuild?: boolean;
   scheme?: string;
   configuration?: string;
   runtimeId: string;
@@ -56,6 +56,7 @@ export type IOSLocalBuildConfig = {
 export type AndroidDevClientBuildConfig = {
   type: BuildType.DevClient;
   platform: DevicePlatform.Android;
+  usePrebuild?: boolean;
   buildType?: string;
   productFlavor?: string;
 } & BuildConfigCommon;
@@ -63,6 +64,7 @@ export type AndroidDevClientBuildConfig = {
 export type IOSDevClientBuildConfig = {
   type: BuildType.DevClient;
   platform: DevicePlatform.IOS;
+  usePrebuild?: boolean;
   scheme?: string;
   configuration?: string;
   runtimeId: string;

--- a/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
@@ -110,7 +110,10 @@ export class ApplicationDependencyManager implements Disposable {
 
   public async ensureDependenciesForBuild(buildConfig: BuildConfig, buildOptions: BuildOptions) {
     if (buildConfig.type === BuildType.Local || buildConfig.type === BuildType.DevClient) {
-      if ((buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) || buildConfig.usePrebuild) {
+      if (
+        (buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) ||
+        buildConfig.usePrebuild
+      ) {
         try {
           await this.prebuild.runPrebuildIfNeeded(buildConfig, buildOptions);
         } catch (e) {

--- a/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
@@ -110,7 +110,7 @@ export class ApplicationDependencyManager implements Disposable {
 
   public async ensureDependenciesForBuild(buildConfig: BuildConfig, buildOptions: BuildOptions) {
     if (buildConfig.type === BuildType.Local || buildConfig.type === BuildType.DevClient) {
-      if (buildConfig.type === BuildType.DevClient || buildConfig.usePrebuild) {
+      if (buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) {
         try {
           await this.prebuild.runPrebuildIfNeeded(buildConfig, buildOptions);
         } catch (e) {

--- a/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
@@ -110,7 +110,7 @@ export class ApplicationDependencyManager implements Disposable {
 
   public async ensureDependenciesForBuild(buildConfig: BuildConfig, buildOptions: BuildOptions) {
     if (buildConfig.type === BuildType.Local || buildConfig.type === BuildType.DevClient) {
-      if (buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) {
+      if ((buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) || buildConfig.usePrebuild) {
         try {
           await this.prebuild.runPrebuildIfNeeded(buildConfig, buildOptions);
         } catch (e) {

--- a/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
+++ b/packages/vscode-extension/src/dependency/ApplicationDependencyManager.ts
@@ -110,10 +110,7 @@ export class ApplicationDependencyManager implements Disposable {
 
   public async ensureDependenciesForBuild(buildConfig: BuildConfig, buildOptions: BuildOptions) {
     if (buildConfig.type === BuildType.Local || buildConfig.type === BuildType.DevClient) {
-      if (
-        (buildConfig.type === BuildType.DevClient && buildConfig.usePrebuild !== false) ||
-        buildConfig.usePrebuild
-      ) {
+      if (buildConfig.usePrebuild) {
         try {
           await this.prebuild.runPrebuildIfNeeded(buildConfig, buildOptions);
         } catch (e) {

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -26,7 +26,7 @@ export type ResolvedLaunchConfig = LaunchOptions & {
     waitForAppLaunch: boolean;
   };
   env: Record<string, string>;
-  usePrebuild: boolean;
+  usePrebuild?: boolean;
   useOldDevtools: boolean;
 };
 
@@ -82,7 +82,7 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
     preview: {
       waitForAppLaunch: configuration.preview?.waitForAppLaunch ?? true,
     },
-    usePrebuild: configuration.usePrebuild ?? false,
+    usePrebuild: configuration.usePrebuild,
     useOldDevtools: configuration.useOldDevtools ?? !checkFuseboxSupport(absoluteAppRoot),
   };
 }


### PR DESCRIPTION
In our recent changes to the prebuild system, we added an automatic detection to check if the project uses `dev-client` and force a prebuild if it does. This however made us ignore the old `usePrebuild` option in such a scenarion not allowing a user to opt in into a manual prebuild by default. 

### How Has This Been Tested: 

- run `social-app` 
- set the `usePrebuild` option to false
- after it works reload the whole of radon ide

### How Has This Change Been Documented:

not different from the 1.11.2


