### PR TITLE
fix: patch babel_transformer to handle React 19.0.1 when using React Native 78 or 79

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -165,7 +165,7 @@ function transformWrapper({ filename, src, ...rest }) {
     const { version: reactVersion } = requireFromAppDir("react/package.json");
     if (
       (reactNativeVersion.startsWith("0.78") || reactNativeVersion.startsWith("0.79")) &&
-      reactVersion.startsWith("19.0")
+      reactVersion.startsWith("19.0.0")
     ) {
       const rendererFilePath = path.join(
         process.env.RADON_IDE_LIB_PATH,
@@ -182,7 +182,7 @@ function transformWrapper({ filename, src, ...rest }) {
     const reactVersion = requireFromAppDir("react/package.json").version;
     if (
       (reactNativeVersion.startsWith("0.78") || reactNativeVersion.startsWith("0.79")) &&
-      reactVersion.startsWith("19.0")
+      reactVersion.startsWith("19.0.0")
     ) {
       src = `module.exports = require("__RNIDE_lib__/JSXRuntime/react-native-78-79/${jsxRuntimeFileName}");`;
     }


### PR DESCRIPTION
### Description

Fixes problems with version 19.0.1 used together with React Native 78 and 79.

Due to the fix for element inspector made in https://github.com/software-mansion/radon-ide/commit/9c79167c3e03ac9442603450435da9d4a459fde9 some issues arise when someone decides to use react native 78 or 79  with React version `19.0.1`. So far, we've been replacing the bundled React Renderer with our modified version of it, by detecting the React version like this:
```ts
if( ... && reactVersion.startsWith("19.0"))
```

We may no longer do that, as version `19.0.1` also matches this predicate and will be replaced by modified 19.0.0 build causing problems.

The fix simply makes the check more specific.

```ts
if( ... && reactVersion.startsWith("19.0.0"))
```

Note, that this is temporary solution, which will cause the element inspector to **not function**. In order to use React 19.0.0 with React Native 78 or 79, you have to patch the react native implementation itself to not throw an error, as it also has an explicit check for version `19.0.0` and will throw an error when using `19.0.1`. The react native code has to be patched manually in order to use `19.0.1`. The only reason to replace this version would be due to [Security Vulnerability](https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components), but react native should remain unaffected by it in most cases.

Because of the reasons of above, we provide this fix instead of creating new patched 19.0.1 bundle for now.

### How Has This Been Tested: 

- Verified that existing projects using React Native 78 and 79 with React `19.0.0` run correctly
- Replaced the version of React in those projects to be `19.0.1`, ran `npm install`, made the necessary patch in React Native, verified the app works correctly with exception to network inspector not functioning (as expected)
- Created fresh React Native 78 and 79 using react-native-cli to confirm that fresh apps with `19.0.0` remain working correctly

### How Has This Change Been Documented:

Not applicable.


