### PR TITLE
feat: show explicit error when running maestro test on iPad

### DIFF
--- a/packages/vscode-extension/src/project/MaestroTestRunner.ts
+++ b/packages/vscode-extension/src/project/MaestroTestRunner.ts
@@ -113,6 +113,14 @@ export class MaestroTestRunner implements Disposable {
     const deviceFamily = getDeviceFamily(this.device.deviceInfo);
     getTelemetryReporter().sendTelemetryEvent(`maestro:test_started:${deviceFamily}`);
 
+    if (deviceFamily === DeviceFamily.IPAD_SIMULATOR) {
+      vscode.window.showErrorMessage(
+        "Maestro tests are currently unsupported for iPad simulator devices. " +
+          "Switch to a different device and run the test again."
+      );
+      return;
+    }
+
     const { terminal, pty } = this.getOrCreateTerminal();
     terminal.show(true);
     // For some reason the terminal isn't ready immediately and loses initial output


### PR DESCRIPTION
Displays an explicit error when launching a maestro test on iPad simulators.
At this time, launching maestro on iPad results in the test visibly hanging.
This PR instead shows a vscode error dialog explaining that the feature is not supported at the moment, and prompting the user to switch the device in order to run the test.

### How Has This Been Tested: 
- select an iPad simulator
- try to run a maestro test
- an error should appear immediately, explaining that the test cannot be run

### How Has This Change Been Documented:
Internal


