### PR TITLE
fix: crashes when auto reload is triggered before Android device boot

### DIFF
--- a/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidEmulatorDevice.ts
@@ -395,7 +395,7 @@ export class AndroidEmulatorDevice extends AndroidDevice {
   }
 
   protected makePreview(licenseToken?: string): Preview {
-    const args = ["android", "--id", this.serial!];
+    const args = ["android", "--id", this.serial];
     if (licenseToken !== undefined) {
       args.push("-t", licenseToken);
     }
@@ -417,15 +417,7 @@ export class AndroidEmulatorDevice extends AndroidDevice {
     const extractPidFromLogcat = async (cancelToken: CancelToken) =>
       new Promise<string>((resolve, reject) => {
         const regexString = `Start proc ([0-9]{4}):${build.packageName}`;
-        const process = exec(ADB_PATH, [
-          "-s",
-          this.serial!,
-          "logcat",
-          "-e",
-          regexString,
-          "-T",
-          "1",
-        ]);
+        const process = exec(ADB_PATH, ["-s", this.serial, "logcat", "-e", regexString, "-T", "1"]);
         cancelToken.adapt(process);
 
         lineReader(process).onLineRead((line) => {
@@ -453,7 +445,7 @@ export class AndroidEmulatorDevice extends AndroidDevice {
 
     this.nativeLogsOutputChannel.clear();
     const pid = await extractPidFromLogcat(this.nativeLogsCancelToken);
-    const process = exec(ADB_PATH, ["-s", this.serial!, "logcat", "--pid", pid]);
+    const process = exec(ADB_PATH, ["-s", this.serial, "logcat", "--pid", pid]);
     this.nativeLogsCancelToken.adapt(process);
 
     lineReader(process).onLineRead(this.nativeLogsOutputChannel.appendLine);

--- a/packages/vscode-extension/src/devices/AndroidPhysicalDevice.ts
+++ b/packages/vscode-extension/src/devices/AndroidPhysicalDevice.ts
@@ -49,7 +49,7 @@ export class AndroidPhysicalDevice extends AndroidDevice {
   }
 
   protected makePreview(licenseToken?: string): Preview {
-    const args = ["android_device", "--id", this.serial!];
+    const args = ["android_device", "--id", this.serial];
     if (licenseToken !== undefined) {
       args.push("-t", licenseToken);
     }

--- a/packages/vscode-extension/src/project/deviceSession.ts
+++ b/packages/vscode-extension/src/project/deviceSession.ts
@@ -550,9 +550,16 @@ export class DeviceSession implements Disposable {
     }
 
     if (!previewURL) {
-      // NOTE: sim-server could have stopped, due to an error or because the device was disconnected.
-      // We try to restart it here in that case.
-      await this.startPreview();
+      try {
+        // NOTE: sim-server could have stopped, due to an error or because the device was disconnected.
+        // We try to restart it here in that case.
+        await this.startPreview();
+      } catch {
+        // NOTE: if sim-server fails to connect to the device, it's not booted (yet?) or otherwise inaccessible,
+        // and the other reload actions are unlikely to succeed anyway, so we skip to fully restarting the device
+        await this.restartDevice({ forceClean: false });
+        return;
+      }
     }
 
     // if reloading JS is possible, we try to do it first and exit in case of success


### PR DESCRIPTION
Fixes sim-server failing to start when an auto-reload is triggered before an Android Emulator first boots.
The issue was caused by `makePreview` method being called by autoreload (in order to restart sim-server in case of crashes/disconnects/killswitch triggering) and accessing the `AndroidDevice`'s `serial` property before it's initialized by the Emulator boot procedure.
The fix checks the `serial` is actually set before accessing it, and throwing an error in that case (instead of passing `"undefined"` to the sim-server).

### How Has This Been Tested: 
- open Radon
- select an Android Emulator device
- trigger an autoreload immediately, before the device finishes booting
- the autoreload should succeed

### How Has This Change Been Documented:
Internal


