### PR TITLE
feat: open in secondary sidebar when moving to side panel

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -418,6 +418,13 @@
       }
     ],
     "viewsContainers": {
+      "secondarySidebar": [
+        {
+          "id": "RadonIDE",
+          "title": "Radon IDE",
+          "icon": "assets/logo.svg"
+        }
+      ],
       "activitybar": [
         {
           "id": "RadonIDE",


### PR DESCRIPTION
[VS Code 1.106](https://code.visualstudio.com/updates/v1_106#_view-containers-in-secondary-side-bar) added an option to register View Containers for the secondary side panel directly.
This allows us to open the IDE Panel initially in the side panel, instead of the previous default of opening in the main Activity Bar when selecting the "Side Panel" IDE location option.

It seems that registering both `"secondarySidebar"` and `"activitybar"` view containers with the same `id` makes the `secondarySidebar` one takes precedence, which is what we want (for compatibility with Cursor and older VS Code versions)

### How Has This Been Tested: 
- open Radon in VS Code 1.106 or newer
- (if already running Radon in side panel) select the "Tab" option for Radon location.
- select the "Side Panel" option for Radon location
- the IDE should open in the secondary side panel (the one containing the Copilot chat by default) instead in the main Activity Bar (the one with Explorer, Version Control etc.)

### How Has This Change Been Documented:
Nah


