### PR TITLE
fix: application session is not reset when restarting app

### DIFF
--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -27,6 +27,7 @@ import {
   DevicePlatform,
   DeviceRotation,
   DeviceType,
+  initialApplicationSessionState,
   InspectorAvailabilityStatus,
   InspectorBridgeStatus,
   NavigationHistoryItem,
@@ -212,6 +213,7 @@ export class ApplicationSession implements Disposable {
     private readonly packageNameOrBundleId: string,
     private readonly supportedOrientations: DeviceRotation[]
   ) {
+    this.stateManager.updateState(initialApplicationSessionState);
     this.registerMetroListeners();
     this.networkBridge = new NetworkBridge();
 


### PR DESCRIPTION
Fixes an issue where restarting the app doesn't reset the application session state.
This can cause issues, for example, when the app is stopped by the debugger and restarted (via "Restart App" or "Reinstall App" reload actions), the app will be stuck with the debugger paused overlay despite running underneath.