### PR TITLE
fix: Disable AI chat participant when AI as a whole is disabled

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1177,7 +1177,7 @@
     },
     "chatParticipants": [
       {
-        "when": "RNIDE.AIEnabled && RNIDE.licenseActive",
+        "when": "RNIDE.AIEnabled",
         "id": "chat.radon-ai",
         "fullName": "Radon AI",
         "name": "radon",


### PR DESCRIPTION
Fixes chat participant being available even when the remaining radon features are disabled.

### How Has This Been Tested: 

- Try using `@radon` chat participant when `Radon IDE › Radon AI: Enabled Boolean` is **disabled**
- Try using it when said setting is **enabled**
- Both cases work as expected

### How Has This Change Been Documented:

N/A


