### PR TITLE
chore: unblock debug console button in radon connect

### DIFF
--- a/packages/vscode-extension/src/webview/views/PreviewView.tsx
+++ b/packages/vscode-extension/src/webview/views/PreviewView.tsx
@@ -188,7 +188,10 @@ function PreviewView() {
     navBarButtonsActive &&
     isRunning &&
     inspectorAvailabilityStatus === InspectorAvailabilityStatus.Available;
-  const debuggerToolsButtonsActive = navBarButtonsActive; // this stays in sync with navBarButtonsActive, but we will enable it for radon connect later
+  // this stays in sync with navBarButtonsActive, but we will enable it for radon connect later,
+  // once we support js and react profiling in radon connect.
+  const debuggerToolsButtonsActive = navBarButtonsActive;
+  const debugConsoleButtonActive = navBarButtonsActive || radonConnectConnected;
 
   const deviceProperties = iOSSupportedDevices.concat(AndroidSupportedDevices).find((sd) => {
     return sd.modelId === modelId;
@@ -441,7 +444,7 @@ function PreviewView() {
             tooltip={{
               label: "Open logs panel",
             }}
-            disabled={!debuggerToolsButtonsActive}>
+            disabled={!debugConsoleButtonActive}>
             <span slot="start" className="codicon codicon-debug-console" />
           </IconButton>
           <SettingsDropdown project={project} isDeviceRunning={isRunning || radonConnectConnected}>


### PR DESCRIPTION
This PR very slightly improves the experience in radon connect mode. By unblocking the button that focuses debug console if the remote metro is connected. 

Things to consider improving in future work: 
- migrate the radon connect state to the new state management 
- support for js and react profiling in radon connect 
- rethink what the `applicationSession` means so we are able to read the "log count" menage debugger state and triger profiles with an uniform api. 

### How Has This Been Tested: 

- use radon connect 

### How Has This Change Been Documented:

none


