### PR TITLE
fix: fingerprint not taking platform into account

### DIFF
--- a/packages/vscode-extension/src/project/FingerprintProvider.ts
+++ b/packages/vscode-extension/src/project/FingerprintProvider.ts
@@ -101,6 +101,7 @@ export class FingerprintProvider implements Disposable {
       fingerprintPromise = calculateCustomFingerprint(options as CustomFingerprintOptions);
     } else {
       fingerprintPromise = createFingerprintAsync(appRoot, {
+        platforms: [options.platform === DevicePlatform.IOS ? "ios" : "android"],
         ignorePaths: resolveIgnoredPaths(options.platform),
       }).then((fingerprint) => fingerprint.hash);
     }


### PR DESCRIPTION
Passes the `platforms` argument to `@expo/fingerprint` when calculating native project changes.
This _should_ prevent changes to Android native builds from triggering "Native dependencies changed" warning from appearing on iOS and vice-versa.

### How Has This Been Tested: 
- run `radon-demo-app` (or another application running expo "54.0.15")
- the "Native Dependencies Changed" warning should not appear on iOS after running the app for some time
- after switching to Android, the warning should appear (due to a bug in `expo-modules-autolinking` changing the fingerprint each time it is generated)

### How Has This Change Been Documented:
Internal