### PR TITLE
fix: path env setup was never invoked

### DIFF
--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -16,6 +16,7 @@ import { FingerprintProvider } from "./FingerprintProvider";
 import { requireNoCache } from "../utilities/requireNoCache";
 import { MetroProvider, SharedMetroProvider, UniqueMetroProvider } from "./metro";
 import { DevtoolsServer, WebSocketDevtoolsServer } from "./devtools";
+import { setupPathEnv } from "../utilities/subprocess";
 
 /**
  * Represents a launch configuration that has been resolved with additional properties.
@@ -141,6 +142,7 @@ export class ApplicationContext implements Disposable {
   ) {
     this.buildCache = new BuildCache();
     this.launchConfig = resolveLaunchConfig(launchConfig);
+    setupPathEnv(this.launchConfig.absoluteAppRoot);
     this.reactNativeVersion = getReactNativeVersion(this.launchConfig.absoluteAppRoot);
     this.applicationDependencyManager = new ApplicationDependencyManager(
       this.stateManager.getDerived("applicationDependencies"),
@@ -172,6 +174,7 @@ export class ApplicationContext implements Disposable {
 
   public async updateLaunchConfig(launchConfig: LaunchConfiguration) {
     this.launchConfig = resolveLaunchConfig(launchConfig);
+    setupPathEnv(this.launchConfig.absoluteAppRoot);
     this.reactNativeVersion = getReactNativeVersion(this.launchConfig.absoluteAppRoot);
     this.applicationDependencyManager.setLaunchConfiguration(this.launchConfig);
     await this.applicationDependencyManager.runAllDependencyChecks();

--- a/packages/vscode-extension/src/utilities/subprocess.ts
+++ b/packages/vscode-extension/src/utilities/subprocess.ts
@@ -48,13 +48,19 @@ async function getPathEnv(appRoot: string) {
   return path;
 }
 
+let lastAppRoot: string | undefined;
 let pathEnv: string | undefined;
 export async function setupPathEnv(appRoot: string) {
-  if (!pathEnv) {
-    pathEnv = await getPathEnv(appRoot);
+  if (!pathEnv || lastAppRoot !== appRoot) {
+    lastAppRoot = undefined;
+    pathEnv = await getPathEnv(appRoot).catch((e) => {
+      Logger.error("Error while resolving PATH environment variable in app root", appRoot);
+      return undefined;
+    });
     if (!pathEnv) {
       throw new Error("Error in getting PATH environment variable");
     }
+    lastAppRoot = appRoot;
   }
 }
 


### PR DESCRIPTION
In #1297 I removed the `setupPathEnv` part of switching app roots, breaking some setups where `PATH` is not set correctly by vscode.
While it never worked fully correctly:
- it wouldn't reevaluate the env on switching to a different approot,
- processes may run before the PATH check finished

and this fix isn't satisfactory either, it should help people impacted by this regression until we introduce a proper solution.

### How Has This Been Tested: 
- launch Radon
- verify via debugger that the `overrideEnv` function in `subprocess` is called and contains the overriden `PATH`

### How Has This Change Been Documented:
Bugfix


