### PR TITLE
fix: react-query plugin not detected

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -79,7 +79,7 @@ if (RN_VERSION.startsWith("0.7")) {
 
 function transformWrapper({ filename, src, ...rest }) {
   function isTransforming(unixPath) {
-    return filename.endsWith(path.normalize(unixPath));
+    return filename.includes(path.normalize(unixPath));
   }
 
   const { transform } = require(ORIGINAL_TRANSFORMER_PATH);
@@ -186,12 +186,9 @@ function transformWrapper({ filename, src, ...rest }) {
     }
   } else if (
     isTransforming("node_modules/@tanstack/react-query/src/index.ts") ||
-    isTransforming("node_modules/@tanstack/react-query/build/lib/index.js") ||
-    isTransforming("node_modules/@tanstack/react-query/build/legacy/index.js") ||
-    isTransforming("node_modules/@tanstack/react-query/build/modern/index.js") ||
-    isTransforming("node_modules/@tanstack/react-query/build/lib/index.mjs") ||
-    isTransforming("node_modules/@tanstack/react-query/build/legacy/index.mjs") ||
-    isTransforming("node_modules/@tanstack/react-query/build/modern/index.mjs")
+    isTransforming("node_modules/@tanstack/react-query/build/lib/index") ||
+    isTransforming("node_modules/@tanstack/react-query/build/legacy/index") ||
+    isTransforming("node_modules/@tanstack/react-query/build/modern/index")
   ) {
     // note: react-query-devtools integration has to be done after the QueryClient class is required
     // which is why the src needs to come before it. Also we need to ensure that we don't


### PR DESCRIPTION
On some monorepo setups, the `react-query` plugin was _still_ not detected, because it used the `.cjs` commonjs entry point instead of one of the files we looked for.
To avoid this issue, we relax the condition on importing our plugin to instead look for _any_ file under the `react-query` module, and depend on the `require` caching mechanism to ensure our hook is set up only once.

### How Has This Been Tested: 
- ran expo-54-prebuild-with-plugins to ensure there's no regression on our test.




