### PR TITLE
feat: enhance license not activated expirience

### DIFF
--- a/packages/vscode-extension/src/webview/components/ActivateLicenseMessage.css
+++ b/packages/vscode-extension/src/webview/components/ActivateLicenseMessage.css
@@ -1,0 +1,106 @@
+.activate-license-message-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--background-dark-120);
+  z-index: 100;
+}
+
+.activate-license-message-container {
+  max-width: 360px;
+  padding: 32px 24px;
+  text-align: center;
+  animation: fadeInUp 0.4s ease-out forwards;
+}
+
+.activate-license-icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--vscode-button-background);
+  opacity: 0.9;
+}
+
+.activate-license-icon .codicon {
+  font-size: 32px;
+  color: var(--vscode-button-foreground);
+}
+
+.activate-license-title {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 0 0 16px;
+  color: var(--vscode-foreground);
+}
+
+.activate-license-description {
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 24px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.activate-license-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.activate-license-primary-button {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 12px 24px;
+  font-size: 16px;
+  height: unset;
+}
+
+.activate-license-secondary-button {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 10px 20px;
+  font-size: 14px;
+  height: unset;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  border: 1px solid var(--vscode-button-border, transparent);
+}
+
+.activate-license-secondary-button:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.activate-license-footer {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin: 0;
+}
+
+.activate-license-footer a {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: none;
+}
+
+.activate-license-footer a:hover {
+  text-decoration: underline;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/vscode-extension/src/webview/components/ActivateLicenseMessage.tsx
+++ b/packages/vscode-extension/src/webview/components/ActivateLicenseMessage.tsx
@@ -1,0 +1,59 @@
+import "./ActivateLicenseMessage.css";
+import { useProject } from "../providers/ProjectProvider";
+import Button from "./shared/Button";
+import { useModal } from "../providers/ModalProvider";
+import { ActivateLicenseView } from "../views/ActivateLicenseView";
+
+export function ActivateLicenseMessage() {
+  const { project } = useProject();
+  const { openModal } = useModal();
+
+  return (
+    <div className="activate-license-message-overlay">
+      <div className="activate-license-message-container">
+        <div className="activate-license-icon">
+          <span className="codicon codicon-lock" />
+        </div>
+
+        <h2 className="activate-license-title">License Required</h2>
+
+        <p className="activate-license-description">
+          Radon IDE has stopped working because your license is not activated.
+        </p>
+
+        <div className="activate-license-actions">
+          <Button
+            className="activate-license-primary-button"
+            onClick={() => {
+              project.sendTelemetry("activateLicenseMessageClicked");
+              openModal(<ActivateLicenseView />, { title: "Activate License" });
+            }}>
+            Activate License
+          </Button>
+
+          <Button
+            className="activate-license-secondary-button"
+            onClick={() => {
+              project.sendTelemetry("getLicenseFromMessageClicked");
+              project.openExternalUrl("https://ide.swmansion.com/pricing");
+            }}>
+            Get License
+          </Button>
+        </div>
+
+        <p className="activate-license-footer">
+          Visit{" "}
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              project.openExternalUrl("https://ide.swmansion.com/pricing");
+            }}>
+            ide.swmansion.com/pricing
+          </a>{" "}
+          to learn more
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -32,9 +32,11 @@ import {
   InspectorAvailabilityStatus,
   InspectorBridgeStatus,
   MultimediaData,
+  PreviewErrorReason,
   ZoomLevelType,
 } from "../../common/State";
 import { useSelectedDeviceSessionState } from "../hooks/selectedSession";
+import { ActivateLicenseMessage } from "./ActivateLicenseMessage";
 
 function TouchPointIndicator({ isPressing }: { isPressing: boolean }) {
   return <div className={`touch-indicator ${isPressing ? "pressed" : ""}`}></div>;
@@ -138,7 +140,12 @@ function Preview({
 
   const previewURL = use$(selectedDeviceSessionState.previewURL);
 
-  const showDevicePreview = previewURL && (showPreviewRequested || isRunning);
+  const shouldShowActivateLicenseMessage =
+    fatalErrorDescriptor?.kind === "preview" &&
+    fatalErrorDescriptor.reason === PreviewErrorReason.NoAccess;
+
+  const showDevicePreview =
+    previewURL && (showPreviewRequested || isRunning) && !shouldShowActivateLicenseMessage;
 
   const isAppDisconnected =
     isRunning && inspectorBridgeStatus === InspectorBridgeStatus.Disconnected;
@@ -677,9 +684,16 @@ function Preview({
             </div>
           </Device>
         )}
-        {hasFatalError && (
+        {hasFatalError && !shouldShowActivateLicenseMessage && (
           <Device device={device!} zoomLevel={zoomLevel} wrapperDivRef={wrapperDivRef}>
             <div className="phone-sized extension-error-screen" />
+          </Device>
+        )}
+        {shouldShowActivateLicenseMessage && (
+          <Device device={device!} zoomLevel={zoomLevel} wrapperDivRef={wrapperDivRef}>
+            <div className="phone-sized">
+              <ActivateLicenseMessage />
+            </div>
           </Device>
         )}
       </div>

--- a/packages/vscode-extension/src/webview/views/PaywallView.tsx
+++ b/packages/vscode-extension/src/webview/views/PaywallView.tsx
@@ -25,11 +25,11 @@ const RadonIDEProYearlyPriceID = window.RNIDE_isDev
 
 const proBenefits = [
   "All the Free features",
-  "Redux UI plugin",
-  "React Query plugin",
-  "CPU Profiler integration",
-  "React Profiler integration",
-  "React Scan integration",
+  "Replays and Screen Recordings",
+  "Device Screenshots",
+  "Location settings",
+  "Localization settings",
+  "Storybook integration",
   "Radon AI assistant",
   "Remote Android Devices Integration",
   "Early access to new features",


### PR DESCRIPTION
this PR enhances the License not activated experience by implementing a new component that shows up in "dead" device: 

<img width="361" height="857" alt="Screenshot 2025-11-14 at 20 13 13" src="https://github.com/user-attachments/assets/b8ed5e79-6217-485a-a9f1-90603aaef1b8" />
<img width="371" height="852" alt="Screenshot 2025-11-14 at 20 13 19" src="https://github.com/user-attachments/assets/c0eea873-fbcd-4e3c-9910-1eb3612df9c6" />

additionally it fixes earlier mistake of listening free features as pro one. 

### How Has This Been Tested: 

- modify sim server just for tests in `killswitch.rs` so it turns of faster 
- run any test app
- try to use restricted feature (e.g. send file) to test new feature list
- touch the device screen to trigger the killswitch and close a modal after it activates to see the new message

### How Has This Change Been Documented:

this is documentation in a way 


