### PR TITLE
fix: don`t refetch Android phone models list on fail

### DIFF
--- a/packages/vscode-extension/src/devices/DeviceNameCache.ts
+++ b/packages/vscode-extension/src/devices/DeviceNameCache.ts
@@ -74,7 +74,10 @@ async function getDeviceModels(refetchIfNotOnList?: string): Promise<DeviceModel
   if (json) {
     await writeCacheFile(json);
   }
-  fetchModelsPromise = null;
+  // NOTE: even if `fetchModelsPromise` resolves to null, we don't want to reset it,
+  // in order to avoid attempting refetching the models list over and over.
+  // Instead, we rely on it only being called once per extension activation here,
+  // so the list can be re-fetched only after restart.
   return json;
 }
 


### PR DESCRIPTION
Changes the behaviour of `DeviceNameCache` so that if the model list fetch fails, the extension won't attempt to refetch it.
This should prevent making unnecessary request and spamming the IDE logs with errors when e.g. the machine doesn't have Internet access.

### How Has This Been Tested: 
- open Radon in Radon
- connect a physical Android device
- disconnect from the Internet
- remove the `~/Library/Application Support/Code/User/globalStorage/swmansion.react-native-ide/RNIDE_device_models.json` file
- verify "Error fetching device models: fetch failed" isn't logged more than once

### How Has This Change Been Documented:
Internal

