### PR TITLE
fix: Expo Dev Client cannot connect to Metro

### DIFF
--- a/packages/vscode-extension/src/builders/expoGo.ts
+++ b/packages/vscode-extension/src/builders/expoGo.ts
@@ -75,7 +75,11 @@ export function fetchExpoLaunchDeeplink(
           // NOTE: for physical Android devices, the address for the host machine is different
           // than the one we get in the redirect. However, since we forward the metro port, we can
           // use `localhost` for the host without issue.
-          location.hostname = "localhost";
+          if (choice === "expo-go") {
+            location.hostname = "localhost";
+          } else {
+            location.searchParams.set("url", `http://localhost:${metroPort}`);
+          }
           resolve(location.toString());
         } else {
           resolve();


### PR DESCRIPTION
In #1688 we changed the deeplink used to launch ExpoGo / Expo Dev Clients to use `localhost` as hostname in order to allow Physical Android Devices which aren't on the same network as the development machine to connect (via localhost port forwarding).
This worked on Expo Go, however, due to the different URL structure used by Dev Client, broke it an all platforms.
Expo Go uses URL that look like:
```
exp://{metro address}
```
While Dev Client uses:
```
exp+{application name}://expo-development-client/?url={metro http url}
```
This PR correctly handles the dev client case, by rewriting the url param in that case.

### How Has This Been Tested: 
- open an app running Expo Go (e.g. expo-54)
- open an app running Expo dev client (e.g. expo-54-prebuild-with-plugins)