### PR TITLE
docs: fix feature videos autofocus on mobile safari

### DIFF
--- a/packages/docs/src/components/Features/FeatureSliderLanding/index.tsx
+++ b/packages/docs/src/components/Features/FeatureSliderLanding/index.tsx
@@ -103,10 +103,22 @@ export default function FeatureSliderLanding() {
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 1 }}>
-              <video autoPlay className={clsx(styles.video, styles.videoLight)} loop muted>
+              <video
+                autoPlay
+                playsInline
+                webkit-playsinline
+                className={clsx(styles.video, styles.videoLight)}
+                loop
+                muted>
                 <source src={features[activeItem.index].videoSrc.light} type="video/mp4" />
               </video>
-              <video autoPlay className={clsx(styles.video, styles.videoDark)} loop muted>
+              <video
+                autoPlay
+                playsInline
+                webkit-playsinline
+                className={clsx(styles.video, styles.videoDark)}
+                loop
+                muted>
                 <source src={features[activeItem.index].videoSrc.dark} type="video/mp4" />
               </video>
             </motion.div>


### PR DESCRIPTION
This PR fixes an issue where videos in the feature slider automatically enter full-screen mode while scrolling. 

Feature slider before:

https://github.com/user-attachments/assets/a1edcead-9d65-41ff-b34e-85968aa42a4c


Feature slider after:

https://github.com/user-attachments/assets/876a43b6-befa-4353-9977-ddfbf49e2136

