### PR TITLE
fix: delay before starting maestro tests

### DIFF
--- a/packages/vscode-extension/src/project/MaestroTestRunner.ts
+++ b/packages/vscode-extension/src/project/MaestroTestRunner.ts
@@ -108,6 +108,10 @@ export class MaestroTestRunner implements Disposable {
       pty.writeLine(`Starting ${fileNames.length} Maestro flows: ${fileNames.join(", ")}`);
     }
 
+    // NOTE: maestro sets application permissions using the `applesimutils` utility,
+    // which does not support custom device sets.
+    // To work around this, we create a symlink to the target Radon device
+    // in the default simulator location for the duration of the test, and remove it afterwards.
     const cleanupSymlink = await this.setupSimulatorSymlink();
     try {
       await this.runMaestro(fileNames, pty);


### PR DESCRIPTION
Fixes a 30s delay after starting maestro tests and before the app is launched on the device.
The delay was caused by `maestro` calling `applesimutils` utility in order to set permissions on the device. The utility does not support passing simulator device sets (and even if it did, `maestro` would not set it anyway), so it would repeatedly try to set permissions on a simulator device which does not exist, and timeout after 30s, after which `maestro` would proceed with running the application to be tested.

The solution allows `applesimutils` to modify the permissions on Radon simulator by symlinking it to the `CoreSimulator` directory -- since `applesimutils` accesses the simulator's files directly (without checking the simulators database, like `xcodebuild`), a symlink is sufficient for it to function.

### How Has This Been Tested: 
- run maestro test on an iOS simulator
- the test should start soon after the Maestro TestRunner opens

### How Has This Change Been Documented:
Bugfix


