### PR TITLE
docs: Remove irrelevant statements from AI documentation 

### DIFF
--- a/packages/docs/docs/features/radon-ai.md
+++ b/packages/docs/docs/features/radon-ai.md
@@ -20,7 +20,7 @@ Our knowledge database is updated daily to provide the most up-to-date informati
 
 ## Usage in Visual Studio Code
 
-You can use Radon AI in Visual Studio Code as a [GitHub Copilot Chat participant](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/asking-github-copilot-questions-in-your-ide#chat-participants) or via [Model Context Protocol (MCP) server](https://modelcontextprotocol.io/introduction) in the [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
+You can use Radon AI in Visual Studio Code as a [GitHub Copilot Chat participant](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/asking-github-copilot-questions-in-your-ide#chat-participants) or via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) in the [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode).
 
 ### Use Radon AI as Copilot Chat participant
 
@@ -40,7 +40,7 @@ To start a new conversation open a new chat window.
 
 ### Use Radon AI in agent mode
 
-Radon IDE automatically configures and activates Radon AI MCP server for you.
+Radon IDE automatically configures and activates Radon AI MCP tools for you.
 
 To access agent mode in Visual Studio code use Ctrl+Shift+I or Cmd+Shift+I.
 
@@ -48,27 +48,27 @@ Alternatively, open vscode command palette (Ctrl+Shift+P or Cmd+Shift+P) and typ
 
 <img width="550" src="/img/docs/ai_vscode_agent_mode.png" className="shadow-image"/>
 
-To adjust the configuration of the MCP server choose `Configure Tools...` menu.
+To adjust the configuration of the MCP tools exposed by Radon - choose `Configure Tools...` menu.
 
 <img width="550" src="/img/docs/ai_vscode_choose_tools.png" className="shadow-image"/>
 
-There you can adjust which tools are enabled or disable the Radon AI MCP server completely.
+There you can adjust which tools are enabled or disable the Radon AI MCP toolset completely.
 
 <img width="600" src="/img/docs/ai_vscode_mcp_tools.png" className="shadow-image"/>
 
 ## Usage in Cursor
 
-Radon AI assistant integrates with Cursor's `agent mode` via Model Context Protocol (MCP) server.
+Radon AI assistant integrates with Cursor's `agent mode`.
 
 <img width="550" src="/img/docs/ai_cursor_chat_response.png" className="shadow-image"/>
 
 The Radon IDE automatically registers Radon AI tools in Cursor.
-You configure the Radon AI MCP server from Cursor Settings. There, you can choose which tools are enabled or disable the MCP server completely.
+You configure the Radon AI MCP tools from Cursor Settings. There, you can choose which tools are enabled or disable the MCP Radon toolset completely.
 
 1. In Cursor, open `Cursor Settings` (Ctrl+Shift+J or Cmd+Shift+J).
 2. Navigate to the `Tools & Integrations`.
 3. Find the `MCP Tools` section.
-4. Select `Radon AI` from the list of available servers.
+4. Select `Radon AI` from the list of available toolsets.
 
 <img width="550" src="/img/docs/ai_cursor_mcp_settings.png" className="shadow-image"/>
 


### PR DESCRIPTION
This PR:
- Removes a `tip` section from the Radon AI documentation, which is not relevant anymore thanks to #1665.
- Removes all `mcp.json` configuration guides and references, since these are also not relevant due to the same PR.
- Replaces `MCP server` with more universal wording, since we usually **do not** use a _server_ for loading MCP tools. 

Before|After
---|---
<img width="797" height="301" alt="image" src="https://github.com/user-attachments/assets/725c421e-9d69-49ff-9fb5-c5c90921fda3" />|<img width="792" height="148" alt="image" src="https://github.com/user-attachments/assets/30bd384c-4c74-4511-a1d2-252344ff1ebe" />
<img width="806" height="447" alt="image" src="https://github.com/user-attachments/assets/433bd972-1cda-43b8-9473-9f7316e17c12" />|<img width="803" height="173" alt="image" src="https://github.com/user-attachments/assets/00fa7e60-1153-4eef-a52b-a16840d21f4e" />
<img width="777" height="541" alt="image" src="https://github.com/user-attachments/assets/2c65054e-8de2-4487-b565-cbef9ee3d8f5" />|<img width="770" height="342" alt="image" src="https://github.com/user-attachments/assets/ece04284-26fb-48b8-b34a-d5c773de7d25" />


