### PR TITLE
fix: network inspector - fix issue with axis not showing the response body

### DIFF
--- a/packages/vscode-extension/lib/network/networkRequestParsers.ts
+++ b/packages/vscode-extension/lib/network/networkRequestParsers.ts
@@ -223,8 +223,6 @@ async function readResponseText(
 
     const responseType = xhr.responseType;
 
-    console.log("REPONSETYPE", responseType);
-
     if (responseType === "" || responseType === "text") {
       return await parseResponseBodyData(xhr.responseText);
     }


### PR DESCRIPTION
### Description

This PR fixes an issue with Network Inspector, which caused the requests made by `axios` library to not show the response body. 

This behaviour was caused by `readResponseText function  defined in`lib/network/networkRequestParsers.ts` which is used as part of the response parsing in `AsyncBoundedResponseBuffer` and `network.js`. The problem stemmed from the check:
```ts
if (!xhr || !xhr._cachedResponse) {
    // if response was not accessed, it's not cached and we don't want to read it
    // here to avoid potential side effects
    return undefined;
  }
```

In react-native implementation xhr._cachedResponse is only set when `xhr.responseType` is set to some known defined value (see [implementation](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Network/XMLHttpRequest.js)).

React-native fetch implementation polyfill, the `whatwg-fetch ` explicitly sets that value to either `blob` or `arraybuffer` (see [implementation](https://github.com/JakeChampion/fetch/blob/main/fetch.js)), unlike `axios`, which only sets it when it is defined in the config and is not `json` (see [implementation](https://github.com/axios/axios/blob/v1.x/lib/adapters/xhr.js)).

Because of that, for axios requests, `responseType` was equal to an empty string`\`\`` and thus `xhr._cachedResponse` was equal to `null`. The check in our file resolved the response to `undefined`.

The solution is simply to omit the `xhr._cachedResponse`, which does not seem to cause any issues, but was part of the "legacy" `network.js` code.


### Fixes #1654

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel
- *check if fetches using axios are now properly handled and responseBody can be seen*
### How Has This Change Been Documented:

Not applicable.
