### PR TITLE
docs: update href for free license in pricing plans

### DIFF
--- a/packages/docs/src/components/Pricing/ComparePricingPlans/index.tsx
+++ b/packages/docs/src/components/Pricing/ComparePricingPlans/index.tsx
@@ -43,7 +43,7 @@ export default function ComparePricingPlans({
             monthlyPrice={0}
             buttonLabel="Get free license"
             stylingFilled={false}
-            href="https://portal.ide.swmansion.com"
+            href="https://portal.ide.swmansion.com/free"
             onClick={handleFree}
           />
           <PlanTableLabel

--- a/packages/docs/src/components/Pricing/pricingIndividualData.tsx
+++ b/packages/docs/src/components/Pricing/pricingIndividualData.tsx
@@ -6,7 +6,7 @@ export const pricingIndividualData: PricingPlanCardProps[] = [
     price: { monthly: 0, yearlyPerMonth: 0 },
     label: "For non-commercial use",
     buttonLabel: "Get free license",
-    href: "https://portal.ide.swmansion.com",
+    href: "https://portal.ide.swmansion.com/free",
     stylingFilled: false,
     featuresAll: [
       { label: "Element inspector" },


### PR DESCRIPTION
In Radon IDE Portal I've added a special `/free` page for Free license saying that you need to create an account first in order to redeem a free license. This should help with the current confusion on how to redeem a license. 

https://portal.ide.swmansion.com/free

I've updated the styles according to the current (new) branding

<img width="670" height="607" alt="image" src="https://github.com/user-attachments/assets/a7ec8aa7-d94c-438a-81c4-762d180b5557" />
