### PR TITLE
chore: improve how we detect the app is loading slowly 

### DIFF
--- a/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
+++ b/packages/vscode-extension/src/webview/components/PreviewLoader.tsx
@@ -81,7 +81,7 @@ function PreviewLoader({ onRequestShowPreview }: { onRequestShowPreview: () => v
           100
       );
     }
-  }, [startupMessage]);
+  }, [startupMessage, stageProgress]);
 
   useEffect(() => {
     setIsLoadingSlowly(false);


### PR DESCRIPTION
This PR improves how we detect that app is loading slowly.

Previously we tried to find a reasonable timeout for each stage, but the difference between: big, small and cached bundle loads is just to vast. 

To solve this issue we now reset the timeout every time stageProgress is changed, assuming that the progress means everything is fine. 

Fixes # (issue)

### How Has This Been Tested: 

- run [bluesky app](https://github.com/bluesky-social/social-app/blob/main/docs/build.md) 
- run it with clean metro cache before this PR the slow load messages should show up 
- now run it with this PR they won't show up 
- break the "app_ready" event to make waiting for an app to load last for ever, the messages should show up 

### How Has This Change Been Documented:

internal-ish