### PR TITLE
fix: iOS build progress

### DIFF
--- a/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
+++ b/packages/vscode-extension/src/builders/BuildIOSProgressProcessor.ts
@@ -44,8 +44,6 @@ export class BuildIOSProgressProcessor implements BuildProgressProcessor {
     });
   }
 
-  
-
   private async countTasksToComplete() {
     try {
       let buildDescriptionPathReadStream = await this.openTasksStoreIfExists();


### PR DESCRIPTION
This PR fixes the build progress on ios that was broken for some time. It is difficult to pin point the exact reason for the issue, but it seems that the `xcodebuild` process is now updating the `task-store` in runtime which might cause corruption of its data. To side step the issue we just use the `taskCount` as is and not wait for all the tasks to be calculated. This is sub optimal as we might undercount the number of tasks performed by the build process, but still gives the user the general idea of the progress.

### How Has This Been Tested: 

- run `react-native-82` test app and clean build it 

### How Has This Change Been Documented:

internal


