### PR TITLE
fix: loading metro config with new (newer then 54.0.20) Expo CLI

### DIFF
--- a/packages/vscode-extension/submodules-NOTICES.json
+++ b/packages/vscode-extension/submodules-NOTICES.json
@@ -77,17 +77,6 @@
           "text": "Permission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
         }
       ]
-    },
-    {
-      "package_name": "node-semver",
-      "repository": "https://github.com/npm/node-semver?tab=ISC-1-ov-file",
-      "license": "ISC",
-      "licenses": [
-        {
-          "license": "ISC",
-          "text": "The ISC License Copyright (c) Isaac Z. Schlueter and Contributors Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. THE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE."
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Tis PR solves the a problem with loading metro configuration in Radon, that was introduced with [this change](https://github.com/expo/expo/pull/41142) in expo CLI. 

Previously Expo CLI has relied on `loadConfig`, that we have overridden to adapt the config. After the change mentioned above expo decided to use `resolveConfig` instead, so we temporally override it as well. 

To avoid overriding even more expos internal functionality. We check the expo CLI version to determine if `resolveConfig` should be overridden. An alternative solution would be to override both `resolveConfig`  and `getDefaultConfig` and modify the logic of `loadConfig` to merge the changes correctly after being given already modified `default`, but this option would potentially affect how the old setups behave, which we want to avoid.

Most of the changes made in this PR should be removed once expo implements more stable solution for providing custom `metro-configs`. 

### How Has This Been Tested: 

- run expo app with expo version 54.0.30 (this matches the CLI version 54.0.20) - radon should work after this fix 
- run expo app with expo version 54.0.29 (this matches the CLI version 54.0.19) - radon should work after this fix and before
- run expo app with expo version 53 - radon should work after this fix and before 

NOTE: If you test multiple versions by reinstalling expo in the same project you need to use "restart metro" option from radons reload menu 

### How Has This Change Been Documented:

internal


