### PR TITLE
fix: Hide element inspector AI button when no elements are present

### DIFF
--- a/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/InspectDataMenu.tsx
@@ -89,7 +89,6 @@ export function InspectDataMenu({
   const onReferenceInChat = usePaywalledCallback(
     (e) => {
       if (inspectedItems.length === 0) {
-        // Silently aborting when `inspectedItems` is empty. There are bugs which make this case possible.
         e.preventDefault();
         return;
       }


### PR DESCRIPTION
The `onReferenceInChat` callback already contains a guard against `inspectedItems` being empty, but the same guard wasn't applied to the rendering logic. This PR fixes that, which resolves #1812.

Fixes #1812

### How Has This Been Tested: 

- Hard-set `inspectedItems` to `[]`
- Neither button renders - as expected

Before|After
-|-
<img width="193" height="77" alt="image" src="https://github.com/user-attachments/assets/65bec6c9-f64e-4bdf-8bb1-14ef2b924c4d" />|<img width="191" height="48" alt="image" src="https://github.com/user-attachments/assets/c066c5c8-519a-45e6-8f98-ed70d3d168e8" />


### How Has This Change Been Documented:

Not applicable


