### PR TITLE
docs: Note Radon AI is disabled in Cursor by defualt

### DIFF
--- a/packages/docs/docs/features/radon-ai.md
+++ b/packages/docs/docs/features/radon-ai.md
@@ -115,7 +115,7 @@ To disable Radon AI assistant navigate to the editor settings.
 
 You can type "Preferences: Open User Settings" in the command palette (Ctrl+Shift+P or Cmd+Shift+P).
 
-Within editor settings, type "Radon AI: Enabled" into the search bar, press the first result and select `Disabled`.
+Within editor settings, type "Radon AI: Enabled", press the first result and select `Disabled`.
 
 ## Privacy
 


### PR DESCRIPTION
In the latest release (`1.12.0` via #1624) Radon AI has been disabled in Cursor by default.
This PR updates the documentation to reflect that.

This PR should be merged immediately after approval, since the related changes have already been released.