### PR TITLE
fix: metro config not overriden on newer Expo 54

### DIFF
--- a/packages/vscode-extension/lib/expo/expo_start.js
+++ b/packages/vscode-extension/lib/expo/expo_start.js
@@ -9,7 +9,7 @@ function createMetroConfigProxy(metroConfig) {
     get(_target, prop, _receiver) {
       const original = Reflect.get(...arguments);
       if (prop === "loadConfig") {
-        return async function pain(...args) {
+        return async function (...args) {
           const config = await original(...args);
           return adaptMetroConfig(config);
         };
@@ -40,7 +40,6 @@ try {
   // to the same instance, so we need to make sure we don't override the loadConfig twice
   const wasMetroConfigAlreadyOverloaded = metroConfigExpo === metroConfigProxy;
   if (!wasMetroConfigAlreadyOverloaded) {
-    console.log("NOT OVERRIDEN");
     overrideModuleFromAppDependency(
       "expo",
       "@expo/metro/metro-config",


### PR DESCRIPTION
Fixes `metro-config` import not being overridden correctly on new Expo 54 versions.
The issue was caused by `metro-config` being built in a different way which changed the shape of exported object from
```js
{
  loadConfig: [async function],
  /* etc... */
}
```
to
```js
{
  default: {
    loadConfig: [async function],
    /* etc... */
  },
  loadConfig: [Getter],
  /* etc... */
}
```
which broke our override.

This PR changes the implementation to instead override the whole export with a `Proxy` object which correctly forwards `loadConfig` calls to our implementation.

### How Has This Been Tested: 
- update dependencies in `expo54` test app to 
```
    "expo": "^54.0.0",
```
- install with `npm install && npx expo install --fix`
- launch app
- it should launch




