### PR TITLE
feat: add remove license command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -283,6 +283,11 @@
         "title": "Toggle device appearance (light/dark mode)",
         "category": "Radon IDE",
         "enablement": "RNIDE.extensionIsActive && RNIDE.panelIsOpen"
+      }, 
+      {
+        "command": "RNIDE.removeLicense",
+        "title": "Remove license",
+        "category": "Radon IDE"
       }
     ],
     "keybindings": [

--- a/packages/vscode-extension/src/common/Project.ts
+++ b/packages/vscode-extension/src/common/Project.ts
@@ -90,7 +90,6 @@ export enum ActivateDeviceResult {
 
 export interface ProjectEventMap {
   projectStateChanged: ProjectState;
-  licenseActivationChanged: boolean;
 }
 
 export interface ProjectEventListener<T> {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -39,6 +39,7 @@ import { DeviceRotationDirection, IDEPanelMoveTarget } from "./common/Project";
 import { AdminRestrictedFunctionalityError, PaywalledFunctionalityError } from "./common/Errors";
 import { registerRadonAI } from "./ai/mcp/RadonMcpController";
 import { MaestroCodeLensProvider } from "./providers/MaestroCodeLensProvider";
+import { removeLicense } from "./utilities/license";
 
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
 
@@ -226,6 +227,20 @@ export async function activate(context: ExtensionContext) {
     }
   }
 
+  function removeLicenseWithConfirmation() {
+    window
+      .showWarningMessage(
+        "Are you sure you want to remove license? Restoring it will require a license key.",
+        "Yes",
+        "No"
+      )
+      .then((item) => {
+        if (item === "Yes") {
+          removeLicense();
+        }
+      });
+  }
+
   context.subscriptions.push(
     window.registerWebviewViewProvider(
       SidePanelViewProvider.viewType,
@@ -300,6 +315,9 @@ export async function activate(context: ExtensionContext) {
   );
   context.subscriptions.push(
     commands.registerCommand("RNIDE.toggleDeviceAppearance", toggleDeviceAppearance)
+  );
+  context.subscriptions.push(
+    commands.registerCommand("RNIDE.removeLicense", removeLicenseWithConfirmation)
   );
   // Debug adapter used by custom launch configuration, we register it in case someone tries to run the IDE configuration
   // The current workflow is that people shouldn't run it, but since it is listed under launch options it might happen


### PR DESCRIPTION
Now that there is a noticeable difference between experience of activated and un activated license we add a "remove license" command with two goals in mind: 
1) make it easier to test multiple setups 
2) if a user has any problem with corrupted license (which hopefully wont happen) we can point them to this command in order to replace it with a new one

### How Has This Been Tested: 

https://github.com/user-attachments/assets/d1f642a8-b3d6-4e01-a4d0-e71446f30c63

### How Has This Change Been Documented:

We have quite a large trouble shooting backlog to document we will handle it all at once in a future PR



