### PR TITLE
fix: network inspector - response body not updating after the request status changed

### DIFF
--- a/packages/vscode-extension/src/network/components/NetworkLogDetails.tsx
+++ b/packages/vscode-extension/src/network/components/NetworkLogDetails.tsx
@@ -36,6 +36,8 @@ interface Tab {
   Tab: React.FC<TabProps>;
 }
 
+let prevRequestId: string | null = null;
+
 const NetworkLogDetails = ({ networkLog, handleClose, parentHeight }: NetworkLogDetailsProps) => {
   const headerRef = useRef<VscodeTabHeaderElement>(null);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
@@ -46,14 +48,19 @@ const NetworkLogDetails = ({ networkLog, handleClose, parentHeight }: NetworkLog
 
   const themeData = useThemeExtractor();
 
+  // Update response body whenever requestId changes
+  // and when the request finishes loading
   useEffect(() => {
-    if (
+    const shouldUpdate =
+      prevRequestId === networkLog.requestId &&
       networkLog.currentState !== NetworkEvent.LoadingFinished &&
-      networkLog.currentState !== NetworkEvent.LoadingFailed
-    ) {
+      networkLog.currentState !== NetworkEvent.LoadingFailed;
+
+    if (!shouldUpdate) {
       return;
     }
 
+    prevRequestId = networkLog.requestId;
     getResponseBody(networkLog).then((data) => {
       setResponseBodyData(data);
     });


### PR DESCRIPTION
### Description

This PR resolves a bug where opening the details tab during a `(pending)` request resulted in the response body not updating even after the request status changed and a response was received. The issue resulted from the useEffect hook only reacting to changes in networkLog.requestId.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel, open network inspector
- *simulate delay, open request when its pending, see if response body updates correctly*
- 
### How Has This Change Been Documented:

Not applicable.
