### PR TITLE
feat: network inspector - enhance XHR responseType support

### DIFF
--- a/packages/vscode-extension/lib/network/networkRequestParsers.ts
+++ b/packages/vscode-extension/lib/network/networkRequestParsers.ts
@@ -288,7 +288,7 @@ async function readResponseText(
       }
     }
 
-    // don't read binary data
+    // fallback
     return undefined;
   } catch (error) {
     return handleReadResponseError(error);


### PR DESCRIPTION
### Description

This PR fixes introduces changes to `lib/network/networkRequestParsers.ts`, to properly handle response types, which can be set using, for example, `axios` instead of fetch.

So far, the implementation of react native `fetch` api, based on `XMLHttpRequest`,  always set the `responseType` attribute of `XMLHttpRequest`'s response to `blob` if it was supported (see https://github.com/JakeChampion/fetch/blob/main/fetch.js):

From the `fetch` implementation provided above:
```ts
if ('responseType' in xhr) {
  if (support.blob) {
    xhr.responseType = 'blob'
  } else if (
    support.arrayBuffer
  ) {
    xhr.responseType = 'arraybuffer'
  }
}
```

Using `XMLHttpRequest`directly, or using libraries which do so such as `axios`, enables to change this `responseType`, for which handling has been introduced.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel
- *use, for example, `axios` or XMLHttpRequest instead of fetch and see whether setting different response types gives desired result and does not end up causing undefined behaviour*

### How Has This Change Been Documented:

Not applicable.
