### PR TITLE
fix: do not replace react renderer if react version does not match 

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -137,13 +137,13 @@ function transformWrapper({ filename, src, ...rest }) {
     // Thankfully, in RN 0.80 the new owner stack-based approach made it possible to
     // retrieve the actual call-site stack for components. Therefore the below logic
     // only covers versions on or after 0.74 but before 0.80.
-    const { version } = requireFromAppDir("react-native/package.json");
+    const { version: reactNativeVersion } = requireFromAppDir("react-native/package.json");
     const rendererFileName = filename.split(path.sep).pop();
     if (
-      version.startsWith("0.74") ||
-      version.startsWith("0.75") ||
-      version.startsWith("0.76") ||
-      version.startsWith("0.77")
+      reactNativeVersion.startsWith("0.74") ||
+      reactNativeVersion.startsWith("0.75") ||
+      reactNativeVersion.startsWith("0.76") ||
+      reactNativeVersion.startsWith("0.77")
     ) {
       const rendererFilePath = path.join(
         process.env.RADON_IDE_LIB_PATH,
@@ -154,7 +154,8 @@ function transformWrapper({ filename, src, ...rest }) {
       const rendererAsString = fs.readFileSync(rendererFilePath, "utf-8");
       src = rendererAsString;
     }
-    if (version.startsWith("0.78") || version.startsWith("0.79")) {
+    const { version: reactVersion } = requireFromAppDir("react/package.json");
+    if ((reactNativeVersion.startsWith("0.78") || reactNativeVersion.startsWith("0.79")) && reactVersion.startsWith("19.0")) {
       const rendererFilePath = path.join(
         process.env.RADON_IDE_LIB_PATH,
         "rn-renderer",
@@ -165,9 +166,10 @@ function transformWrapper({ filename, src, ...rest }) {
       src = rendererAsString;
     }
   } else if (isTransforming("node_modules/react/cjs/react-jsx-dev-runtime.development.js")) {
-    const { version } = requireFromAppDir("react-native/package.json");
+    const { version: reactNativeVersion } = requireFromAppDir("react-native/package.json");
     const jsxRuntimeFileName = filename.split(path.sep).pop();
-    if (version.startsWith("0.78") || version.startsWith("0.79")) {
+    const reactVersion = requireFromAppDir("react/package.json").version;
+    if ((reactNativeVersion.startsWith("0.78") || reactNativeVersion.startsWith("0.79")) && reactVersion.startsWith("19.0")) {
       src = `module.exports = require("__RNIDE_lib__/JSXRuntime/react-native-78-79/${jsxRuntimeFileName}");`;
     }
   } else if (


### PR DESCRIPTION
In order to make inspector work on react native 78-79 we replace the react renderer. Do detect if the replacement is necessary we relied on react native version found in the project, but as it turns out there are projects using `reactCanary` flag in `appConfig.js` that allow for upgrading react version independently from react native version. To avoid mismatch renderer versions we add additional check for react version. 

### How Has This Been Tested: 

- run react-native-79 test app and see if inspector works
- do the same for expo-53 and expo-53 with canary builds
- and the same for react-native-78

### How Has This Change Been Documented:

internal


