### PR TITLE
fix: Element inspector AI reference now works in Cursor

### DIFF
--- a/packages/vscode-extension/src/project/project.ts
+++ b/packages/vscode-extension/src/project/project.ts
@@ -802,7 +802,7 @@ export class Project implements Disposable, ProjectInterface, DeviceSessionsMana
 
       if (editor === EditorType.CURSOR) {
         focusCommand = "composer.startComposerPrompt";
-        // attachFileCommand = "composer.startComposerPrompt";
+        attachFileCommand = "composer.addfilestocomposer";
       }
 
       commands.executeCommand(focusCommand).then(async () => {


### PR DESCRIPTION
#1732 used to only work in VSCode. This PR makes it work in Cursor. 

Support for other editors will be introduced in a separate PR, as right now, this feature cannot even be enabled on editors other than VSCode or Cursor due to how feature permissions & licensing are implemented.

### How Has This Been Tested: 

https://github.com/user-attachments/assets/cd49ffb0-fbd6-435c-9476-afadf4aecdf0

### How Has This Change Been Documented:

TBD: Will see if docs need updating


