### PR TITLE
rebranding: fix legal styling

### DIFF
--- a/packages/docs/src/css/colors.css
+++ b/packages/docs/src/css/colors.css
@@ -310,7 +310,7 @@
 
   --ifm-table-head-background: var(--swm-off-background);
   --ifm-table-stripe-background: var(--swm-off-background) !important;
-  --ifm-table-border-color: var(--swm-table-border-color);
+  --ifm-table-border-color: var(--radon-border);
 
   /* Pagination */
   --swm-paginator-sublabel: var(--ifm-color-primary) !important;

--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -388,6 +388,7 @@ button {
   max-width: 1110px;
   --ifm-col-width: 100%;
   flex: 1;
+  min-height: calc(100vh - 365px);
 }
 
 [class*="mdxPageWrapper"] > .col--2 {

--- a/packages/docs/src/pages/legal/dpa.module.css
+++ b/packages/docs/src/pages/legal/dpa.module.css
@@ -1,15 +1,18 @@
 .container {
-  width: 60%;
-  margin: 0 auto;
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
+  align-self: center;
+  padding: 80px;
+  max-width: 1360px;
 }
 
 .container p {
   text-wrap: balance;
   max-width: 600px;
+  text-align: justify;
 }
 
 .link {
@@ -20,26 +23,8 @@
   min-width: 200px;
 }
 
-@media (max-width: 1920px) {
+@media (max-width: 800px) {
   .container {
-    width: 65%;
-  }
-}
-
-@media (max-width: 1440px) {
-  .container {
-    width: 75%;
-  }
-}
-
-@media (max-width: 996px) {
-  .container {
-    width: 85%;
-  }
-}
-
-@media (max-width: 430px) {
-  .container {
-    width: 90%;
+    padding: 40px 24px;
   }
 }

--- a/packages/docs/src/pages/legal/dpa.tsx
+++ b/packages/docs/src/pages/legal/dpa.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Layout from "@theme/Layout";
 import styles from "./dpa.module.css";
 import Button from "@site/src/components/Button";
+import clsx from "clsx";
 
 const dpaUrl =
   "https://uzpiutmionwuvyybiztr.supabase.co/storage/v1/object/public/legal//Radon%20DPA.pdf";
@@ -9,7 +10,7 @@ const dpaUrl =
 export default function DPA(): JSX.Element {
   return (
     <Layout description="Data Processing Addendum">
-      <div className={styles.container}>
+      <div className={clsx(styles.container, "border-layout")}>
         <h1>DPA</h1>
         <p>
           We prioritize the privacy and security of your information. To reflect this, we have


### PR DESCRIPTION
This PR fixes page styling in DPA and Sub-Processors subpages of legal.

DPA before:
<img width="1447" height="583" alt="Screenshot 2025-11-05 at 13 21 45" src="https://github.com/user-attachments/assets/03fd999c-3e89-4798-8734-bc8222783ae1" />


DPA after:
       <img width="1426" height="907" alt="Screenshot 2025-11-05 at 13 19 46" src="https://github.com/user-attachments/assets/92bfa4dc-6ffe-46ac-a58f-1e8fe1faa701" />


Sub-Processors before:
<img width="1434" height="431" alt="Screenshot 2025-11-05 at 13 21 10" src="https://github.com/user-attachments/assets/65612800-57c2-4099-9458-5f89ad8f63c0" />


Sub-Processors after:
<img width="1409" height="463" alt="Screenshot 2025-11-05 at 13 28 20" src="https://github.com/user-attachments/assets/e2059bea-b512-4b28-af64-f19e15ed2364" />

