### PR TITLE
chore: change panel location default 

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -253,7 +253,7 @@
           "RadonIDE.userInterface.panelLocation": {
             "type": "string",
             "scope": "window",
-            "default": "tab",
+            "default": "side-panel",
             "enum": [
               "tab",
               "side-panel"

--- a/packages/vscode-extension/src/common/State.ts
+++ b/packages/vscode-extension/src/common/State.ts
@@ -611,7 +611,7 @@ export const initialState: State = {
       inspectorExcludePattern: null,
     },
     userInterface: {
-      panelLocation: "tab",
+      panelLocation: "side-panel",
       showDeviceFrame: true,
     },
     deviceSettings: {

--- a/packages/vscode-extension/src/utilities/workspaceConfiguration.ts
+++ b/packages/vscode-extension/src/utilities/workspaceConfiguration.ts
@@ -55,7 +55,7 @@ export function getCurrentWorkspaceConfiguration(config: WorkspaceConfiguration)
     userInterface: {
       panelLocation:
         config.get<PanelLocation>(WorkspaceConfigurationKeyMap.userInterface.panelLocation) ??
-        "tab",
+        "side-panel",
       showDeviceFrame:
         config.get<boolean>(WorkspaceConfigurationKeyMap.userInterface.showDeviceFrame) ?? true,
     },


### PR DESCRIPTION
Converted to a draft in light of https://github.com/microsoft/vscode/pull/261619 

This PR changes the default panel location to reflect the preferences of small majority of users that used this setting. 

#### test plan:
- open radon 
- go to settings and find radonIDE.userInterface.PanelLocation 
- choose "clear setting" option 
- restart radon
