### PR TITLE
fix: zod token scheme 

### DIFF
--- a/packages/vscode-extension/src/utilities/license.ts
+++ b/packages/vscode-extension/src/utilities/license.ts
@@ -301,7 +301,7 @@ async function decodeJWTPayload(token: string): Promise<{
     cp_ent: z.string().optional(),
     cp_usr: z.string().optional(),
     cp_plan: z.string().optional(),
-    cp_features: featuresSchema.optional(),
+    cp_features: featuresSchema.default({}),
   });
 
   try {


### PR DESCRIPTION
This PR fixes an issue with `zod` typing causing enterprise tokens to not parse the correct scheme. 

Additionally this PR changes `cp_features: featuresSchema.optional(),` to cp_features: featuresSchema.default({})`

### How Has This Been Tested: 

- activate enterprise license and check if it works

### How Has This Change Been Documented:

internal



