### PR TITLE
chore: silence the dev client tester 

### DIFF
--- a/packages/vscode-extension/src/builders/devClient.ts
+++ b/packages/vscode-extension/src/builders/devClient.ts
@@ -31,6 +31,7 @@ export async function isDevClientProject(
     const result = await exec("node", [devClientProjectTesterScript], {
       cwd: appRoot,
       allowNonZeroExit: true,
+      quietErrorsOnExit: true,
     });
     return result.exitCode === 0;
   } catch (e) {


### PR DESCRIPTION
This PR hides the expected failure of dev client tester from logs 

### How Has This Been Tested: 

- run not dev client application 
- see no message about dev client tester unexpected exit 

### How Has This Change Been Documented:

internal


