### PR TITLE
fix: object type workspace configurations 

### DIFF
--- a/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
+++ b/packages/vscode-extension/src/panels/WorkspaceConfigController.ts
@@ -46,7 +46,7 @@ export class WorkspaceConfigController implements Disposable {
 
         this.workspaceConfigurationUpdatesToIgnore.push(updatedConfig);
 
-        await updateWorkspaceConfig(config, singleChange);
+        await updateWorkspaceConfig(config, currentWorkspaceConfig, singleChange);
       }
     });
 


### PR DESCRIPTION
This PR fixes how we save workspace configurations to not reset parts of objects to their default value (if only individually changed). This fixes an issue we found with location settings what would always restart one of the coordinates back to the default value. 

### How Has This Been Tested: 

- run radon and open an iphone 
- go to "maps" application and change location to something that is not default

### How Has This Change Been Documented:

bug fix



