### PR TITLE
Translate source location urls to server-relative address before symbolicating

### DIFF
--- a/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
+++ b/packages/vscode-extension/src/debugging/ProxyDebugAdapter.ts
@@ -31,6 +31,12 @@ export class ProxyDebugSessionAdapterDescriptorFactory
   }
 }
 
+// extract address independent part of the URL (no address or port included)
+function sourceUrlKey(sourceUrl: string) {
+  const url = new URL(sourceUrl);
+  return url.pathname + url.search;
+}
+
 const CHILD_SESSION_TYPE = "radon-pwa-node";
 
 export class ProxyDebugAdapter extends DebugSession {
@@ -42,6 +48,7 @@ export class ProxyDebugAdapter extends DebugSession {
   private attached: boolean = false;
   private eventsQueue: Event[] = [];
   private cpuProfileFilePath: string | undefined;
+  private sourceUrlKeyToServerRelativeUrl: Map<string, string> = new Map();
 
   constructor(private session: vscode.DebugSession) {
     super();
@@ -90,7 +97,11 @@ export class ProxyDebugAdapter extends DebugSession {
       proxyDelegate.onBindingCalled(({ name, payload }) => {
         this.sendEvent(new Event(BINDING_CALLED, { name, payload }));
       }),
-      proxyDelegate.onBundleParsed(({ isMainBundle }) => {
+      proxyDelegate.onBundleParsed(({ isMainBundle, sourceUrl }) => {
+        // we store a mapping to the sourceUrl using the sourceUrlKey method that extracts
+        // the bits of the URL that are address independent. This is needed later in the
+        // findOriginalPosition method where more in-depth details are provided in a comment.
+        this.sourceUrlKeyToServerRelativeUrl.set(sourceUrlKey(sourceUrl), sourceUrl);
         this.sendEvent(new Event(SCRIPT_PARSED, { isMainBundle }));
       }),
       debug.onDidReceiveDebugSessionCustomEvent((event) => {
@@ -332,8 +343,22 @@ export class ProxyDebugAdapter extends DebugSession {
   }
 
   private async findOriginalPosition(sourceInfo: SourceInfo) {
+    // Stack trace source URLs always point to the device-relative paths (how hermes sees the bundle URL).
+    // In some setups (i.e. Expo with prebuild) the default path used by the app to fetch the bundle includes
+    // the main network interface IP address, see the below code for reference:
+    // https://github.com/expo/expo/blob/703382eff76b42e0e8908deebcfab47dab3c866d/packages/%40expo/cli/src/start/server/UrlCreator.ts#L157
+    // Metro translates URLs in certain CDP commands from the device-relative (what hermes sees) to the server-relative paths (what
+    // the debugger sees), however, stringified stack traces are not translated (because they are just part of the message being sent).
+    // As a consequence, we may receive a device-relative path, while the debugger can only handle server-relative paths.
+    // When the source is parsed, we extract the sourceUrl that has already been translated and store it using an address
+    // independent key. This allows us to lookup the source Url address as provided to the debugger and use it here to reliably
+    // symbolicate the source location.
+    const serverRelativeUrl = this.sourceUrlKeyToServerRelativeUrl.get(
+      sourceUrlKey(sourceInfo.fileName)
+    );
+
     const res = await this.childDebugSession?.customRequest("getPreferredUILocation", {
-      originalUrl: sourceInfo.fileName,
+      originalUrl: serverRelativeUrl ?? sourceInfo.fileName, // fallback to the original URL is we couldn't find the registered source URL
       line: sourceInfo.line0Based,
       column: sourceInfo.column0Based,
     });

--- a/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
+++ b/packages/vscode-extension/src/debugging/RadonCDPProxyDelegate.ts
@@ -25,7 +25,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
   private debuggerResumedEmitter = new EventEmitter();
   private consoleAPICalledEmitter = new EventEmitter();
   private bindingCalledEmitter = new EventEmitter<Cdp.Runtime.BindingCalledEvent>();
-  private bundleParsedEmitter = new EventEmitter<{ isMainBundle: boolean }>();
+  private bundleParsedEmitter = new EventEmitter<{ isMainBundle: boolean; sourceUrl: string }>();
   private networkEventEmitter = new EventEmitter();
 
   private justCalledStepOver = false;
@@ -287,7 +287,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
 
   private async handleScriptParsed(command: IProtocolCommand): Promise<IProtocolCommand> {
     const params = command.params as Cdp.Debugger.ScriptParsedEvent;
-    const { sourceMapURL } = params;
+    const { sourceMapURL, url } = params;
     if (!sourceMapURL) {
       return command;
     }
@@ -305,7 +305,7 @@ export class RadonCDPProxyDelegate implements CDPProxyDelegate {
         this.mainScriptId = params.scriptId;
       }
 
-      this.bundleParsedEmitter.fire({ isMainBundle });
+      this.bundleParsedEmitter.fire({ isMainBundle, sourceUrl: url });
     } catch (e) {
       Logger.error("Could not process the source map", e);
     }


### PR DESCRIPTION
In #1660 we started using debugStack information in order to provide mapping from components into actual sources.

Since debugStack items use JS traces, we had to decipher from the bundled location into the original source URLs. However, we missed the fact that sometimes the stack trace as seen by hermes, may point to a different URL than the one that the debugger sees.

This comes from the fact that metro translates between so-called "device-relative URLs" and "server-relative URLs" (see more details here: https://github.com/facebook/react-native/blob/05ec7e0ad13cce59e7e3161aa1005392584d6c59/packages/dev-middleware/src/inspector-proxy/Device.js#L710). The translation is done for certain CDP commands and in particular the url provided to the scriptParsed event gets translated as well. When the device and server relative paths are different, we may attempt to use the device one to ask for symbolicating a source location while debugger never gets that url to even register.

In particular, this scenario happens for Expo dev client projects where by default the main network interface is used as the bundle URL location while the server uses localhost, see the below code sections:
1) https://github.com/expo/expo/blob/703382eff76b42e0e8908deebcfab47dab3c866d/packages/%40expo/cli/src/start/server/UrlCreator.ts#L157
2) https://github.com/expo/expo/blob/703382eff76b42e0e8908deebcfab47dab3c866d/packages/%40expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts#L24

All of this results in the source location not being properly translated as we attempt to ask for a device-relative Url while the debugger only operates on the server-relative one.

This PR fixes this issue by tracking the paths that are registered by the debugger. For that we use the `onBundleParsed` where we now also provide the sourceUrl on top of the `isMainBundle` flag.
We then store the mapping from an address independent url key to the actual server-relative source url provided to the scriptParsed event.
When we are asked to translate the source location, we first check whether the address independent url of the source location exists in our map. If it does, we use the mapped server-relative url.

### How Has This Been Tested: 
1) Open expo 54 dev client project
2) Use right-click inspect -> expect the component context menu to show up (before there was none and we'd get some errors in the console)