### PR TITLE
fix: Fix extension crashing on startup

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -40,8 +40,8 @@ import { AdminRestrictedFunctionalityError, PaywalledFunctionalityError } from "
 import { registerRadonAI } from "./ai/mcp/RadonMcpController";
 import { MaestroCodeLensProvider } from "./providers/MaestroCodeLensProvider";
 import { removeLicense } from "./utilities/license";
-import { getEditorType } from "./utilities/editorType";
 import { getTelemetryReporter } from "./utilities/telemetry";
+import { getEditorType } from "./utilities/editorType";
 
 const CHAT_ONBOARDING_COMPLETED = "chat_onboarding_completed";
 


### PR DESCRIPTION
Extension crashes on startup. This PR fixes that.

This was happening because `workspace.getConfiguration();` (located in `getEditorType();`) was being called before `setExtensionContext(context);`.

<img width="914" height="152" alt="image" src="https://github.com/user-attachments/assets/adc99ef2-7518-4b2e-9e79-925b70ca3fa6" />

### How Has This Been Tested: 

- Start the extension
- The panel works, and no errors are thrown



