### PR TITLE
fix: Radon does not pick up schemes for XCode workspaces

### DIFF
--- a/packages/vscode-extension/src/builders/buildIOS.ts
+++ b/packages/vscode-extension/src/builders/buildIOS.ts
@@ -279,7 +279,19 @@ async function buildLocal(
     }`
   );
 
-  const scheme = buildConfig.scheme ?? (await findXcodeScheme(xcodeProject))[0];
+  let scheme = buildConfig.scheme;
+  if (scheme === undefined) {
+    const availableSchemes = await findXcodeScheme(xcodeProject);
+    if (availableSchemes.length > 1) {
+      Logger.warn(
+        `Multiple Xcode schemes found ` +
+          `(${availableSchemes.map((s) => `"${s}"`).join(", ")}). ` +
+          `Scheme "${availableSchemes[0]}" will be used. ` +
+          `Consider specifying the scheme in the launch configuration.`
+      );
+    }
+    scheme = availableSchemes[0];
+  }
 
   Logger.debug(`Xcode build will use "${scheme}" scheme`);
 

--- a/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
+++ b/packages/vscode-extension/src/webview/views/LaunchConfigurationView.tsx
@@ -449,6 +449,13 @@ function StandardBuildConfiguration({
       return { value: xcodeScheme, label: xcodeScheme };
     });
 
+    const selectedScheme = config?.ios?.scheme;
+
+    // NOTE: this is necessary for a custom scheme to appear in the list when initially opening the modal
+    if (selectedScheme && !availableXcodeSchemes.find((s) => s.value === selectedScheme)) {
+      availableXcodeSchemes.unshift({ value: selectedScheme, label: selectedScheme });
+    }
+
     return (
       <>
         <FormGroup variant="settings-group">
@@ -458,10 +465,8 @@ function StandardBuildConfiguration({
           <FormHelper>
             {launchConfigAttrs?.properties?.ios?.properties?.scheme?.description}
           </FormHelper>
-          <SingleSelect initialValue={config?.ios?.scheme ?? ""} name="ios.scheme">
-            <Option disabled value="">
-              Detect automatically
-            </Option>
+          <SingleSelect combobox creatable initialValue={selectedScheme ?? ""} name="ios.scheme">
+            <Option value="">Detect automatically ({xcodeSchemes[0]})</Option>
             {availableXcodeSchemes.map((scheme) => (
               <Option key={scheme.value} value={scheme.value}>
                 {scheme.label}


### PR DESCRIPTION
- fixes Radon not detecting XCode project schemes correctly for applications using XCode workspaces (which seems to include all of our test apps)
- changes the scheme select in the Launch Configurations dialog to a combobox, allowing setting custom schemes without editing `launch.json` manually

### How Has This Been Tested: 
- open reanimated's FabricExample in Radon
- the "Debug FabricExample" scheme should be detected

### How Has This Change Been Documented:
Bugfix

