### PR TITLE
fix: Disable the URL bar on fatal errors

### DIFF
--- a/packages/vscode-extension/src/webview/components/UrlBar.tsx
+++ b/packages/vscode-extension/src/webview/components/UrlBar.tsx
@@ -44,7 +44,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
   const navigationHistory = use$(selectedDeviceSessionState.navigationState.navigationHistory);
   const navigationRouteList = use$(selectedDeviceSessionState.navigationState.navigationRouteList);
 
-  const disabledAlsoWhenStarting = disabled || selectedDeviceSessionStatus === "starting";
+  const disabledAlsoWhenNotRunning = disabled || selectedDeviceSessionStatus !== "running";
   const canGoBack = navigationHistory?.[0]?.canGoBack;
   const isExpoRouterProject = !expoRouterStatus?.isOptional;
 
@@ -55,7 +55,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
           label: "Go back",
           side: "bottom",
         }}
-        disabled={disabledAlsoWhenStarting || !canGoBack}
+        disabled={disabledAlsoWhenNotRunning || !canGoBack}
         onClick={() => project.navigateBack()}>
         <span className="codicon codicon-arrow-left" />
       </IconButton>
@@ -66,7 +66,7 @@ function UrlBar({ disabled }: { disabled?: boolean }) {
         }}
         navigationHistory={navigationHistory ?? []}
         routeList={navigationRouteList ?? []}
-        disabled={disabledAlsoWhenStarting}
+        disabled={disabledAlsoWhenNotRunning}
         dropdownOnly={!isExpoRouterProject}
       />
     </>


### PR DESCRIPTION
This PR fixes a bug where the `UrlSelect` and the `Go back` button weren't disabled when the `deviceSession` status was `fatalError`, as the check only considered the `starting` and `running` statuses.

Correct me if I'm wrong, but I don't think this is intentional, as a fatal error usually suggests that the simulator is completely unresponsive, let alone to navigation.

### How Has This Been Tested: 

- Run an app
- Cause any fatal error, e.g. break some imports or disconnect the device
- The `UrlSelect` is now disabled when the error box appears
