### PR TITLE
fix: expo-router plugin injection when entry is not used directly

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -87,17 +87,17 @@ function transformWrapper({ filename, src, ...rest }) {
   const { transform } = require(ORIGINAL_TRANSFORMER_PATH);
   if (isTransforming("node_modules/react-native/Libraries/Core/InitializeCore.js")) {
     src = `${src};require("__RNIDE_lib__/runtime.js");`;
-  } else if (isTransforming("node_modules/expo-router/entry.js")) {
+  } else if (isTransforming("node_modules/expo-router/build/qualified-entry.js")) {
     // expo-router v2 and v3 integration
     const { version } = requireFromAppDir("expo-router/package.json");
     if (version.startsWith("2.")) {
-      src = `${src};require("__RNIDE_lib__/expo_router/expo_router_v2_plugin.js");`;
+      src = `${src};\nrequire("__RNIDE_lib__/expo_router/expo_router_v2_plugin.js");`;
     } else if (version.startsWith("3.") || version.startsWith("4.")) {
-      src = `${src};require("__RNIDE_lib__/expo_router/expo_router_plugin.js");`;
+      src = `${src};\nrequire("__RNIDE_lib__/expo_router/expo_router_plugin.js");`;
     } else if (version.startsWith("5.")) {
-      src = `${src};require("__RNIDE_lib__/expo_router/expo_router_v5_plugin.js");`;
+      src = `${src};\nrequire("__RNIDE_lib__/expo_router/expo_router_v5_plugin.js");`;
     } else if (version.startsWith("6.")) {
-      src = `${src};require("__RNIDE_lib__/expo_router/expo_router_v6_plugin.js");`;
+      src = `${src};\nrequire("__RNIDE_lib__/expo_router/expo_router_v6_plugin.js");`;
     }
   } else if (
     isTransforming("node_modules/react-native-ide/index.js") || // using react-native-ide for compatibility with old NPM package name


### PR DESCRIPTION
Fixes a problem when `expo-router` is used by using your own entry file instead of `expo-router/entry`, instead deep-importing `qualified-entry.js` wrapping it in a separate component, and calling `renderRootComponent` on that.

Normally, the `entry.js` file imports the `App` component from `qualified-entry.js` and calls `renderRootComponent` on it, so this approach shouldn't change the behaviour in that case.

### How Has This Been Tested: 
- open an app using `expo-router` (e.g. `expo-52-prebuild-with-plugins`)
- add an entry file (`main.js`) to your test app:
```js
import { useEffect } from "react";
import { App } from "expo-router/build/qualified-entry";
import { renderRootComponent } from "expo-router/build/renderRootComponent";

function WrappedApp() {
  useEffect(() => {
    console.log("App Mounted");
  }, []);

  return <App />;
}

renderRootComponent(WrappedApp);
```
- specify it as the entry in `package.json`:
```json
  "main": "./main.js",
```
- run the app in Radon
- verify the `"App Mounted"` message is logged
- verify the URL bar works

### How Has This Change Been Documented:
INTERNAL

