### PR TITLE
fix: use namespace instead of appId when generating MainActivity

### DIFF
--- a/packages/vscode-extension/src/builders/buildAndroid.ts
+++ b/packages/vscode-extension/src/builders/buildAndroid.ts
@@ -89,7 +89,7 @@ async function getNamespaceFromGradle(projectRoot: string): Promise<string | nul
   }
 
   // The namespace field in build.gradle defines the Java package name for the app's code.
-  const matchResult = gradleBuild.contents.match(/namespace\s+['"].*['"]/);
+  const matchResult = gradleBuild.contents.match(/namespace\s+['"](.*)['"]/);
   return matchResult?.[1] ?? null;
 }
 


### PR DESCRIPTION
Changes how the fully specified MainActivity is specified.
Previously, for `.`-prefixed activities, we read the `applicationId` from `build.gradle` and appended the Activity name, e.g. `build.gradle` with:
```
// ...
namespace "com.example"
defaultConfig {
  applicationId "com.example.mobile"
  // etc...
```
and `AndroidManifest.xml` with:
```
<activity android:name=".MainActivity" ... />
```
would generate `com.example.mobile.MainActivity`.

However, Android uses the application package's `namespace` instead of AppID when creating the Activity name ([docs](https://developer.android.com/guide/topics/manifest/activity-element)):
> if the first character of the name is a period, such as ".ExtracurricularActivity", it is appended to the [namespace](https://developer.android.com/studio/build/configure-app-module#set-namespace) specified in the build.gradle file.

This means, in the previous example, the actual name of the main activity would have been `com.example.MainActivity`.

This hasn't historically been a problem because the activity name is only used when launching expo-dev-client apps, and Expo CNG generates an Android application package with the same `namespace` and `applicationId`, but we've run into a case of an application which bypasses Expo CNG and overrides the default `applicationId` for legacy reasons.

This PR changes the approach to correctly use the namespace in this case.

The implementation is based on `@expo/config-plugin`'s implementation of `getApplicationIdAsync`, which is not very resilient (it's just a regex looking for `namespace` in the `build.gradle` file), but since it's only used in projects using expo dev client at the moment, it should be good enough (without having to properly parse Groovy files).

### How Has This Been Tested: 
- check that apps using expo-dev-client still launch

### How Has This Change Been Documented:
INTERNAL

