### PR TITLE
fix: metro config in non flat dependency structures

### DIFF
--- a/packages/vscode-extension/lib/expo/expo_start.js
+++ b/packages/vscode-extension/lib/expo/expo_start.js
@@ -15,6 +15,13 @@ metroConfigReactNative.loadConfig = async function (...args) {
 
 // in projects using expo 54 and newer, the metro config dependency can be found as a dependency of expo
 try {
+  // this is a location that expo CLI uses to import loadConfig method 
+  // unfortunately we can not use something simpler like requireFromAppDependency("expo", "metro-config")
+  // as it would point to the same instance as the one imported from react-native above 
+  // we also need to be careful not to require "@expo/metro-config" witch also exists but is a different package
+  // used for generating "default metro config". This is something we might want to adapt in the future as well.
+  // But for now we want to adapt the config that expo CLI uses in expected scenarios,
+  // which is imported from "@expo/metro/metro-config"
   const metroConfigExpo = requireFromAppDependency("expo", "@expo/metro/metro-config");
   // when the project has "flat"/"no-hoisting" node_modules, the metro-config package
   // will be found as a dependency of both react-native and expo, but they will resolve


### PR DESCRIPTION
This PR updates the logic of how we adapt metro config for expo projects to support `pnpm workspace`. 
Since Expo 54 the `metro-config` module is no longer imported as a `react-native` dependency but is located in `@expo/metro/metro-config` instead. That make our old method of adapting it pass with no effect if `node_modules` do not have a flat structure. 
 
### How Has This Been Tested: 

- run test [pnpm monorepo](https://github.com/byCedric/expo-monorepo-example) to verify it worked 
- run `expo-54`, `expo-53` and `expo-52-prebuildwithplugins` test apps 

### How Has This Change Been Documented:

internal


