### PR TITLE
docs: Document `view_component_tree`

### DIFF
--- a/packages/docs/docs/features/radon-ai.md
+++ b/packages/docs/docs/features/radon-ai.md
@@ -90,7 +90,7 @@ The AI models automatically discover and invoke tools when they decide it will b
 - `query_documentation` Retrieves documentation snippets relevant to a provided query.
 - `view_application_logs` Returns all the build, bundling and runtime logs available to Radon IDE. If the app builds and launches successfully, this tool will also attach a screenshot of the app.
 - `view_screenshot` Captures a device preview screenshot. Can help the agent with debugging issues and making UI adjustments. Currently only supported in GPT, Gemini and Claude models.
-- `view_component_tree` Views component tree of the running app. This tool allows the agent to gain a broad understanding of the project's structure.
+- `view_component_tree` Displays the component tree of the running app. This tool allows the agent to gain a broad understanding of the project's structure.
 
 ## Limitations
 


### PR DESCRIPTION
Adds docs for `view_component_tree` added in #1672

before|after
---|---
<img width="906" height="339" alt="image" src="https://github.com/user-attachments/assets/49b93721-5748-4adb-87d2-441d09994667" />|<img width="909" height="400" alt="image" src="https://github.com/user-attachments/assets/cb098e84-2a32-47aa-b6b3-6c87afe6ff77" />
