### PR TITLE
fix: redux expo plugin crashes the application

### DIFF
--- a/packages/vscode-extension/lib/plugins/redux-devtools-expo-dev-plugin.js
+++ b/packages/vscode-extension/lib/plugins/redux-devtools-expo-dev-plugin.js
@@ -1,4 +1,5 @@
 // override the expo-devtools inspection with the one injected by Radon, provided by the redux-devtools extension
-export let composeWithDevtools = globalThis.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
+require("__RNIDE_lib__/plugins/redux-devtools");
+export let composeWithDevTools = globalThis.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__;
 let devtoolsEnhancer = globalThis.__REDUX_DEVTOOLS_EXTENSION__;
 export default devtoolsEnhancer;


### PR DESCRIPTION
Fixes a crash when an application uses `redux-devtools-expo-dev-plugin` with deprecated `redux.createStore` + `composeWithDevTools` approach.
The issue was caused by ~me being dumb~ a typo in the reexport of the `compose` function from the module we overwrite `redux-devtools-expo-dev-plugin` with.

### How Has This Been Tested: 
- open Radon test app with plugins
- replace the Redux `store` with one that uses `composeWithDevTools` (unused `store2` in that file)
- check that the app still runs and devtools connect
