### PR TITLE
fix: update CSP to allow resources from Paddle and ProfitWell

### DIFF
--- a/packages/vscode-extension/src/panels/webviewContentGenerator.ts
+++ b/packages/vscode-extension/src/panels/webviewContentGenerator.ts
@@ -61,8 +61,9 @@ export function generateWebviewContent(
               content="default-src 'none';
                       img-src vscode-resource: http: https: data:;
                       media-src vscode-resource: http: https:;
-                      style-src ${webview.cspSource} 'unsafe-inline';
-                      script-src 'nonce-${nonce}' ${allowUnsafeEval ? "'unsafe-eval'" : ""};
+                      style-src ${webview.cspSource} 'unsafe-inline' https://cdn.paddle.com;
+                      script-src 'nonce-${nonce}' ${allowUnsafeEval ? "'unsafe-eval'" : ""} https://cdn.paddle.com;
+                      connect-src https://public.profitwell.com https://cdn.paddle.com https://api.paddle.com;
                       worker-src 'self' blob:;
                       font-src vscode-resource: https:;" />
         <link rel="stylesheet" type="text/css" href="style.css" />


### PR DESCRIPTION
### Description

This PR fixes issue with requests to paddle on package build caused by CSP configuration.

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel
- *check whether requests to paddle work by activating paywall*
### How Has This Change Been Documented:

Not applicable.
