### PR TITLE
fix: test fails to override imports after refactor

### DIFF
--- a/packages/vscode-extension/src/ai/mcp/index.test.ts
+++ b/packages/vscode-extension/src/ai/mcp/index.test.ts
@@ -82,7 +82,7 @@ describe("creatingMcpConfig", () => {
   it("should differenciate vscode and cursor", async () => {
     const cursorStub = stub().withArgs("cursor").returns({});
     const onCursor = proxyquire("./configCreator", {
-      "./utils": proxyquire("./utils", {
+      "../../utilities/editorType": proxyquire("../../utilities/editorType", {
         vscode: { workspace: { getConfiguration: () => ({ get: cursorStub }) } },
       }),
     });


### PR DESCRIPTION
#1624 broke one of the unit tests by moving one of the exported functions to a different file without updating the path to it in a unit test which stubs it.

### How Has This Been Tested: 
- `npm run test` should pass



