### PR TITLE
fix: react query devtools detection broken on newer versions

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -172,7 +172,9 @@ function transformWrapper({ filename, src, ...rest }) {
     }
   } else if (
     isTransforming("node_modules/@tanstack/react-query/src/index.ts") ||
-    isTransforming("node_modules/@tanstack/react-query/build/lib/index.js")
+    isTransforming("node_modules/@tanstack/react-query/build/lib/index.js") ||
+    isTransforming("node_modules/@tanstack/react-query/build/legacy/index.js") ||
+    isTransforming("node_modules/@tanstack/react-query/build/modern/index.js")
   ) {
     src = `require("__RNIDE_lib__/plugins/react-query-devtools.js");${src}`;
   } else if (isTransforming("/lib/rn-internals/rn-internals.js")) {


### PR DESCRIPTION
When testing on a newer version of `react-query` (`"^5.90.5"`) Radon did not detect the tool automatically.
This seems to be caused by a change to the bundled package's directory structure, with `build/lib` directory moving to `build/legacy` and `build/modern`

### How Has This Been Tested: 
- setup an app using a newer version of `react-query`
- run the app
- the React Query devtool should appear in the tools drop-down



