### PR TITLE
chore: disable wrong react version warining

### DIFF
--- a/packages/vscode-extension/lib/rn-renderer/react-native-78-79/ReactNativeRenderer-dev.js
+++ b/packages/vscode-extension/lib/rn-renderer/react-native-78-79/ReactNativeRenderer-dev.js
@@ -16809,13 +16809,18 @@ __DEV__ &&
     setSuspenseHandler = function (newShouldSuspendImpl) {
       shouldSuspendImpl = newShouldSuspendImpl;
     };
-    var isomorphicReactPackageVersion = React.version;
-    if ("19.0.0" !== isomorphicReactPackageVersion)
-      throw Error(
-        'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-          (isomorphicReactPackageVersion +
-            "\n  - react-native-renderer:  19.0.0\nLearn more: https://react.dev/warnings/version-mismatch")
-      );
+    // [Radon IDE] This Code here is commented out to prevent React version mismatch errors.
+    // this error when thrown is shown in the Log box as unhandled excepton and does not actulally prevent applicatin from running 
+    // it might be usefull for deguging perpouses for very small section of users but is currentlly blocing users using expo cannary's that 
+    // use non canonical react versions from useing radon so we remove this check for now. 
+    // TODO: create a patching sollution that is capable of working with arbitrary react renderer version
+    // var isomorphicReactPackageVersion = React.version;
+    // if ("19.0.0" !== isomorphicReactPackageVersion)
+    //   throw Error(
+    //     'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+    //       (isomorphicReactPackageVersion +
+    //         "\n  - react-native-renderer:  19.0.0\nLearn more: https://react.dev/warnings/version-mismatch")
+    //   );
     if (
       "function" !==
       typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog

--- a/packages/vscode-extension/lib/rn-renderer/react-native-80-81/ReactNativeRenderer-dev.js
+++ b/packages/vscode-extension/lib/rn-renderer/react-native-80-81/ReactNativeRenderer-dev.js
@@ -16869,13 +16869,18 @@ __DEV__ &&
     setSuspenseHandler = function (newShouldSuspendImpl) {
       shouldSuspendImpl = newShouldSuspendImpl;
     };
-    var isomorphicReactPackageVersion = React.version;
-    if ("19.1.0" !== isomorphicReactPackageVersion)
-      throw Error(
-        'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-          (isomorphicReactPackageVersion +
-            "\n  - react-native-renderer:  19.1.0\nLearn more: https://react.dev/warnings/version-mismatch")
-      );
+    // [Radon IDE] This Code here is commented out to prevent React version mismatch errors.
+    // this error when thrown is shown in the Log box as unhandled excepton and does not actulally prevent applicatin from running 
+    // it might be usefull for deguging perpouses for very small section of users but is currentlly blocing users using expo cannary's that 
+    // use non canonical react versions from useing radon so we remove this check for now. 
+    // TODO: create a patching sollution that is capable of working with arbitrary react renderer version
+    // var isomorphicReactPackageVersion = React.version;
+    // if ("19.1.0" !== isomorphicReactPackageVersion)
+      // throw Error(
+      //   'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+      //     (isomorphicReactPackageVersion +
+    //         "\n  - react-native-renderer:  19.1.0\nLearn more: https://react.dev/warnings/version-mismatch")
+    //   );
     if (
       "function" !==
       typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog

--- a/packages/vscode-extension/lib/rn-renderer/react-native-82/ReactNativeRenderer-dev.js
+++ b/packages/vscode-extension/lib/rn-renderer/react-native-82/ReactNativeRenderer-dev.js
@@ -16872,13 +16872,18 @@ __DEV__ &&
     setSuspenseHandler = function (newShouldSuspendImpl) {
       shouldSuspendImpl = newShouldSuspendImpl;
     };
-    var isomorphicReactPackageVersion = React.version;
-    if ("19.1.1" !== isomorphicReactPackageVersion)
-      throw Error(
-        'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-          (isomorphicReactPackageVersion +
-            "\n  - react-native-renderer:  19.1.1\nLearn more: https://react.dev/warnings/version-mismatch")
-      );
+    // [Radon IDE] This Code here is commented out to prevent React version mismatch errors.
+    // this error when thrown is shown in the Log box as unhandled excepton and does not actulally prevent applicatin from running 
+    // it might be usefull for deguging perpouses for very small section of users but is currentlly blocing users using expo cannary's that 
+    // use non canonical react versions from useing radon so we remove this check for now. 
+    // TODO: create a patching sollution that is capable of working with arbitrary react renderer version
+    // var isomorphicReactPackageVersion = React.version;
+    // if ("19.1.1" !== isomorphicReactPackageVersion)
+    //   throw Error(
+    //     'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+    //       (isomorphicReactPackageVersion +
+    //         "\n  - react-native-renderer:  19.1.1\nLearn more: https://react.dev/warnings/version-mismatch")
+    //   );
     if (
       "function" !==
       typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog


### PR DESCRIPTION
This PR prevents React version mismatch errors.
This error when thrown is shown in the Log box as unhandled excepton and does not actulally prevent applicatin from running it might be usefull for deguging perpouses for very small section of users but is currentlly blocing users using expo cannary's that use non canonical react versions from useing radon so we remove this check for now. 

### How Has This Been Tested: 

- run a test app and see if something broke

### How Has This Change Been Documented:

internal (?)


