### PR TITLE
fix: preview not sending `mouse-up` event after debugger triggered

### DIFF
--- a/packages/vscode-extension/src/webview/components/Preview.tsx
+++ b/packages/vscode-extension/src/webview/components/Preview.tsx
@@ -313,10 +313,6 @@ function Preview({
   /**
    * Trigger the "Up" event after the input events are re-enabled.
    * The currentMousePosition right after re-enabling does not change.
-   *
-   * The dependency array does not include the state,
-   * but updates are triggered correctly by changes to
-   * the booleans in shouldPreventInputEvents
    */
   useEffect(() => {
     if (!shouldPreventInputEvents) {


### PR DESCRIPTION
### Description

This PR fixes behaviour of Preview, where triggering the debugger (and presumably - other action that causes it to suddenly "lose focus" within the window) while holding the mouse button would cause the "down" touch event to be sent infinitely afterwards, until user makes another input. 

The fix should be universal to all the situations that make the `shouldPreventInputEvents = true` in `Preview`. The fix "lets go" of the down touch event after the flag goes back to false again, as it is rather expected that the "down" input should not be reset when debugger or other action like this is triggered.

### Fixes #1737 

### How Has This Been Tested: 

Features were tested in local development environment of extension as follows:
- open radon-ide/packages/vscode-extension
- [ON FIRST RUN] build simulator-server locally as follows:
  - in `/packages` run: `git submodule update --init --recursive packages/simulator-server`
  - step into simulator-server folder: `cd simulator-server`
  - install dependencies as given in README.md and build simulator-server-macos file locally using: `cargo build --release ` 
  - step into extension folder: `cd /packages/vscode-extension`
  - run: `npm run build:sim-server-debug` or copy built binary from simulator-server into `dist` folder
- run the extension locally using Run and Debug menu -> Run Extension
- open an application supporting Radon IDE in editor - example of app supporting  rotation: radon-ide-test-apps/react-native-80 
- run Radon IDE extension panel
- *check whether holding the mouse button and moving / scrolling some element on screen when debugger triggers is correctly released after it is closed*

### How Has This Change Been Documented:

Not applicable.