### PR TITLE
Don't trigger metro port configuration for iOS simulators when launching with initialUrl (expo go/dev client)

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -522,7 +522,6 @@ export class IosSimulatorDevice extends DeviceBase {
         );
 
         const launchArgsWithInitialUrl = [...launchArguments, "--initialUrl", expoDeeplink];
-        await this.configureMetroPort(build.bundleID, metroPort);
         await this.launchWithBuild(build, launchArgsWithInitialUrl);
       } else {
         // for older Expo SDKs we need to launch via deeplink


### PR DESCRIPTION
In #1662 we introduced a new method for launching expo-go and dev client apps for Expo SDK 52 and above.

Now, instead of launching with a deeplink, we use a normal process launch command and pass additional argument. Soon after landing that PR, I realized that we don't need to call the method resposible for setting up metro port like we do when we launch Expo prebuild or bare RN app. It is because the initialUrl already contains the port. This way we can avoid a bit of extra work that's require for setting up the port (in particular resetting a bunch of services on the simulator).

### How Has This Been Tested: 
1) Run examples for expo-52 and expo-53 dev client and expo-go setups.