### PR TITLE
fix: network inspector - disable native implementation on android

### DIFF
--- a/packages/vscode-extension/src/project/applicationSession.ts
+++ b/packages/vscode-extension/src/project/applicationSession.ts
@@ -334,10 +334,9 @@ export class ApplicationSession implements Disposable {
     const reactNativeVersion = this.applicationContext.reactNativeVersion;
     const meetsMinimumVersion = (reactNativeVersion?.compare("0.83.0") ?? -1) >= 0;
     const isAndroid = this.device.platform === DevicePlatform.Android;
-    const isAndroid0830 = reactNativeVersion?.compare("0.83.0") === 0 && isAndroid;
 
-    // RN 0.83.0 on Android has known issues with native network inspector
-    if (isAndroid0830) {
+    // Android has known issues with native network inspector
+    if (isAndroid) {
       return false;
     }
 


### PR DESCRIPTION
### Description

This PR is a follow-up to the issue tackled in https://github.com/software-mansion/radon-ide/pull/1816

It changes additional check for React Native 0.83.0 running on an Android device and now, instead of just checking whether it is 0.83.0, it disables the native network inspector implementation for Android for every version, as `0.83.1` is also broken and it is suspected that the future versions may also be effected by the issue mentioned earlier.

The only notable change is just the predicate in `ApplicationSession` which now checks for android and not specific version of android.


### How Has This Been Tested: 

Verified that, on version 0.83.0 and 0.83.1 native network inspector is used on iOS and disabled on android.

### How Has This Change Been Documented:

Not applicable.


