### PR TITLE
rebranding: add new pricing plan legal documents

### DIFF
--- a/packages/docs/src/pages/legal/free-license-terms.mdx
+++ b/packages/docs/src/pages/legal/free-license-terms.mdx
@@ -1,0 +1,185 @@
+# RADON IDE FREEWARE LICENSE
+
+<br />
+
+#### Version 1.0, effective as of November 1, 2025
+
+IMPORTANT! READ CAREFULLY:
+THIS IS A LEGAL AGREEMENT. BY CLICKING ON THE "I AGREE" (OR SIMILAR) BUTTON THAT IS PRESENTED TO YOU AT THE TIME OF PURCHASE, OR BY DOWNLOADING, INSTALLING, COPYING, SAVING ON YOUR DEVICE, OR OTHERWISE USING SOFTWARE MANSION SOFTWARE, SUPPORT, OR PRODUCTS, YOU BECOME A PARTY TO THIS AGREEMENT, YOU DECLARE YOU HAVE THE LEGAL CAPACITY TO ENTER INTO THIS AGREEMENT, AND YOU CONSENT TO BE BOUND BY ALL THE TERMS AND CONDITIONS SET FORTH BELOW.
+Software Mansion and Customer may each also be referred to individually as a "Party" or jointly as the "Parties".
+
+## 1. PARTIES
+
+<br />
+
+1.1. "Customer" or "you" means the individual specified in the Subscription Confirmation who is at least 13 years old. For the avoidance of doubt, Customer is a natural person and not a corporation, company, partnership, association, or other entity or organization.
+
+1.2. "Software Mansion" or "we" means: Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
+
+## 2. DEFINITIONS
+
+<br />
+
+2.1. "Affiliate" means, with respect to any Party, any entity that directly, or indirectly through one or more intermediaries, controls, is controlled by, or is under common control of such Party; "control" for such purposes means the possession, direct or indirect, of the power to direct or affect the direction of the management and policies of a person or entity, whether through the ownership of voting securities, by contract, or otherwise.
+
+2.2. "Agreement" means this Radon IDE Freeware License.
+
+2.3. "Machine" means a computing device used by Customer for running the Product.
+
+2.4. "Product" means Radon IDE created by Software Mansion, intended for mass distribution ("Software Mansion Radon IDE"). Software Mansion does not develop Products according to Customer's specifications, nor are Products customized through modification or personalization.
+
+2.5. "Freeware" specifies the Freeware License terms and Products provided to Customer.
+
+## 3. GRANT OF RIGHTS
+
+<br />
+
+3.1. The Product is provided to Customer, solely for non-commercial use on a 'per seat' basis, where Customer may deploy the Product on a single Machine in accordance with the Product documentation, provided that Customer remains the sole user of the Product.
+
+3.2. Unless the Freeware has expired or this Agreement is terminated in accordance with Section 9, and subject to the terms and conditions specified in this Agreement, Software Mansion grants you the non-exclusive and non-transferable right to use each Product covered by this Freeware License as stipulated below:
+
+(A) You may:
+
+(i) install and use any version of the Product covered by the Freeware on a single Machine and on any operating system supported by the Product; and
+
+(ii) make one copy of the Product solely for archival, security, and/or backup purposes.
+
+(B) You may not:
+
+(i) allow the same Freeware to be used concurrently by another user apart from yourself;
+
+(ii) rent, lease, reproduce, modify, adapt, create derivative works of, distribute, sell, or transfer the Product;
+
+(iii) provide a third party with access to the Product, or the right to use the Product;
+
+(iv) reverse engineer, decompile, disassemble, modify, translate, or make any attempt to discover the source code of, the Product;
+
+(v) remove or obscure any proprietary or other notices contained in the Product; or
+
+(vi) use Radon IDE for commercial purposes.
+
+3.3. This Freeware is only for natural persons.
+
+3.4. You acknowledge that no ownership rights are conveyed to you, irrespective of the use of terms such as 'purchase' or 'sale'. Software Mansion has and retains all rights, title, and interest, including all intellectual property rights, in and to the Products, any and all related or underlying technology, and any modifications or derivative works of the Products, including without limitation as they may incorporate Feedback (as defined below).
+
+## 4. ACCESS TO PRODUCTS
+
+<br />
+
+4.1. All deliveries under this Agreement will be electronic. You must have an Internet connection in order to access the Product and receive any deliveries. You are responsible for downloading and installing the Products.
+
+4.2. You may activate and access Product by downloading the Product at www.ide.swmansion.com.
+
+## 5. FEEDBACK
+
+<br />
+
+You have no obligation to provide us with ideas, suggestions, or proposals ("Feedback"). However, if you submit Feedback to us, then you grant us a non-exclusive, worldwide, royalty-free license that is sub-licensable and transferable, to make, use, sell, have made, offer to sell, import, reproduce, publicly display, distribute, modify, or publicly perform the Feedback in any manner without any obligation, royalty, or restriction based on intellectual property rights or otherwise.
+
+## 6. THIRD-PARTY SOFTWARE
+
+<br />
+
+The Products include code and libraries licensed to us by third parties, including open source software ("Third-Party Software"). A list of Third-Party Software included in each Product is available in the respective Product documentation. All Third-Party Software is provided to You under the respective terms stipulated in the Product documentation.
+
+## 7. WARRANTY LIMITATIONS
+
+<br />
+
+ALL PRODUCTS ARE PROVIDED TO CUSTOMER ON AN "AS IS" AND "AS AVAILABLE" BASIS. USE OF THE PRODUCTS IS AT CUSTOMER'S OWN RISK.
+
+SOFTWARE MANSION MAKES NO WARRANTY AS TO THE PRODUCTS' USE OR PERFORMANCE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION (AND ITS AFFILIATES, SHAREHOLDERS, AGENTS, DIRECTORS, AND EMPLOYEES), ITS LICENSORS, SUPPLIERS (INCLUDING THE PROVIDERS OF THIRD PARTY SOFTWARE), AND RESELLERS (COLLECTIVELY HEREUNDER, "SOFTWARE MANSION PARTIES") DISCLAIM ALL WARRANTIES AND CONDITIONS, WHETHER EXPRESS OR IMPLIED (INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT) WITH REGARD TO THE PRODUCTS AND THE PROVISION OF OR FAILURE TO PROVIDE SUPPORT SERVICES.
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION DOES NOT REPRESENT OR WARRANT THAT THE PRODUCTS: (A) ARE ACCURATE, RELIABLE, OR CORRECT; (B) WILL MEET ANY CUSTOMER REQUIREMENTS; (C) WILL BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, UNINTERRUPTED, OR SECURE; (D) ARE FREE OF DEFECTS OR ERRORS AND THAT ANY, IF FOUND, WILL BE CORRECTED; AND/OR (E) ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+
+ANY CONTENT OR DATA DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE PRODUCTS ARE DOWNLOADED AT CUSTOMER'S OWN RISK; CUSTOMER AGREES IT IS SOLELY RESPONSIBLE FOR ANY DAMAGE TO ITS PROPERTY AND/OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD.
+
+CUSTOMER MAY HAVE OTHER RIGHTS WHICH MAY NOT BE LIMITED OR EXCLUDED AND WHICH MAY VARY FROM JURISDICTION TO JURISDICTION. THIS DOCUMENT IS NOT INTENDED TO NEGATIVELY AFFECT SUCH RIGHTS.
+
+## 8. LIMITATION OF LIABILITY
+
+<br />
+
+THE USE OF THE PRODUCT DURING THE FREEWARE SHALL BE ENTIRELY AT THE CUSTOMER'S OWN RISK AND SOFTWARE MANSION SHALL NOT BE LIABLE FOR ANY DAMAGES WHATSOEVER.
+
+Software Mansion also disclaims all liability regarding:
+
+(i) The manner in which the user utilizes the Product.
+
+(ii) The security of data and devices connected through the Product.
+
+(iii) Any damages, losses, or breaches arising from the use of the Product.
+
+IN NO EVENT SHALL SOFTWARE MANSION BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, PUNITIVE, OR CONSEQUENTIAL DAMAGES, INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF PROFITS, LOSS OF DATA, BUSINESS INTERRUPTION, OR ANY OTHER COMMERCIAL DAMAGES OR LOSSES, ARISING OUT OF OR IN CONNECTION WITH THE USE OR INABILITY TO USE THE PRODUCT, HOWEVER CAUSED, AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, EVEN IF SOFTWARE MANSION HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE USER'S SOLE AND EXCLUSIVE REMEDY FOR ANY DISPUTE WITH SOFTWARE MANSION IS TO CEASE USE OF THE PRODUCT.
+
+## 9. TERM AND TERMINATION
+
+<br />
+
+9.1. The term of this Agreement will commence upon the first download of the Product by Customer.
+
+9.2. The product distributed under the Freeware License is available in a limited-functionality version and does not include all features present in the full software editions. This license provides a basic scope of use, with certain restrictions on functionality. To gain access to extended capabilities and the complete feature set, the user is required to purchase one of the offered commercial licenses. The Freeware license is intended solely for non-commercial use of the Product.
+
+9.3. Software Mansion may terminate this Agreement if:
+
+(i) Customer has materially breached this Agreement;
+
+(ii) Software Mansion is required to do so by law (for example, where the provision of the Product to Customer is, or becomes, unlawful); or
+
+(iii) Software Mansion elects to discontinue providing the Product, in whole or in part.
+
+9.4. Upon termination of this Agreement, Customer shall cease all use of the Product.
+
+9.5. Survival. Upon the expiration or termination of this Agreement, Sections 3, 5, 7, 8, 11 and 12 of this Agreement survive.
+
+## 10. TEMPORARY SUSPENSION
+
+<br />
+
+Software Mansion reserves the right to suspend Customer's access to Software Mansion Products if Customer's use of Product is in violation of this Agreement or disrupts or imminently threatens the security, integrity, or availability of a Product.
+
+## 11. EXPORT REGULATIONS
+
+<br />
+
+Customer must comply with all applicable laws and regulations with regard to economic sanctions, export controls, import regulations, restrictive measures, and trade embargoes (all herein referred to as "Sanctions"), including those of the European Union and United States. Customer declares and warrants that it is not a person targeted by Sanctions nor is it otherwise acting on behalf of any entity or person targeted by Sanctions. Customer agrees that it will not download or otherwise export or re-export the Product or any related technical data directly or indirectly to any person targeted by Sanctions or download or otherwise use the Product for any end-use prohibited or restricted by Sanctions.
+
+## 12. GENERAL
+
+<br />
+
+12.1. Entire Agreement. The following documents are part of ('incorporated into') this Agreement: the Software Mansion IDE Privacy Policy, available at https://ide.swmansion.com/privacy-policy. Together, these documents form the entire agreement and replace any previous agreement between you and us in relation to its subject matter. Except as expressly mentioned, this Agreement does not apply or give rights to anyone else ('no third-party beneficiaries'). No purchase order, Customer terms, or other document that purports to modify or supplement this Agreement will vary the terms of this Agreement unless signed by Customer and Software Mansion.
+
+12.2. Reservation of Rights. Software Mansion reserves the right at any time to cease its support of the Product and to alter prices, features, specifications, capabilities, functions, terms of use, release dates, general availability, and other characteristics of the Product. Nothing in this Agreement limits any rights a consumer may have under applicable consumer protection laws.
+
+12.3. Changes to this Agreement. The Agreement can be updated from time to time, to reflect changes in the Product and the Freeware.
+
+If this happens, we will update the terms on the Software Mansion website and let you know either:
+
+(i) by displaying them to you in the Product; or
+
+(ii) by sending the updated version to the email address used.
+
+Any updated Agreement will start ('be effective') on the date specified in the updated Agreement. By continuing to use the Product after the effective date you agree to be bound by the modified Agreement.
+
+12.4. Opportunity to Review. You declare that you have had sufficient opportunity to review this Agreement, understand the content of all of its sections, negotiate its terms, and seek independent professional legal advice before entering into it. Consequently, any statutory "form contract" ("adhesion contract") regulations shall not be applicable to this Agreement.
+
+12.5. Severability. If a particular term of this Agreement is not enforceable, the unenforceability of that term will not affect any other terms of this Agreement.
+
+12.6. Interpretation. Headings and titles are for convenience only and do not affect the interpretation of this Agreement. Terms such as "including" are not exhaustive.
+
+12.7. No Waiver. Our failure to enforce or exercise any part of this Agreement is not a waiver of that section.
+
+12.8. Notice. Software Mansion may deliver any notice to Customer via electronic mail to an email address provided by Customer, registered mail, personal delivery, or reputable express courier (such as DHL, FedEx, or UPS). Any such notice will be deemed to be effective (i) on the day the notice is sent to Customer via email, (ii) upon personal delivery, (iii) one (1) day after deposit with an express courier, or (iv) five (5) days after deposit in the mail, whichever occurs first.
+
+12.9. Governing Law. This Agreement is governed by the laws of Poland, without reference to conflict of laws principles and specifically excluding the United Nations Convention on Contracts for the International Sale of Goods. The Parties to the agreement constituted by this Agreement undertake to use best commercial efforts to amicably settle any disputes arising hereunder ("Dispute").
+
+12.10. Dispute Resolution. Should the Parties to this Agreement fail to settle a Dispute amicably, the Dispute will be decided by the courts having general jurisdiction over Software Mansion; if you are a consumer, we both agree that any Dispute-related litigation may only be brought in, and shall be subject to the jurisdiction of, any competent court of Poland, unless provided otherwise by applicable consumer law. Consumer Disputes can also be settled out of court through the European Commission's online platform for dispute resolution (ec.europa.eu/consumers/odr).
+
+12.11. Data Privacy. By accepting this Agreement, Customer acknowledges that Software Mansion will process personal data in accordance with Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy).
+
+12.12. Force Majeure. Neither Party shall be in breach of this Agreement, or otherwise liable to the other, by reason of any delay in performance, or non-performance, of any of its obligations under this Agreement (except payment obligations), arising directly from an act of God, fire, flood, natural disaster, act of terrorism, strike, lock-out, labor dispute, public health emergency, civil commotion, riot, or act of war.
+
+12.13. Children and minors. If You are under 18 years old, then by entering into this Agreement you explicitly stipulate that (i) you have legal capacity to conclude this Agreement or that you have valid consent from a parent or legal guardian to do so and (ii) you understand the Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy). You may not enter into this Agreement if you are under 13 years old. IF YOU DO NOT UNDERSTAND THIS SECTION, DO NOT UNDERSTAND THE SOFTWARE MANSION PRIVACY POLICY, OR DO NOT KNOW WHETHER YOU HAVE THE LEGAL CAPACITY TO ACCEPT THESE TERMS, PLEASE ASK YOUR PARENT OR LEGAL GUARDIAN FOR HELP.
+
+For further information, please contact us at legal@swmansion.com.

