### PR TITLE
fix: renderer patch for projects using expo canary 

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -87,10 +87,10 @@ function transformWrapper({ filename, src, ...rest }) {
     src = `require("__RNIDE_lib__/plugins/expo_dev_plugins.js").register("redux-devtools-expo-dev-plugin");${src}`;
   } else if (
     isTransforming(
-      "node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js"
+      "react-native/Libraries/Renderer/implementations/ReactFabric-dev.js"
     ) ||
     isTransforming(
-      "node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js"
+      "react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js"
     )
   ) {
     // This is a temporary workaround for inspector in React Native 0.74 & 0.75 & 0.76


### PR DESCRIPTION
This PR fixes the inspector functionality in expo-canary projects, by changing the condition for renderer detection

As it turns out projects using expo canary strore the renderer in a expo specific path:
`/node_modules/@expo/cli/static/canary/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js`
instead of expected `/node_modules/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js` 

### How Has This Been Tested: 

- run a test app and see if the changes broke anything 

### How Has This Change Been Documented:

internal


