### PR TITLE
feat: disable maestro UI until it`s ready

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -38,7 +38,6 @@ import { PanelLocation } from "./common/State";
 import { DeviceRotationDirection, IDEPanelMoveTarget } from "./common/Project";
 import { AdminRestrictedFunctionalityError, PaywalledFunctionalityError } from "./common/Errors";
 import { registerRadonAI } from "./ai/mcp/RadonMcpController";
-import { MaestroCodeLensProvider } from "./providers/MaestroCodeLensProvider";
 import { removeLicense } from "./utilities/license";
 
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
@@ -208,25 +207,6 @@ export async function activate(context: ExtensionContext) {
     }
   }
 
-  async function startMaestroTest(fileNames: string[]) {
-    const ide = IDE.getInstanceIfExists();
-    if (ide) {
-      ide.project.startMaestroTest(fileNames);
-    } else {
-      window.showWarningMessage(
-        "Wait for the app to load before running Maestro tests.",
-        "Dismiss"
-      );
-    }
-  }
-
-  async function stopMaestroTest() {
-    const ide = IDE.getInstanceIfExists();
-    if (ide) {
-      ide.project.stopMaestroTest();
-    }
-  }
-
   function removeLicenseWithConfirmation() {
     window
       .showWarningMessage(
@@ -286,8 +266,6 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     commands.registerCommand("RNIDE.showInlinePreview", showInlinePreview)
   );
-  context.subscriptions.push(commands.registerCommand("RNIDE.startMaestroTest", startMaestroTest));
-  context.subscriptions.push(commands.registerCommand("RNIDE.stopMaestroTest", stopMaestroTest));
 
   context.subscriptions.push(commands.registerCommand("RNIDE.captureReplay", captureReplay));
   context.subscriptions.push(commands.registerCommand("RNIDE.toggleRecording", toggleRecording));
@@ -389,13 +367,6 @@ export async function activate(context: ExtensionContext) {
         { scheme: "file", language: "javascript" },
       ],
       new PreviewCodeLensProvider()
-    )
-  );
-
-  context.subscriptions.push(
-    languages.registerCodeLensProvider(
-      [{ scheme: "file", language: "yaml" }],
-      new MaestroCodeLensProvider()
     )
   );
 

--- a/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
+++ b/packages/vscode-extension/src/webview/components/ToolsDropdown.tsx
@@ -16,7 +16,6 @@ import { ProjectInterface } from "../../common/Project";
 import Tooltip from "./shared/Tooltip";
 import { useSelectedDeviceSessionState } from "../hooks/selectedSession";
 import { ToolsState, ToolState } from "../../common/State";
-import { useStore } from "../providers/storeProvider";
 
 interface DevToolCheckboxProps {
   label: string;
@@ -95,12 +94,7 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
   const selectedDeviceSessionStatus = use$(selectedDeviceSessionState.status);
 
   const { project } = useProject();
-  const store$ = useStore();
-  const applicationDependencies = use$(
-    store$.projectState.applicationContext.applicationDependencies
-  );
 
-  const isMaestroInstalled = applicationDependencies.maestro?.status === "installed";
   const isRunning = selectedDeviceSessionStatus === "running";
 
   const profilingCPUState = use$(selectedDeviceSessionState?.applicationSession.profilingCPUState);
@@ -132,26 +126,6 @@ function ToolsDropdown({ children, disabled }: { children: React.ReactNode; disa
           data-testid="radon-tools-dropdown-menu"
           onCloseAutoFocus={(e) => e.preventDefault()}>
           <h4 className="device-settings-heading">Tools</h4>
-          {isMaestroInstalled && (
-            <>
-              <Label>Testing</Label>
-              <DropdownMenu.Item
-                className="dropdown-menu-item"
-                data-testid="tools-dropdown-menu-maestro-test-button"
-                onSelect={() => {
-                  const fileDialogPromise = project.openSelectMaestroFileDialog();
-                  fileDialogPromise.then((fileNames) => {
-                    if (fileNames) {
-                      project.startMaestroTest(fileNames);
-                    }
-                  });
-                }}>
-                <span className="codicon codicon-github-action" />
-                Start Maestro test(s)...
-              </DropdownMenu.Item>
-            </>
-          )}
-
           <Label>Utilities</Label>
           <DropdownMenu.Item
             className="dropdown-menu-item"

--- a/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
+++ b/packages/vscode-extension/src/webview/views/DiagnosticView.tsx
@@ -70,7 +70,6 @@ function DiagnosticView() {
       <Label>Other</Label>
       <DiagnosticItem label="Expo Router" name="expoRouter" info={dependencies.expoRouter} />
       <DiagnosticItem label="Storybook" name="storybook" info={dependencies.storybook} />
-      <DiagnosticItem label="Maestro" name="maestro" info={dependencies.maestro} />
       <DiagnosticItem label="eas-cli" name="easCli" info={dependencies.easCli} />
       <div className="diagnostic-section-margin" />
 


### PR DESCRIPTION
Removes entry points for Maestro tests from the UI:
- CodeLens Provider for editor inline hints
- Tools drop-down entry
- Diagnostics entry
- VSCode commands

### How Has This Been Tested: 
- run Radon with maestro installed
- check that you can't start maestro tests inside Radon

### How Has This Change Been Documented:
meh


