### PR TITLE
fix: network inspector -`FilterInput` styles fix

### DIFF
--- a/packages/vscode-extension/src/network/components/FilterInput.css
+++ b/packages/vscode-extension/src/network/components/FilterInput.css
@@ -43,6 +43,13 @@
   font-family: var(--vscode-font-family);
   font-size: var(--vscode-font-size);
   font-weight: var(--vscode-font-weight);
+  height: auto;
+  font-size: var(--vscode-font-size);
+  box-shadow: unset;
+  gap: 0;
+  padding: 0;
+  display: inline-block;
+  border-radius: 0;
   line-height: normal;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
### Description

This PR fixes the improper styling of Network Inspector `FilterInput`, caused by unexpected style override during bundling process.

<img width="883" height="315" alt="Screenshot 2025-10-17 at 16 07 41" src="https://github.com/user-attachments/assets/4c2a6e19-eadd-41b2-a28d-e68ae2d9e09b" />

<img width="688" height="293" alt="Screenshot 2025-10-17 at 16 11 11" src="https://github.com/user-attachments/assets/f3e0d77c-97c6-4024-a0a3-afe354f2cc2b" />

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- build the `.vsix` file by running `npm run vscode:package`, install the extension from file
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, launch app on selected device, open network inspector
- **click on the filter button, see if FilterInput element does not look odd**

### How Has This Change Been Documented:

Not applicable.
