### PR TITLE
fix: network inspector - disable native implementation on android 0.83.0 due to issues

### DIFF
--- a/packages/vscode-extension/src/plugins/network/network-plugin.ts
+++ b/packages/vscode-extension/src/plugins/network/network-plugin.ts
@@ -54,9 +54,9 @@ export class NetworkPlugin implements ToolPlugin {
     inspectorBridge: RadonInspectorBridge,
     networkBridge: NetworkBridge,
     metroPort: number,
-    useNativeNetworkInspectorFlag: boolean
+    useNativeNetworkInspector: boolean
   ) {
-    this.networkInspector = useNativeNetworkInspectorFlag
+    this.networkInspector = useNativeNetworkInspector
       ? new DebuggerNetworkInspector(inspectorBridge, networkBridge, metroPort)
       : new InspectorBridgeNetworkInspector(inspectorBridge, metroPort);
     initialize();

--- a/packages/vscode-extension/src/project/ApplicationContext.ts
+++ b/packages/vscode-extension/src/project/ApplicationContext.ts
@@ -61,15 +61,6 @@ function checkFuseboxSupport(appRoot: string): boolean {
   return supportsFusebox;
 }
 
-function checkNativeNetworkInspectorSupport(appRoot: string): boolean {
-  const reactNativeVersion = getReactNativeVersion(appRoot);
-  if (reactNativeVersion === null) {
-    return false;
-  }
-  const supportsNativeNetworkInspector = reactNativeVersion.compare("0.83.0") >= 0;
-  return supportsNativeNetworkInspector;
-}
-
 function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunchConfig {
   const appRoot = configuration.appRoot;
   const absoluteAppRoot = path.resolve(workspace.workspaceFolders![0].uri.fsPath, appRoot);
@@ -115,9 +106,7 @@ function resolveLaunchConfig(configuration: LaunchConfiguration): ResolvedLaunch
     },
     usePrebuild: configuration.usePrebuild,
     useOldDevtools: configuration.useOldDevtools ?? !checkFuseboxSupport(absoluteAppRoot),
-    useNativeNetworkInspector:
-      configuration.useNativeNetworkInspector ??
-      checkNativeNetworkInspectorSupport(absoluteAppRoot),
+    useNativeNetworkInspector: configuration.useNativeNetworkInspector,
   };
 }
 

--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -239,7 +239,8 @@ export class ApplicationSession implements Disposable {
       this.applicationContext,
       devtoolsInspectorBridge,
       this.networkBridge,
-      this.metro.port
+      this.metro.port,
+      this.shouldEnableNativeNetworkInspector()
     );
 
     this.disposables.push(this.toolsManager);
@@ -315,6 +316,33 @@ export class ApplicationSession implements Disposable {
   }
 
   // #region Tools
+
+  private shouldEnableNativeNetworkInspector(): boolean {
+    const launchConfig = this.applicationContext.launchConfig;
+    const useNativeNetworkInspectorFlag = launchConfig.useNativeNetworkInspector;
+
+    const explicitlyEnabled = useNativeNetworkInspectorFlag === true;
+    const explicitlyDisabled = useNativeNetworkInspectorFlag === false;
+
+    if (explicitlyEnabled) {
+      return true;
+    }
+    if (explicitlyDisabled) {
+      return false;
+    }
+
+    const reactNativeVersion = this.applicationContext.reactNativeVersion;
+    const meetsMinimumVersion = (reactNativeVersion?.compare("0.83.0") ?? -1) >= 0;
+    const isAndroid = this.device.platform === DevicePlatform.Android;
+    const isAndroid0830 = reactNativeVersion?.compare("0.83.0") === 0 && isAndroid;
+
+    // RN 0.83.0 on Android has known issues with native network inspector
+    if (isAndroid0830) {
+      return false;
+    }
+
+    return meetsMinimumVersion;
+  }
 
   public async updateToolEnabledState(toolName: ToolKey, enabled: boolean) {
     return this.toolsManager.updateToolEnabledState(toolName, enabled);

--- a/packages/vscode-extension/src/project/tools.ts
+++ b/packages/vscode-extension/src/project/tools.ts
@@ -69,18 +69,17 @@ export class ToolsManager implements Disposable {
   private disposables: Disposable[] = [];
   private readonly workspaceConfigState: StateManager<WorkspaceConfiguration>;
   private readonly launchConfig: ResolvedLaunchConfig;
-  private readonly useNativeNetworkInspectorFlag: boolean;
 
   public constructor(
     private readonly stateManager: StateManager<ToolsState>,
     private readonly applicationContext: ApplicationContext,
     public readonly inspectorBridge: RadonInspectorBridge,
     public readonly networkBridge: NetworkBridge,
-    public readonly metroPort: number
+    public readonly metroPort: number,
+    private readonly useNativeNetworkInspector: boolean
   ) {
     this.workspaceConfigState = this.applicationContext.workspaceConfigState;
     this.launchConfig = this.applicationContext.launchConfig;
-    this.useNativeNetworkInspectorFlag = this.launchConfig.useNativeNetworkInspector ?? false;
 
     this.toolsSettings = Object.assign({}, extensionContext.workspaceState.get(TOOLS_SETTINGS_KEY));
     for (const plugin of createExpoDevPluginTools()) {
@@ -106,12 +105,7 @@ export class ToolsManager implements Disposable {
     this.plugins.set(APOLLO_PLUGIN_ID, new ApolloClientDevtoolsPlugin(inspectorBridge));
     this.plugins.set(
       NETWORK_PLUGIN_ID,
-      new NetworkPlugin(
-        inspectorBridge,
-        networkBridge,
-        metroPort,
-        this.useNativeNetworkInspectorFlag
-      )
+      new NetworkPlugin(inspectorBridge, networkBridge, metroPort, this.useNativeNetworkInspector)
     );
     this.plugins.set(
       RENDER_OUTLINES_PLUGIN_ID,


### PR DESCRIPTION
### Description

This PR introduces additional check for React Native `0.83.0` running on an Android device, which helps to disable native network inspector in this case.

When using native network inspector implementation with Android device on version `0.83.0`, the `Size` of request made to an `https` endpoint is always `-1`. This behaviour is caused by React Native DevTools bug and is not our fault (it is in fact also apparent in the devtools window itself), but given that our implementation works in this case, we should switch to it to provide proper user experience when we can.


<img width="1190" height="356" alt="image" src="https://github.com/user-attachments/assets/12bbf342-fb2f-4b9f-be2e-2f0618efd54d" />

This change required moving the compatibility check from `ApplicationContext` to `ApplicationSession`, as we do not have information about used device in the LaunchConfig (it is tailored for both platforms, the platform information itself comes at later initialisation stage).

### How Has This Been Tested: 

Verified that, on version `0.83.0` native network inspector is used on iOS and disabled on android, switched to other version (`0.82.0`), then back to `0.83.0` to check whether the version updates correctly.

Changed `package.json` of react-native to state that version is `0.83.2` and checked that in this case, android properly uses the native implementation.

Checked that explicitly toggling the option `useNativeInspectorImplementation` in launch configuration works as expected.

### How Has This Change Been Documented:

Not Applicable.



