### PR TITLE
docs: add information about extaExpoArgs config

### DIFF
--- a/packages/docs/docs/guides/configuration.md
+++ b/packages/docs/docs/guides/configuration.md
@@ -239,6 +239,7 @@ Here, we list other attributes that can be configured using launch configuration
   `metro.config.js` or `metro.config.ts`.
 - `isExpo` — Boolean that can be set to `true` if IDE doesn't automatically detect the project should use Expo CLI. By default, the IDE tries to detect whether project is Expo-base or based on the React Native community CLI, so in most of the cases this options shouldn't be needed.
 - `usePrebuild` — Boolean that when set to `true` makes Radon IDE run `expo prebuild` command before building the app and when set to `false` Radon IDE will always skip it. By default, Radon uses Prebuild for projects with `expo dev-client` and skips it for other projects.
+- `expoStartArgs` - Extra arguments to pass to Expo start command. (e.g. ["--scheme", "your_scheme"]).
 
 Below is a sample `launch.json` config file with `appRoot`, `metroConfigPath`, and `env` setting specified:
 


### PR DESCRIPTION
This PR documents `extraExpoArgs` config.

### How Has This Been Tested: 

- vercel preview 

### How Has This Change Been Documented:

this is documentation 