--- a/packages/docs/src/pages/legal/index.tsx
+++ b/packages/docs/src/pages/legal/index.tsx
@@ -3,18 +3,22 @@ import Layout from "@theme/Layout";
 import styles from "./index.module.css";
 import clsx from "clsx";
 
-const data = [
+const currentDocuments = [
   {
     label: "Privacy Policy",
     link: "/legal/privacy-policy",
   },
   {
-    label: "Subscription Agreement for Individual Customers",
-    link: "/legal/personal-license-terms",
+    label: "Radon IDE Freeware License Terms",
+    link: "/legal/free-license-terms",
   },
   {
-    label: "Subscription Agreement For Businesses and Organizations",
-    link: "/legal/b2b-license-terms",
+    label: "Subscription Agreement for Radon IDE Pro",
+    link: "/legal/pro-license-terms",
+  },
+  {
+    label: "Subscription Agreement for Radon IDE Team",
+    link: "/legal/team-license-terms",
   },
   {
     label: "Terms and conditions of purchase",
@@ -23,18 +27,6 @@ const data = [
   {
     label: "Refund policy",
     link: "/legal/refund-policy",
-  },
-  {
-    label: "Free Trial License Terms",
-    link: "/legal/free-trial",
-  },
-  {
-    label: "Early Access Terms of use",
-    link: "/legal/early-terms-of-use",
-  },
-  {
-    label: "Supporter's License Terms",
-    link: "/legal/supporter-terms",
   },
   {
     label: "Data Processing Addendum (DPA)",
@@ -46,6 +38,29 @@ const data = [
   },
 ];
 
+const legacyDocuments = [
+  {
+    label: "Subscription Agreement for Individual Customers",
+    link: "/legal/personal-license-terms",
+  },
+  {
+    label: "Subscription Agreement For Businesses and Organizations",
+    link: "/legal/b2b-license-terms",
+  },
+  {
+    label: "Free Trial License Terms",
+    link: "/legal/free-trial",
+  },
+  {
+    label: "Supporter's License Terms",
+    link: "/legal/supporter-terms",
+  },
+  {
+    label: "Early Access Terms of use",
+    link: "/legal/early-terms-of-use",
+  },
+];
+
 export default function Legal(): JSX.Element {
   return (
     <Layout description="An IDE for React Native">
@@ -53,7 +68,13 @@ export default function Legal(): JSX.Element {
         <div className={clsx(styles.wrapper, "border-layout")}>
           <div className={styles.container}>
             <h1>Software Mansion Radon IDE Terms & Policies</h1>
-            {data.map((item) => (
+            {currentDocuments.map((item) => (
+              <a href={item.link} className={styles.card}>
+                <div>{item.label}</div> <span className={styles.button}>Read document</span>
+              </a>
+            ))}
+            <h2>Legacy documents</h2>
+            {legacyDocuments.map((item) => (
               <a href={item.link} className={styles.card}>
                 <div>{item.label}</div> <span className={styles.button}>Read document</span>
               </a>

--- a/packages/docs/src/pages/legal/pro-license-terms.mdx
+++ b/packages/docs/src/pages/legal/pro-license-terms.mdx
@@ -1,0 +1,247 @@
+# RADON IDE PRO SUBSCRIPTION AGREEMENT
+
+<br />
+
+#### Version 1.0, effective as of November 1, 2025
+
+IMPORTANT! READ CAREFULLY:
+THIS IS A LEGAL AGREEMENT. BY CLICKING ON THE "I AGREE" (OR SIMILAR) BUTTON THAT IS PRESENTED TO YOU AT THE TIME OF PURCHASE, OR BY DOWNLOADING, INSTALLING, COPYING, SAVING ON YOUR DEVICE, OR OTHERWISE USING SOFTWARE MANSION SOFTWARE, SUPPORT, OR PRODUCTS, YOU BECOME A PARTY TO THIS AGREEMENT, YOU DECLARE YOU HAVE THE LEGAL CAPACITY TO ENTER INTO THIS AGREEMENT, AND YOU CONSENT TO BE BOUND BY ALL THE TERMS AND CONDITIONS SET FORTH BELOW.
+Software Mansion and Customer may each also be referred to individually as a "Party" or jointly as the "Parties".
+
+## 1. PARTIES
+
+<br />
+
+1.1. "Customer" or "you" means the individual specified in the Subscription Confirmation. For the avoidance of doubt, Customer is any natural person or legal entity, including companies and organizations, who subscribes to the products or services offered.
+
+1.2. "Software Mansion" or "we" means: Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
+
+## 2. DEFINITIONS
+
+<br />
+
+2.1. "Affiliate" means, with respect to any Party, any entity that directly, or indirectly through one or more intermediaries, controls, is controlled by, or is under common control of such Party; "control" for such purposes means the possession, direct or indirect, of the power to direct or affect the direction of the management and policies of a person or entity, whether through the ownership of voting securities, by contract, or otherwise.
+
+2.2. "Agreement" means this Radon IDE Pro Subscription Agreement for Individual Customers.
+
+2.3. "Machine" means a computing device used by Customer for running the Product.
+
+2.4. "Product" means Radon IDE created by Software Mansion, intended for mass distribution ("Software Mansion Radon IDE"). Software Mansion does not develop Products according to Customer's specifications, nor are Products customized through modification or personalization.
+
+2.5. "Subscription" specifies the subscription term, Products provided to Customer, subscription fees, and payment schedules.
+
+2.6. "Subscription Confirmation" means an email confirming Customer's rights to access and use Products, including Subscription plans, and stating the applicable use limitations for the Product (such as, for example, the number of users and the license period).
+
+## 3. GRANT OF RIGHTS
+
+<br />
+
+3.1. The Product is provided to Customer on a 'per seat' basis, where Customer may deploy the Product on a single Machine in accordance with the Product documentation, provided that Customer remains the sole user of the Product.
+
+3.2. Unless the Subscription has expired or this Agreement is terminated in accordance with Section 13, and subject to the terms and conditions specified in this Agreement, Software Mansion grants you the non-exclusive and non-transferable right to use each Product covered by the Subscription as stipulated below:
+
+(A) You may:
+
+(i) install and use any version of the Product covered by the Subscription on a single Machine and on any operating system supported by the Product; and
+
+(ii) make one copy of the Product solely for archival, security, and/or backup purposes.
+
+(B) You may not:
+
+(i) allow the same Subscription to be used concurrently by another user apart from yourself;
+
+(ii) rent, lease, reproduce, modify, adapt, create derivative works of, distribute, sell, or transfer the Product;
+
+(iii) provide a third party with access to the Product, or the right to use the Product;
+
+(iv) reverse engineer, decompile, disassemble, modify, translate, or make any attempt to discover the source code of, the Product; or
+
+(v) remove or obscure any proprietary or other notices contained in the Product.
+
+3.3. This subscription is for any natural person or legal entity, including companies and organizations. Notwithstanding anything to the contrary in this Agreement, you may not use any of the Products, and this grant of rights shall not be in effect, in the event that you do not pay Subscription fees.
+
+3.4. You acknowledge that no ownership rights are conveyed to you, irrespective of the use of terms such as 'purchase' or 'sale'. Software Mansion has and retains all rights, title, and interest, including all intellectual property rights, in and to the Products, any and all related or underlying technology, and any modifications or derivative works of the Products, including without limitation as they may incorporate Feedback (as defined below).
+
+## 4. PURCHASING THROUGH RESELLERS AND DISTRIBUTORS
+
+<br />
+
+This Agreement applies whether you purchase a Subscription directly from Software Mansion or through an authorized Software Mansion reseller or distributor. If you purchase through a Software Mansion reseller or distributor, the Subscription details shall be as stated in the Subscription Confirmation issued to you by the reseller or distributor, and the reseller or distributor is responsible for the accuracy of any such Subscription Confirmation. Neither resellers nor distributors are authorized to make any promises or commitments on Software Mansion' behalf, and you understand and agree that Software Mansion is not bound by any obligations to you other than as specified in this Agreement.
+
+## 5. ACCESS TO PRODUCTS
+
+<br />
+
+5.1. All deliveries under this Agreement will be electronic. You must have an Internet connection in order to access the Product and receive any deliveries. You are responsible for downloading and installing the Products.
+
+5.2 You may activate and access Products by using the link provided to you in the Subscription Confirmation email.
+
+## 6. FEES
+
+<br />
+
+6.1. Customer shall pay Subscription fees, as specified on the Software Mansion website at www.ide.swmansion.com and in accordance with the Software Mansion IDE Terms and Conditions of Purchase (available at https://ide.swmansion.com/purchase-terms) or an authorized Software Mansion reseller's terms of purchase, whichever are applicable.
+
+6.2. The Subscription fees must be paid in full, and any levies, duties, and/or taxes imposed by Customer's jurisdiction (including, but not limited to, value added tax, sales tax, and withholding tax) shall be borne solely by Customer. Customer may not deduct any amounts from fees payable to Software Mansion or an authorized Software Mansion reseller, unless otherwise specified in the applicable terms of purchase.
+
+## 7. FREE TRIAL
+
+<br />
+
+7.1. The Pro license includes a one-time 14-day free trial, which will automatically convert into a paid monthly or yearly subscription, based on the plan picked by the Customer before starting the trial, unless cancelled. Please note that providing payment card information is required before starting the trial period. By signing up for the free trial, you agree to the terms of this License. Upon expiration of the free trial, you will be charged the full price of the Product.
+
+## 8. MERCHANT OF RECORD
+
+<br />
+
+Software Mansion may use third party payment processors (each, a "Payment Processor") to bill Customer. The processing of payments will be subject to the terms, conditions and privacy policies of the Payment Processor, in addition to these Purchase Terms. Customer agrees to pay Software Mansion, through the Payment Processor, all charges at the prices then in effect for any purchase in accordance with the applicable payment terms. Customer agrees to make payment using the payment method Customer provides with Customer's Account.
+
+## 9. FEEDBACK
+
+<br />
+
+You have no obligation to provide us with ideas, suggestions, or proposals ("Feedback"). However, if you submit Feedback to us, then you grant us a non-exclusive, worldwide, royalty-free license that is sub-licensable and transferable, to make, use, sell, have made, offer to sell, import, reproduce, publicly display, distribute, modify, or publicly perform the Feedback in any manner without any obligation, royalty, or restriction based on intellectual property rights or otherwise.
+
+## 10. THIRD-PARTY SOFTWARE
+
+<br />
+
+The Products include code and libraries licensed to us by third parties, including open source software ("Third-Party Software"). A list of Third-Party Software included in each Product is available in the respective Product documentation. All Third-Party Software is provided to You under the respective terms stipulated in the Product documentation.
+
+## 11. WARRANTY LIMITATIONS
+
+<br />
+
+11.1. ALL PRODUCTS ARE PROVIDED TO CUSTOMER ON AN "AS IS" AND "AS AVAILABLE" BASIS. USE OF THE PRODUCTS IS AT CUSTOMER'S OWN RISK.
+
+11.2. SOFTWARE MANSION MAKES NO WARRANTY AS TO THE PRODUCTS' USE OR PERFORMANCE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION (AND ITS AFFILIATES, SHAREHOLDERS, AGENTS, DIRECTORS, AND EMPLOYEES), ITS LICENSORS, SUPPLIERS (INCLUDING THE PROVIDERS OF THIRD PARTY SOFTWARE), AND RESELLERS (COLLECTIVELY HEREUNDER, "SOFTWARE MANSION PARTIES") DISCLAIM ALL WARRANTIES AND CONDITIONS, WHETHER EXPRESS OR IMPLIED (INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT) WITH REGARD TO THE PRODUCTS AND THE PROVISION OF OR FAILURE TO PROVIDE SUPPORT SERVICES.
+
+11.3. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION DOES NOT REPRESENT OR WARRANT THAT THE PRODUCTS:
+
+(A) ARE ACCURATE, RELIABLE, OR CORRECT;
+
+(B) WILL MEET ANY CUSTOMER REQUIREMENTS;
+
+(C) WILL BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, UNINTERRUPTED, OR SECURE;
+
+(D) ARE FREE OF DEFECTS OR ERRORS AND THAT ANY, IF FOUND, WILL BE CORRECTED; AND/OR
+
+(E) ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+
+11.4. ANY CONTENT OR DATA DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE PRODUCTS ARE DOWNLOADED AT CUSTOMER'S OWN RISK; CUSTOMER AGREES IT IS SOLELY RESPONSIBLE FOR ANY DAMAGE TO ITS PROPERTY AND/OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD.
+
+11.5. CUSTOMER MAY HAVE OTHER RIGHTS WHICH MAY NOT BE LIMITED OR EXCLUDED AND WHICH MAY VARY FROM JURISDICTION TO JURISDICTION. THIS DOCUMENT IS NOT INTENDED TO NEGATIVELY AFFECT SUCH RIGHTS.
+
+## 12. DISCLAIMER OF DAMAGES
+
+<br />
+
+12.1. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL SOFTWARE MANSION BE LIABLE TO CUSTOMER, CUSTOMER'S AFFILIATES, USERS, OR ANYONE ELSE FOR:
+
+(A) ANY LOSS OF USE, DATA, GOODWILL, OR PROFITS, WHETHER OR NOT FORESEEABLE;
+
+(B) ANY LOSS OR DAMAGES IN CONNECTION WITH TERMINATION OR SUSPENSION OF CUSTOMER'S ACCESS TO THE PRODUCTS IN ACCORDANCE WITH THIS AGREEMENT; OR
+
+(C) ANY SPECIAL, INCIDENTAL, INDIRECT, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES WHATSOEVER (EVEN IF THE RELEVANT SOFTWARE MANSION PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF THESE DAMAGES), INCLUDING THOSE
+
+(i) RESULTING FROM LOSS OF USE, DATA, OR PROFITS, WHETHER OR NOT THEY ARE FORESEEABLE,
+
+(ii) BASED ON ANY THEORY OF LIABILITY, INCLUDING BREACH OF CONTRACT OR WARRANTY, STRICT LIABILITY, NEGLIGENCE, OR OTHER TORTIOUS ACTION, OR
+
+(iii) ARISING FROM ANY OTHER CLAIM ARISING OUT OF OR IN CONNECTION WITH CUSTOMER'S USE OF OR ACCESS TO THE PRODUCTS OR SUPPORT. THIS LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+
+12.2. THE TOTAL LIABILITY OF SOFTWARE MANSION IN ANY MATTER ARISING OUT OF OR IN RELATION TO THIS AGREEMENT IS LIMITED TO THE GREATER OF
+
+(A) ONE HUNDRED (100) US DOLLARS OR
+
+(B) THE AGGREGATE AMOUNT PAID OR PAYABLE BY CUSTOMER DURING THE THREE-MONTH PERIOD PRECEDING THE EVENT FOR THE PRODUCTS GIVING RISE TO THE LIABILITY. THIS LIMITATION WILL APPLY EVEN IF THE SOFTWARE MANSION PARTIES HAVE BEEN ADVISED OF THE POSSIBILITY OF LIABILITY EXCEEDING SUCH AN AMOUNT AND NOTWITHSTANDING ANY FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.
+
+## 13. TERM AND TERMINATION
+
+<br />
+
+13.1. The term of this Agreement will commence upon acceptance of this Agreement by Customer as set forth in the preamble above, and it will continue for each Product through the end of the applicable Subscription period specified in the respective Subscription Confirmation. The Subscription and this Agreement will automatically renew in respect to each Product for a successive Subscription period, unless terminated in accordance with this Agreement.
+
+13.2. You may terminate this Agreement at any time by cancelling your Product Subscription via the link provided to you in Subscription Confirmation or via the termination procedure available at the Merchant of Record's website (e.g. Paddle.com). If such termination occurs during a Subscription period, this Agreement will continue to be effective until the end of that Subscription period. Such termination does not relieve you of the obligation to pay any outstanding Subscription fees owed to Software Mansion, and no credits or refunds will be issued to you for prepaid Subscription fees.
+
+13.3. Software Mansion may terminate this Agreement and the associated Subscription if:
+
+(A) Customer has materially breached this Agreement and fails to remedy the breach within thirty (30) days of written notice;
+
+(B) Customer fails to make timely payment of Subscription fees in accordance with Section 6 of this Agreement;
+
+(C) Software Mansion is required to do so by law (for example, where the provision of the Product to Customer is, or becomes, unlawful); or
+
+(D) Software Mansion elects to discontinue providing the Product, in whole or in part.
+
+13.4. Software Mansion will make reasonable efforts to notify Customer via email (to the email address of the billing or technical contact provided by Customer) as follows:
+
+(A) Thirty (30) days prior to termination of the Agreement in the events specified in Sections 13.3(C) and 13.3(D) above, in which case Customer will be entitled to a refund of the unused portion of prepaid Subscription fees, if applicable;
+
+(B) Three (3) days prior to termination of the Agreement in the event specified in Section 13.3(B), in which case Customer will not be entitled to any refund of the unused portion of prepaid Subscription fees.
+
+13.5. Survival. Upon the expiration or termination of this Agreement, Sections 6, 8, 9, 10, 11, and 16 of this Agreement survive.
+
+## 14. TEMPORARY SUSPENSION
+
+<br />
+
+14.1. Software Mansion reserves the right to suspend Customer's access to Software Mansion Products if:
+
+(A) Customer fails to pay Subscription fees on time in accordance with Section 6;
+
+(B) Customer's use of Product is in violation of this Agreement or disrupts or imminently threatens the security, integrity, or availability of a Product.
+
+14.2. If Software Mansion suspends Customer's access to Products for non-payment in accordance with Section 14.1(A), Customer must pay all past due amounts in order to resume access to Product.
+
+14.3. If Software Mansion suspends access to Product in accordance with Section 14.1, Customer agrees that Software Mansion is entitled to charge Customer for the time period during which Customer has access to Software Mansion Products until either access is restored in accordance with Section 14.2 or the Subscription is terminated in accordance with this Agreement.
+
+## 15. EXPORT REGULATIONS
+
+<br />
+
+15.1. Customer must comply with all applicable laws and regulations with regard to economic sanctions, export controls, import regulations, restrictive measures, and trade embargoes (all herein referred to as "Sanctions"), including those of the European Union and United States. Customer declares and warrants that it is not a person targeted by Sanctions nor is it otherwise acting on behalf of any entity or person targeted by Sanctions. Customer agrees that it will not download or otherwise export or re-export the Product or any related technical data directly or indirectly to any person targeted by Sanctions or download or otherwise use the Product for any end-use prohibited or restricted by Sanctions.
+
+## 16. GENERAL
+
+<br />
+
+16.1. **Entire Agreement**. The following documents are part of ('incorporated into') this Agreement: the Software Mansion IDE Privacy Policy, available at https://ide.swmansion.com/privacy-policy, and the Software Mansion IDE Terms and Conditions of Purchase, available at https://ide.swmansion.com/purchase-terms). Together, these documents form the entire agreement and replace any previous agreement between you and us in relation to its subject matter. Except as expressly mentioned, this Agreement does not apply or give rights to anyone else ('no third-party beneficiaries'). No purchase order, Customer terms, or other document that purports to modify or supplement this Agreement will vary the terms of this Agreement unless signed by Customer and Software Mansion.
+
+16.2. **Reservation of Rights**. Software Mansion reserves the right at any time to cease its support of the Product and to alter prices, features, specifications, capabilities, functions, terms of use, release dates, general availability, and other characteristics of the Product. Nothing in this Agreement limits any rights a consumer may have under applicable consumer protection laws.
+
+16.3. **Changes to this Agreement**. The Agreement can be updated from time to time, to reflect changes in the Product and how it is offered to you.
+
+(A) If this happens, we will update the terms on the Software Mansion website and let you know either:
+
+(i) by displaying them to you in the Product; or
+
+(ii) by sending the updated version to the email address used.
+
+(B) Any updated Agreement will start ('be effective') on the date specified in the updated Agreement. By continuing to use the Product after the effective date you agree to be bound by the modified Agreement.
+
+(C) We respect that you may not agree to the updated Agreement. If that is the case, you can terminate your Subscription any time up to 30 days after the effective date of the updated Agreement. Termination according to this Section entitles you to a pro-rata refund of the pre-paid unused Subscription fees.
+
+16.4. **Opportunity to Review**. You declare that you have had sufficient opportunity to review this Agreement, understand the content of all of its sections, negotiate its terms, and seek independent professional legal advice before entering into it. Consequently, any statutory "form contract" ("adhesion contract") regulations shall not be applicable to this Agreement.
+
+16.5. **Severability**. If a particular term of this Agreement is not enforceable, the unenforceability of that term will not affect any other terms of this Agreement.
+
+16.6. **Interpretation**. Headings and titles are for convenience only and do not affect the interpretation of this Agreement. Terms such as "including" are not exhaustive.
+
+16.7. **No Waiver**. Our failure to enforce or exercise any part of this Agreement is not a waiver of that section.
+
+16.8. **Notice**. Software Mansion may deliver any notice to Customer via electronic mail to an email address provided by Customer, registered mail, personal delivery, or reputable express courier (such as DHL, FedEx, or UPS). Any such notice will be deemed to be effective (i) on the day the notice is sent to Customer via email, (ii) upon personal delivery, (iii) one (1) day after deposit with an express courier, or (iv) five (5) days after deposit in the mail, whichever occurs first.
+
+16.9. **Governing Law**. This Agreement is governed by the laws of Poland, without reference to conflict of laws principles and specifically excluding the United Nations Convention on Contracts for the International Sale of Goods. The Parties to the agreement constituted by this Agreement undertake to use best commercial efforts to amicably settle any disputes arising hereunder ("Dispute").
+
+16.10. **Dispute Resolution**. Should the Parties to this Agreement fail to settle a Dispute amicably, the Dispute will be decided by the courts having general jurisdiction over Software Mansion; if you are a consumer, we both agree that any Dispute-related litigation may only be brought in, and shall be subject to the jurisdiction of, any competent court of Poland, unless provided otherwise by applicable consumer law. Consumer Disputes can also be settled out of court through the European Commission's online platform for dispute resolution (ec.europa.eu/consumers/odr).
+
+16.11. **Data Privacy**. By accepting this Agreement, Customer acknowledges that Software Mansion will process personal data in accordance with Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy).
+
+16.12. **Force Majeure**. Neither Party shall be in breach of this Agreement, or otherwise liable to the other, by reason of any delay in performance, or non-performance, of any of its obligations under this Agreement (except payment obligations), arising directly from an act of God, fire, flood, natural disaster, act of terrorism, strike, lock-out, labor dispute, public health emergency, civil commotion, riot, or act of war.
+
+16.13. **Children and minors**. If You are under 18 years old, then by entering into this Agreement you explicitly stipulate that (i) you have legal capacity to conclude this Agreement or that you have valid consent from a parent or legal guardian to do so and (ii) you understand the Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy). You may not enter into this Agreement if you are under 13 years old. IF YOU DO NOT UNDERSTAND THIS SECTION, DO NOT UNDERSTAND THE SOFTWARE MANSION PRIVACY POLICY, OR DO NOT KNOW WHETHER YOU HAVE THE LEGAL CAPACITY TO ACCEPT THESE TERMS, PLEASE ASK YOUR PARENT OR LEGAL GUARDIAN FOR HELP.
+
+The previous version of this agreement is available here.
+
+For further information, please contact us at [legal@swmansion.com](mailto:legal@swmansion.com).

--- a/packages/docs/src/pages/legal/team-license-terms.mdx
+++ b/packages/docs/src/pages/legal/team-license-terms.mdx
@@ -1,0 +1,226 @@
+# RADON IDE TEAM SUBSCRIPTION AGREEMENT
+
+<br />
+
+#### Version 1.0, effective as of November 1, 2025
+
+IMPORTANT! READ CAREFULLY:
+THIS IS A LEGAL AGREEMENT. BY CLICKING ON THE "I AGREE" (OR SIMILAR) BUTTON THAT IS PRESENTED TO CUSTOMER AT THE TIME OF PURCHASE, OR BY DOWNLOADING, INSTALLING, COPYING, SAVING ON CUSTOMER'S DEVICE, OR OTHERWISE USING SOFTWARE MANSION SOFTWARE, SUPPORT, OR PRODUCTS, CUSTOMER BECOMES A PARTY TO THIS AGREEMENT AND CONSENTS TO BE BOUND BY ALL THE TERMS AND CONDITIONS SET FORTH BELOW.
+
+Note: In the event that the terms of this Agreement are in conflict with the terms of any agreement individually negotiated and agreed between Software Mansion and Customer (as defined below), the terms of the latter shall prevail. Software Mansion and Customer may each also be referred to individually as a "Party" or jointly as the "Parties".
+
+## 1. PARTIES
+
+<br />
+
+1.1. "Customer" or "you" means the individual specified in the Subscription Confirmation. For the avoidance of doubt, Customer is any natural person or legal entity, including companies and organizations, who subscribes to the products or services offered.
+
+1.2. "Software Mansion" or "we" means: Software Mansion S.A., a joint stock company with its principal place of business at ul. Zabłocie 43b, 30-701 Kraków, Poland, entered in the register of businesses conducted by the District Court in Kraków for Kraków-Śródmieście, XI Commercial Division of the National Court Register with KRS number 0000961952, NIP 6793131302, REGON 364909814.
+
+## 2. DEFINITIONS
+
+<br />
+
+2.1. "Affiliate" means, with respect to any Party, any entity that directly, or indirectly through one or more intermediaries, controls, is controlled by, or is under common control of such Party; "control" for such purposes means the possession, direct or indirect, of the power to direct or affect the direction of the management and policies of a person or entity, whether through the ownership of voting securities, by contract, or otherwise.
+
+2.2. "Agreement" means this Subscription Agreement for Businesses and Organizations.
+
+2.3. "Machine" means a computing device used by a User for running the Product.
+
+2.4. "Product" means Radon IDE created by Software Mansion, intended for mass distribution ("Software Mansion Radon IDE"). Software Mansion does not develop Products according to Customer's specifications, nor are Products customized through modification or personalization.
+
+2.5. "Subscription" specifies the subscription term, Products provided to Customer, subscription fees, and payment schedules. Subscriptions do not apply to Redistributable Products. A single Subscription may include one or multiple seats/Machines and corresponding Users.
+
+2.6. "Subscription Confirmation" means an email confirming Customer's rights to access and use Products, including Subscription plans, and stating the applicable use limitations for the Product (such as, for example, the number of Users and the license period).
+
+2.7. "User" means any employee, independent contractor, or other individual who obtains access to a Product from Customer (including, for the avoidance of doubt, its Affiliates).
+
+2.8. "Seat" is a device on which the product license is activated. Each device is assigned a unique identifier (fingerprint﻿)﻿, that allows the physical computer to be uniquely recognized. Purchasing a license for 1 seat means the license can be activated on 1 Machine. The term "seat" refers to a single device on which the license can be used.
+
+## 3. GRANT OF RIGHTS
+
+<br />
+
+3.1. The Product is provided to Customer on a 'per seat' basis, where Customer must assign a Subscription to a specific User who may deploy the Product on a specific Machine in accordance with the Product documentation. If Customer complies with the terms of this Agreement, Software Mansion grants to Customer the rights set out in this Section 3 to the extent necessary to enable Customer and their Users to effectively use the Product. All other rights remain reserved by Software Mansion.
+
+3.2. Unless the Subscription has expired or this Agreement is terminated in accordance with Section 13, and subject to the terms and conditions specified in this Agreement, Software Mansion grants Customer the non-exclusive and non-transferable right to use each Product covered by the Subscription as stipulated below:
+
+(A) Customer may:
+
+(i) install and use any version of the Product covered by the Subscription on any operating system supported by the Product; and
+
+(ii) make one copy of the Product solely for archival, security, and/or backup purposes.
+
+(B) Customer may not:
+
+(i) allow the same seat to be used concurrently by more than one (1) User;
+
+(ii) rent, lease, reproduce, modify, adapt, create derivative works of, distribute, sell, or transfer the Product;
+
+(iii) provide a third party with access to the Product, or the right to use the Product;
+
+(iv) reverse engineer, decompile, disassemble, modify, translate, or make any attempt to discover the source code of, the Product; or
+
+(v) remove or obscure any proprietary or other notices contained in the Product.
+
+3.3. The subscription for businesses and organizations is exclusively available to professional entities. This subscription includes functionality enabling the management of a group of licenses within a single account. It has been specifically designed to meet the requirements of professional entities; therefore, if a professional entity intends to utilize the Product, only this subscription type is applicable.
+
+3.4. Customer acknowledges that no ownership rights are conveyed to Customer under this Agreement, irrespective of the use of terms such as 'purchase' or 'sale'. Software Mansion has and retains all rights, title, and interest, including all intellectual property rights, in and to the Products, any and all related or underlying technology, and any modifications or derivative works of the Products, including without limitation as they may incorporate Feedback (as defined below).
+
+## 4. PURCHASING THROUGH RESELLERS AND DISTRIBUTORS
+
+<br />
+
+This Agreement applies whether Customer purchases a Subscription directly from Software Mansion or through an authorized Software Mansion reseller or distributor. If Customer purchases through a Software Mansion reseller or distributor, the Subscription details shall be as stated in the Subscription Confirmation issued by the reseller or distributor to Customer, and the reseller or distributor is responsible for the accuracy of any such Subscription Confirmation. Neither resellers nor distributors are authorized to make any promises or commitments on Software Mansion' behalf, and Customer understands and agrees that Software Mansion is not bound by any obligations to Customer other than as specified in this Agreement.
+
+## 5. ACCESS TO PRODUCTS
+
+<br />
+
+5.1. All deliveries under this Agreement will be electronic. You must have an Internet connection in order to access the Product and receive any deliveries. You are responsible for downloading and installing the Products.
+
+5.2. You may activate and access Products by using the link provided to you in the Subscription Confirmation email. For detailed information on how to activate the service, please refer to the manual available at: https://ide.swmansion.com/docs/guides/activation-manual
+
+## 6. FEES
+
+<br />
+
+6.1. Customer shall pay Subscription fees, as specified on the Software Mansion website at www.ide.swmansion.com and in accordance with the Software Mansion IDE Terms and Conditions of Purchase (available at https://ide.swmansion.com/purchase-terms) or an authorized Software Mansion reseller's terms of purchase, whichever are applicable.
+
+6.2. The Subscription fees must be paid in full, and any levies, duties, and/or taxes imposed by Customer's jurisdiction (including, but not limited to, value added tax, sales tax and withholding tax) shall be borne solely by Customer. Customer may not deduct any amounts from fees payable to Software Mansion or an authorized Software Mansion reseller, unless otherwise specified in the applicable terms of purchase.
+
+## 7. MERCHANT OF RECORD
+
+<br />
+
+Software Mansion may use third party payment processors (each, a "Payment Processor") to bill Customer. The processing of payments will be subject to the terms, conditions and privacy policies of the Payment Processor, in addition to these Purchase Terms. Customer agrees to pay Software Mansion, through the Payment Processor, all charges at the prices then in effect for any purchase in accordance with the applicable payment terms. Customer agrees to make payment using the payment method Customer provides with Customer's Account.
+
+## 8. FEEDBACK
+
+<br />
+
+Customer has no obligation to provide us with ideas, suggestions, or proposals ("Feedback"). However, if Customer or Users submit Feedback to us, then Customer grants us a non-exclusive, worldwide, royalty-free license that is sub-licensable and transferable, to make, use, sell, have made, offer to sell, import, reproduce, publicly display, distribute, modify, or publicly perform the Feedback in any manner without any obligation, royalty, or restriction based on intellectual property rights or otherwise.
+
+## 9. THIRD-PARTY SOFTWARE
+
+<br />
+
+The Products may include code and libraries licensed to us by third parties, including open source software ("Third-Party Software"). A list of Third-Party Software included in each Product is available in the respective Product documentation. All Third-Party Software is provided to Customer under the respective terms stipulated in the Product documentation.
+
+## 10. WARRANTY LIMITATIONS
+
+<br />
+
+10.1. ALL PRODUCTS ARE PROVIDED TO CUSTOMER ON AN "AS IS" AND "AS AVAILABLE" BASIS. USE OF THE PRODUCTS IS AT CUSTOMER'S OWN RISK.
+
+10.2. SOFTWARE MANSION MAKES NO WARRANTY AS TO THE PRODUCTS' USE OR PERFORMANCE. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION (AND ITS AFFILIATES, SHAREHOLDERS, AGENTS, DIRECTORS, AND EMPLOYEES), ITS LICENSORS, SUPPLIERS (INCLUDING THE PROVIDERS OF THIRD PARTY SOFTWARE), AND RESELLERS (COLLECTIVELY HEREUNDER, "SOFTWARE MANSION PARTIES") DISCLAIM ALL WARRANTIES AND CONDITIONS, WHETHER EXPRESS OR IMPLIED (INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT) WITH REGARD TO THE PRODUCTS AND THE PROVISION OF OR FAILURE TO PROVIDE SUPPORT SERVICES.
+
+10.3. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SOFTWARE MANSION PARTIES DO NOT REPRESENT OR WARRANT THAT THE PRODUCTS: (A) ARE ACCURATE, RELIABLE, OR CORRECT; (B) WILL MEET ANY CUSTOMER REQUIREMENTS; (C) WILL BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, UNINTERRUPTED, OR SECURE; (D) ARE FREE OF DEFECTS OR ERRORS AND THAT ANY, IF FOUND, WILL BE CORRECTED; AND/OR (E) ARE FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS.
+
+10.4. ANY CONTENT OR DATA DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE PRODUCTS ARE DOWNLOADED AT CUSTOMER'S OWN RISK; CUSTOMER AGREES IT IS SOLELY RESPONSIBLE FOR ANY DAMAGE TO ITS PROPERTY AND/OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD.
+
+10.5. CUSTOMER MAY HAVE OTHER RIGHTS WHICH MAY NOT BE LIMITED OR EXCLUDED AND WHICH MAY VARY FROM JURISDICTION TO JURISDICTION. THIS DOCUMENT IS NOT INTENDED TO NEGATIVELY AFFECT SUCH RIGHTS.
+
+## 11. DISCLAIMER OF DAMAGES
+
+<br />
+
+11.1. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL SOFTWARE MANSION PARTIES BE LIABLE TO CUSTOMER, CUSTOMER'S AFFILIATES, USERS, OR ANYONE ELSE FOR: (A) ANY LOSS OF USE, DATA, GOODWILL, OR PROFITS, WHETHER OR NOT FORESEEABLE; (B) ANY LOSS OR DAMAGES IN CONNECTION WITH TERMINATION OR SUSPENSION OF CUSTOMER'S ACCESS TO THE PRODUCTS IN ACCORDANCE WITH THIS AGREEMENT; OR (C) ANY SPECIAL, INCIDENTAL, INDIRECT, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES WHATSOEVER (EVEN IF THE RELEVANT SOFTWARE MANSION PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF THESE DAMAGES), INCLUDING THOSE (i) RESULTING FROM LOSS OF USE, DATA, OR PROFITS, WHETHER OR NOT THEY ARE FORESEEABLE, (ii) BASED ON ANY THEORY OF LIABILITY, INCLUDING BREACH OF CONTRACT OR WARRANTY, STRICT LIABILITY, NEGLIGENCE, OR OTHER TORTIOUS ACTION, OR (iii) ARISING FROM ANY OTHER CLAIM ARISING OUT OF OR IN CONNECTION WITH CUSTOMER'S USE OF OR ACCESS TO THE PRODUCTS OR SUPPORT. THIS LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+
+11.2. THE TOTAL LIABILITY OF THE SOFTWARE MANSION PARTIES IN ANY MATTER ARISING OUT OF OR IN RELATION TO THIS AGREEMENT IS LIMITED TO THE GREATER OF (A) ONE HUNDRED (100) US DOLLARS OR (B) THE AGGREGATE AMOUNT PAID OR PAYABLE BY CUSTOMER DURING THE THREE-MONTH PERIOD PRECEDING THE EVENT FOR THE PRODUCTS GIVING RISE TO THE LIABILITY. THIS LIMITATION WILL APPLY EVEN IF THE SOFTWARE MANSION PARTIES HAVE BEEN ADVISED OF THE POSSIBILITY OF LIABILITY EXCEEDING SUCH AN AMOUNT AND NOTWITHSTANDING ANY FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.
+
+## 12. TERM AND TERMINATION
+
+<br />
+
+12.1. The term of this Agreement will commence upon acceptance of this Agreement by Customer as set forth in the preamble above, and it will continue for each Product through the end of the applicable Subscription period specified in the respective Subscription Confirmation. The Subscription and this Agreement will automatically renew in respect to each Product for a successive Subscription period, unless terminated in accordance with this Agreement.
+
+12.2. Customer may terminate this Agreement at any time by (i) cancelling its Product Subscription via Radon IDE customer portal; (ii) cancelling its Product Subscription via the link provided to the Customer in Subscription Confirmation; or (iii) via the termination procedure available at the Merchant of Record's website (e.g. Paddle.com). If such termination occurs during a Subscription period, this Agreement will continue to be effective until the end of that Subscription period. Such termination does not relieve the Customer of the obligation to pay any outstanding Subscription fees owed to Software Mansion, and no credits or refunds will be issued to the Customer for prepaid Subscription fees.
+
+12.3. Software Mansion may terminate this Agreement and the associated Subscription if:
+
+(A) Customer has materially breached this Agreement and fails to remedy the breach within thirty (30) days of notice;
+
+(B) Customer fails to make timely payment of Subscription fees in accordance with Section 6 of this Agreement;
+
+(C) Software Mansion is required to do so by law (for example, where the provision of the Product to Customer is, or becomes, unlawful); or
+
+(D) Software Mansion elects to discontinue providing the Product, in whole or in part.
+
+12.4. Software Mansion will make reasonable efforts to notify Customer via email (to the email address of the billing or technical contact provided by Customer) as follows:
+
+(A) Thirty (30) days prior to termination of the Agreement in the events specified in Sections 12.3(C) and 12.3(D) above, in which case Customer will be entitled to a refund of the unused portion of prepaid Subscription fees, if applicable;
+
+(B) Three (3) days prior to termination of the Agreement in the event specified in Section 12.3(B), in which case Customer will not be entitled to any refund of the unused portion of prepaid Subscription fees.
+
+12.5. Survival. Upon the expiration or termination of this Agreement, Sections 6, 8, 9, 10, 11, and 16 of this Agreement survive.
+
+## 13. TEMPORARY SUSPENSION
+
+<br />
+
+13.1. Software Mansion reserves the right to suspend Customer's access to Software Mansion Products if:
+
+(A) Customer fails to pay Subscription fees on time in accordance with Section 6;
+
+(B) Customer or User's use of Product is in violation of this Agreement or disrupts or imminently threatens the security, integrity, or availability of a Product.
+
+13.2. If Software Mansion suspends Customer's access to Products for non-payment in accordance with Section 13.1(A), Customer must pay all past due amounts in order to resume access to Product.
+
+13.3. If Software Mansion suspends access to Product in accordance with Section 13.1, Customer agrees that Software Mansion is entitled to charge Customer for the time period during which Customer has access to Software Mansion Products until either access is restored in accordance with Section 13.2 or the Subscription is terminated in accordance with this Agreement.
+
+## 14. EXPORT REGULATIONS
+
+<br />
+
+14.1. Customer must comply with all applicable laws and regulations with regard to economic sanctions, export controls, import regulations, restrictive measures, and trade embargoes (all herein referred to as "Sanctions"), including those of the European Union and United States. Customer declares and warrants that it is not a person targeted by Sanctions, nor is it otherwise owned or controlled by or acting on behalf of any entity or person targeted by Sanctions. Customer agrees that it will not download or otherwise export or re-export the Product or any related technical data directly or indirectly to any person targeted by Sanctions or download or otherwise use the Product for any end-use prohibited or restricted by Sanctions.
+
+## 15. MARKETING
+
+<br />
+
+Customer agrees that Software Mansion may identify them as a customer of Software Mansion and may refer to them by name, trade name, and trademark, if applicable. Software Mansion may also briefly describe Customer's business in Software Mansion marketing materials, on the Software Mansion website, and/or in public or legal documents. Customer hereby grants Software Mansion a worldwide, non-exclusive, and royalty-free license to use Customer's name and any of Customer's trade names and trademarks solely pursuant to this marketing section.
+
+## 16. GENERAL
+
+<br />
+
+16.1. **Entire Agreement**. The following documents are part of ('incorporated into') this Agreement: the Software Mansion Radon IDE Privacy Policy, available at https://ide.swmansion.com/privacy-policy, and the Software Mansion Radon IDE Terms and Conditions of Purchase, available at https://ide.swmansion.com/purchase-terms. Together, these documents form the entire agreement and replace any previous agreement between you and us in relation to its subject matter. Except as expressly mentioned, this Agreement does not apply or give rights to anyone else ('no third-party beneficiaries'). No purchase order, Customer terms, or other document that purports to modify or supplement this Agreement will vary the terms of this Agreement unless signed by Customer and Software Mansion.
+
+16.2. **Reservation of Rights**. Software Mansion reserves the right at any time to cease its support of the Product and to alter prices, features, specifications, capabilities, functions, terms of use, release dates, general availability, and other characteristics of the Product. Nothing in this Agreement limits any rights a consumer may have under applicable consumer protection laws.
+
+16.3. **Changes to this Agreement**. The Agreement can be updated from time to time to reflect changes in the Product and how it is offered to you.
+
+(A) If this happens, we will update the terms on the Software Mansion website and let you know either:
+
+(i) by displaying them to you in the Product; or
+
+(ii) by sending the updated version to your email address.
+
+(B) Any updated Agreement will start ('be effective') on the date specified in the updated Agreement. By continuing to use the Product after the effective date, you agree to be bound by the modified Agreement.
+
+(C) We respect that you may not agree to the updated Agreement. If that is the case, you can terminate your Subscription any time up to 30 days after the effective date of the updated Agreement. Termination according to this Section entitles you to a pro-rata refund of the pre-paid unused Subscription fees.
+
+16.4. **Opportunity to Review**. Customer declares that it has had sufficient opportunity to review this Agreement, understand the content of all of its sections, negotiate its terms, and seek independent professional legal advice before entering into it. Consequently, any statutory "form contract" ("adhesion contract") regulations shall not be applicable to this Agreement.
+
+16.5. **Severability**. If a particular term of this Agreement is not enforceable, the unenforceability of that term will not affect any other terms of this Agreement.
+
+16.6. **Interpretation**. Headings and titles are for convenience only and do not affect the interpretation of this Agreement. Terms such as "including" are not exhaustive.
+
+16.7. **No Waiver**. Our failure to enforce or exercise any part of this Agreement is not a waiver of that section.
+
+16.8. **Notice**. Software Mansion may deliver any notice to Customer via electronic mail to an email address provided by Customer, registered mail, personal delivery, or reputable express courier (such as DHL, FedEx, or UPS). Any such notice will be deemed to be effective (i) on the day the notice is sent to Customer via email, (ii) upon personal delivery, (iii) one (1) day after deposit with an express courier, or (iv) five (5) days after deposit in the mail, whichever occurs first.
+
+16.9. **Governing Law**. This Agreement is governed by the laws of Poland, without reference to conflict of laws principles and specifically excluding the United Nations Convention on Contracts for the International Sale of Goods. The Parties to the agreement constituted by this Agreement undertake to use best commercial efforts to amicably settle any disputes arising hereunder ("Dispute").
+
+16.10. **Dispute Resolution**. Should the Parties to this Agreement fail to settle a Dispute amicably, the Dispute will be decided by the courts having general jurisdiction over Software Mansion; if you are a consumer, we both agree that any Dispute-related litigation may only be brought in, and shall be subject to the jurisdiction of, any competent court of Poland, unless provided otherwise by applicable consumer law. Consumer Disputes can also be settled out of court through the European Commission's online platform for dispute resolution (ec.europa.eu/consumers/odr).
+
+16.11. **Data Privacy**. By accepting this Agreement, Customer acknowledges that Software Mansion will process personal data in accordance with Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy).
+
+16.12. **Force Majeure**. Neither Party shall be in breach of this Agreement, or otherwise liable to the other, by reason of any delay in performance, or non-performance, of any of its obligations under this Agreement (except payment obligations), arising directly from an act of God, fire, flood, natural disaster, act of terrorism, strike, lock-out, labor dispute, public health emergency, civil commotion, riot, or act of war.
+
+16.13. **Children and minors**. If You are under 18 years old, then by entering into this Agreement you explicitly stipulate that (i) you have legal capacity to conclude this Agreement or that you have valid consent from a parent or legal guardian to do so and (ii) you understand the Software Mansion IDE Privacy Policy (available at https://ide.swmansion.com/privacy-policy). You may not enter into this Agreement if you are under 13 years old. IF YOU DO NOT UNDERSTAND THIS SECTION, DO NOT UNDERSTAND THE SOFTWARE MANSION PRIVACY POLICY, OR DO NOT KNOW WHETHER YOU HAVE THE LEGAL CAPACITY TO ACCEPT THESE TERMS, PLEASE ASK YOUR PARENT OR LEGAL GUARDIAN FOR HELP.
+
+The previous version of this agreement is available here.
+
+For further information, please contact us at [legal@swmansion.com](mailto:legal@swmansion.com).


### PR DESCRIPTION
Updated /legal page to distinct between currently applicable documents and legacy/invalid ones.

Added `legal/free-license-terms`,  `legal/pro-license-terms`, and `legal/team-license-terms` pages with appropriate documents prepared by legal team.