### PR TITLE
fix: cannot remove a broken iOS simulator

### DIFF
--- a/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
+++ b/packages/vscode-extension/src/webview/views/ManageDevicesView.tsx
@@ -78,7 +78,6 @@ function DeviceRow({
   return (
     <button
       className="device-row"
-      disabled={disabled}
       onClick={selectDevice}
       data-selected={isSelected}
       data-testid={dataTest}>


### PR DESCRIPTION
Fixes the "Remove Device" button in the "Manage Devices" dialog not working for "broken" devices.
The issue was caused by us disabling the whole Device Row for unavailable devices, preventing touch events from ever reaching the "Remove" button...

<img width="994" height="912" alt="image" src="https://github.com/user-attachments/assets/d47bd63a-703e-46e8-bee4-b124dbdae43c" />

This PR removes the `disabled` attribute, and instead relies on a descriptive error dialog when the user selects the unavailable device.
(example for physical device)
<img width="488" height="176" alt="image" src="https://github.com/user-attachments/assets/c123a979-4bb0-4454-80c3-8636dbadd517" />
The "Play" button in "Manage Devices" remains disabled, suggesting to the user that they won't be able to start the device before they take any action.

### How Has This Been Tested: 
- create an iOS device and close Radon / vscode completely
- remove the runtime for that device via xcode
- restart Radon verify you can remove the device through Radon

### How Has This Change Been Documented:
Internal / Bug Fix


