### PR TITLE
Update custom build path parser to fix issues with dot directory parsing

### DIFF
--- a/packages/vscode-extension/src/builders/customBuild.test.ts
+++ b/packages/vscode-extension/src/builders/customBuild.test.ts
@@ -5,112 +5,101 @@ import { extractFilePath } from "./customBuild";
 
 describe("customBuild", () => {
   describe("extractFilePath", () => {
-    it("should extract file paths from various formats and edge cases", () => {
-      const testCases = [
-        {
-          input: `Path: "/Users/me/My App.app"`,
-          expected: "/Users/me/My App.app",
-          description: "quoted path with spaces",
-        },
-        {
-          input: `Installing 'C:\\Program Files\\AppFolder\\App.apk'...`,
-          expected: "C:\\Program Files\\AppFolder\\App.apk",
-          description: "Windows path with single quotes",
-        },
-        {
-          input: `Archive created at ./builds/output.tar.gz`,
-          expected: "./builds/output.tar.gz",
-          description: "relative path with tar.gz",
-        },
-        {
-          input: "/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app",
-          expected: "/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app",
-          description: "absolite app under dot directory with spaces without quotes",
-        },
-        {
-          input: '"/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app"',
-          expected: "/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app",
-          description: "absolite app under dot directory with spaces without quotes",
-        },
-        {
-          input: `No path here`,
-          expected: null,
-          description: "no path present",
-        },
-        {
-          input: `Build output: /tmp/build/MyApp.app`,
-          expected: "/tmp/build/MyApp.app",
-          description: "unquoted absolute path",
-        },
-        {
-          input: `'C:\\Users\\Test\\App.apk' installed successfully`,
-          expected: "C:\\Users\\Test\\App.apk",
-          description: "Windows path with single quotes and additional text",
-        },
-        {
-          input: `Creating archive: "builds/release.tar.gz"`,
-          expected: "builds/release.tar.gz",
-          description: "quoted relative path",
-        },
-        {
-          input: `No valid file extensions here`,
-          expected: null,
-          description: "text without valid extensions",
-        },
-        {
-          input: `/Users/johndow/notes.txt`,
-          expected: null,
-          description: "invalid file extension",
-        },
-        // Dot-directory tests
-        {
-          input: `Build output: /tmp/.hidden/build/MyApp.app`,
-          expected: "/tmp/.hidden/build/MyApp.app",
-          description: "path with dot-directory",
-        },
-        {
-          input: `Archive: "./.build/output.tar.gz"`,
-          expected: "./.build/output.tar.gz",
-          description: "quoted path with dot-directory",
-        },
-        {
-          input: `Installing 'C:\\.hidden\\AppFolder\\App.apk'...`,
-          expected: "C:\\.hidden\\AppFolder\\App.apk",
-          description: "Windows path with dot-directory",
-        },
-        // Single quote tests
-        {
-          input: `Path: '/Users/me/My App.app'`,
-          expected: "/Users/me/My App.app",
-          description: "single-quoted path with spaces",
-        },
-        {
-          input: `Archive created at './builds/output.tar.gz'`,
-          expected: "./builds/output.tar.gz",
-          description: "single-quoted relative path",
-        },
-        // Unquoted paths with spaces
-        {
-          input: `Build output: /tmp/my build/MyApp.app`,
-          expected: "/tmp/my build/MyApp.app",
-          description: "unquoted path with spaces",
-        },
-        {
-          input: `Archive created at ./my builds/output.tar.gz`,
-          expected: "./my builds/output.tar.gz",
-          description: "unquoted relative path with spaces",
-        },
-        {
-          input: `Installing C:\\Program Files\\AppFolder\\App.apk...`,
-          expected: "C:\\Program Files\\AppFolder\\App.apk",
-          description: "unquoted Windows path with spaces",
-        },
-      ];
+    it("should extract quoted path with spaces", () => {
+      const result = extractFilePath(`Path: "/Users/me/My App.app"`);
+      assert.equal(result, "/Users/me/My App.app");
+    });
 
-      testCases.forEach(({ input, expected, description }) => {
-        const result = extractFilePath(input);
-        assert.equal(result, expected, `Failed for ${description}: "${input}"`);
-      });
+    it("should extract Windows path with single quotes", () => {
+      const result = extractFilePath(`Installing 'C:\\Program Files\\AppFolder\\App.apk'...`);
+      assert.equal(result, "C:\\Program Files\\AppFolder\\App.apk");
+    });
+
+    it("should extract relative path with tar.gz", () => {
+      const result = extractFilePath(`Archive created at ./builds/output.tar.gz`);
+      assert.equal(result, "./builds/output.tar.gz");
+    });
+
+    it("should extract absolute app under dot directory with spaces without quotes", () => {
+      const result = extractFilePath("/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app");
+      assert.equal(result, "/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app");
+    });
+
+    it("should extract quoted absolute app under dot directory with spaces", () => {
+      const result = extractFilePath(
+        '"/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app"'
+      );
+      assert.equal(result, "/Users/johndoe/.builds/builds/app-3aabf66a76gggg/My App.app");
+    });
+
+    it("should return null when no path is present", () => {
+      const result = extractFilePath(`No path here`);
+      assert.equal(result, null);
+    });
+
+    it("should extract unquoted absolute path", () => {
+      const result = extractFilePath(`Build output: /tmp/build/MyApp.app`);
+      assert.equal(result, "/tmp/build/MyApp.app");
+    });
+
+    it("should extract Windows path with single quotes and additional text", () => {
+      const result = extractFilePath(`'C:\\Users\\Test\\App.apk' installed successfully`);
+      assert.equal(result, "C:\\Users\\Test\\App.apk");
+    });
+
+    it("should extract quoted relative path", () => {
+      const result = extractFilePath(`Creating archive: "builds/release.tar.gz"`);
+      assert.equal(result, "builds/release.tar.gz");
+    });
+
+    it("should return null for text without valid extensions", () => {
+      const result = extractFilePath(`No valid file extensions here`);
+      assert.equal(result, null);
+    });
+
+    it("should return null for invalid file extension", () => {
+      const result = extractFilePath(`/Users/johndow/notes.txt`);
+      assert.equal(result, null);
+    });
+
+    it("should extract path with dot-directory", () => {
+      const result = extractFilePath(`Build output: /tmp/.hidden/build/MyApp.app`);
+      assert.equal(result, "/tmp/.hidden/build/MyApp.app");
+    });
+
+    it("should extract quoted path with dot-directory", () => {
+      const result = extractFilePath(`Archive: "./.build/output.tar.gz"`);
+      assert.equal(result, "./.build/output.tar.gz");
+    });
+
+    it("should extract Windows path with dot-directory", () => {
+      const result = extractFilePath(`Installing 'C:\\.hidden\\AppFolder\\App.apk'...`);
+      assert.equal(result, "C:\\.hidden\\AppFolder\\App.apk");
+    });
+
+    it("should extract single-quoted path with spaces", () => {
+      const result = extractFilePath(`Path: '/Users/me/My App.app'`);
+      assert.equal(result, "/Users/me/My App.app");
+    });
+
+    it("should extract single-quoted relative path", () => {
+      const result = extractFilePath(`Archive created at './builds/output.tar.gz'`);
+      assert.equal(result, "./builds/output.tar.gz");
+    });
+
+    it("should extract unquoted path with spaces", () => {
+      const result = extractFilePath(`Build output: /tmp/my build/MyApp.app`);
+      assert.equal(result, "/tmp/my build/MyApp.app");
+    });
+
+    it("should extract unquoted relative path with spaces", () => {
+      const result = extractFilePath(`Archive created at ./my builds/output.tar.gz`);
+      assert.equal(result, "./my builds/output.tar.gz");
+    });
+
+    it("should extract unquoted Windows path with spaces", () => {
+      const result = extractFilePath(`Installing C:\\Program Files\\AppFolder\\App.apk...`);
+      assert.equal(result, "C:\\Program Files\\AppFolder\\App.apk");
     });
   });
 });

--- a/packages/vscode-extension/src/builders/customBuild.ts
+++ b/packages/vscode-extension/src/builders/customBuild.ts
@@ -12,11 +12,23 @@ import { DevicePlatform } from "../common/State";
 type Env = Record<string, string> | undefined;
 
 export function extractFilePath(line: string): string | null {
-  // Fixed regex pattern to properly capture only the path
-  const regex =
-    /["']([^"']*\.(?:tar\.gz|app|apk))["']|([a-zA-Z]:\\[^"']*\.(?:tar\.gz|app|apk))|(\/[^"']*\.(?:tar\.gz|app|apk))|(\.\/[^"']*\.(?:tar\.gz|app|apk))/i;
+  // Define file extensions we're looking for
+  const fileExtensions = "(?:tar\\.gz|app|apk)";
 
-  const match = line.match(regex);
+  // Single regex that handles all cases:
+  // 1. Quoted paths: "path.ext" or 'path.ext' (any format inside quotes)
+  // 2. Windows paths: C:\path\file.ext
+  // 3. Unix absolute paths: /path/file.ext
+  // 4. Relative paths: ./path/file.ext
+  const pathRegex = new RegExp(
+    `["']([^"']*\\.${fileExtensions})["']|` + // Quoted: "any/path.ext"
+      `([a-zA-Z]:\\\\[^"']*\\.${fileExtensions})|` + // Windows: C:\path\file.ext
+      `(\\/[^"']*\\.${fileExtensions})|` + // Unix absolute: /path/file.ext
+      `(\\.\\/[^"']*\\.${fileExtensions})`, // Relative: ./path/file.ext
+    "i"
+  );
+
+  const match = line.match(pathRegex);
   if (match) {
     // Return the first non-undefined capture group
     return match[1] || match[2] || match[3] || match[4];


### PR DESCRIPTION
This PR fixes the logic behind the custom build file path parsing.

The previous regex that we used was falling short when there was a dot (".") in the path followed by an empty space, for example: `/Users/krzys/.builds/My App.app`

This PR updates the parsing regex to be more resilient and also consider the cases where quotes are put around the paths (which is often the case when paths include spaces).

On top of that the package contributes a number of unit tests for the new parser. 

### How Has This Been Tested: 
1. Run tests