### PR TITLE
fix: inspector on expo 54 while using _debugStack

### DIFF
--- a/packages/vscode-extension/lib/wrapper.js
+++ b/packages/vscode-extension/lib/wrapper.js
@@ -151,11 +151,13 @@ function extractComponentStack(startNode, viewDataHierarchy) {
             let { file, lineNumber, column } = parsedStack[1];
             // the bundle url for which the source map is being registered does use localhost as the host,
             // but in some setups (e.g. expo 54) the debugStack source file names use the numerical IP address
-            // instead resulting in failure to find the source map. To avoid this issue we normalize the address
-            // to localhost here.
+            // in a local network ( 192.x.x.x ) instead resulting in failure to find the source map. 
+            // To avoid this issue we override the address to localhost here. If it is in that range.
             if (file.startsWith("http")) {
               const url = new URL(file);
-              url.hostname = "localhost";
+              if (/^192\.(\d{1,3}\.){2}\d{1,3}$/.test(url.hostname)) {
+                url.hostname = "localhost";
+              }
               file = url.toString();
             }
             source = {


### PR DESCRIPTION
In #1660 we introduce a new way of getting sources of inspected elements, that uses build in react functionality called `_debugStack`. Unfortunately this information points to the bundle location and not a source location, which means we need to translate it. 

As it turns out sometimes (and more specifically we found this behavior in expo 54 apps) the file url we receive as part of  `_debugStack` hostname that is an address in a local network `192.X.X.X` instead of registered in the debugger `localhost`.  I am not quite sure why it is happening as the address that comes with the source map is correct. 

To avoid this in a function responsible for retrieving the inspect information we override incoming address to localhost if it is in `192.x.x.x` range.

### How Has This Been Tested: 

-run `expo-54` test app and check the inspector

### How Has This Change Been Documented:

internal


