### PR TITLE
feat: support for react native 83

### DIFF
--- a/packages/vscode-extension/lib/rn-internals/rn-internals-0.83.js
+++ b/packages/vscode-extension/lib/rn-internals/rn-internals-0.83.js
@@ -1,0 +1,26 @@
+module.exports = {
+  parseErrorStack: require("__REACT_NATIVE_INTERNALS__/Libraries/Core/Devtools/parseErrorStack")
+    .default,
+  symbolicateStackTrace: require("__REACT_NATIVE_INTERNALS__/Libraries/Core/Devtools/symbolicateStackTrace")
+    .default,
+  get LogBoxData() {
+    return require("__REACT_NATIVE_INTERNALS__/Libraries/LogBox/Data/LogBoxData");
+  },
+  get SceneTracker() {
+    return require("__REACT_NATIVE_INTERNALS__/Libraries/Utilities/SceneTracker").default;
+  },
+  get getInspectorDataForViewAtPoint() {
+    return require("__REACT_NATIVE_INTERNALS__/src/private/devsupport/devmenu/elementinspector/getInspectorDataForViewAtPoint")
+      .default;
+  },
+  get LoadingView() {
+    return require("__REACT_NATIVE_INTERNALS__/Libraries/Utilities/DevLoadingView").default;
+  },
+  get XHRInterceptor() {
+    return require("__REACT_NATIVE_INTERNALS__/src/private/devsupport/devmenu/elementinspector/XHRInterceptor")
+      .default;
+  },
+  get FabricUIManager() {
+    return require("__REACT_NATIVE_INTERNALS__/Libraries/ReactNative/FabricUIManager");
+  },
+};


### PR DESCRIPTION
This PR updates the internal imports to support react native 83. 

For radon to work with rn 83 this [PR](https://github.com/facebook/react-native/pull/54687) needs to be cherry-picked, thats because of changes mage in: 
https://github.com/facebook/react-native/commit/005d705aff70e560ac937740798b69582a5b6954
to implement proposal: 
https://github.com/j-piasecki/discussions-and-proposals/blob/set-bundle-url/proposals/0933-bundle-source-customization.md

For now to test android we need to copy in the changes from [here](https://github.com/facebook/react-native/pull/54687) and build from sources. 

### How Has This Been Tested: 

- run `react-native-83` test app
- build android from source with the above modifications

### How Has This Change Been Documented:

#1765


