### PR TITLE
fix: location on ios 

### DIFF
--- a/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
+++ b/packages/vscode-extension/src/devices/IosSimulatorDevice.ts
@@ -218,9 +218,7 @@ export class IosSimulatorDevice extends DeviceBase {
         "clear",
       ]);
     } else {
-      // This is a work around for the problem with location set command not working  when passed, 0 0 coordinates
-      // when provided coordinates are close enough to 0 that the xcrun assumes they are 0 we pass the smallest
-      // working number instead.
+      // NOTE: because `simctl` does not accept `"0,0"` location coordinates, we pass smallest accepted values instead whenever the passed values would be rounded down to `"0,0"`
       let latitude = settings.location.latitude.toString();
       let longitude = settings.location.longitude.toString();
       if (latitude === "0" && longitude === "0") {


### PR DESCRIPTION
Similarly to #681 this PR fixes an issue on ios simulators that when passed 0,0 coordinates the `xcrun simctl location {deviceID} set` command does not take any effect so we add the smallest precision it accepts ("0.0001") to it so it has an effect. This should also fix: https://github.com/software-mansion/radon-ide/pull/1759#discussion_r2559115422


### How Has This Been Tested: 

- run any app in radon on simulator
- exit it 
- open stock maps app 
- set the location to 0 0 
- it works now 

### How Has This Change Been Documented:

internal


