### PR TITLE
feat: paywall messaging based on feature availability

### DIFF
--- a/packages/vscode-extension/src/webview/views/PaywallView.tsx
+++ b/packages/vscode-extension/src/webview/views/PaywallView.tsx
@@ -10,7 +10,12 @@ import { useProject } from "../providers/ProjectProvider";
 import { useStore } from "../providers/storeProvider";
 import { ActivateLicenseView } from "./ActivateLicenseView";
 import { useModal } from "../providers/ModalProvider";
-import { Feature, FeatureNamesMap, LicenseStatus } from "../../common/License";
+import {
+  Feature,
+  FeatureAvailabilityStatus,
+  FeatureNamesMap,
+  LicenseStatus,
+} from "../../common/License";
 
 import "./PaywallView.css";
 
@@ -249,15 +254,20 @@ function PaywallView({ title, feature }: PaywallViewProps) {
   const store$ = useStore();
 
   const licenseState = use$(store$.license.status);
+  const featuresAvailability = use$(store$.license.featuresAvailability);
 
   const isLicenseInactive = licenseState === LicenseStatus.Inactive;
+  const isFeaturePaywalled =
+    feature && featuresAvailability[feature] === FeatureAvailabilityStatus.PAYWALLED;
+
+  const showGetProMessage = isFeaturePaywalled || !isLicenseInactive;
 
   return (
     <div className="paywall-view">
       <RadonBackgroundImage className="paywall-background-image" />
       <div className="paywall-container">
         <h1 className="paywall-title">
-          {title ?? (isLicenseInactive ? "Get Radon IDE License" : "Unlock Radon IDE Pro")}
+          {title ?? (showGetProMessage ? "Unlock Radon IDE Pro" : "Get Radon IDE License")}
         </h1>
         {feature && (
           <p className="paywall-feature-description">
@@ -265,7 +275,7 @@ function PaywallView({ title, feature }: PaywallViewProps) {
           </p>
         )}
 
-        {isLicenseInactive ? <InactiveLicenseDescription /> : <FreeLicenseDescription />}
+        {showGetProMessage ? <FreeLicenseDescription /> : <InactiveLicenseDescription />}
 
         <ActivateLicenseButton />
       </div>


### PR DESCRIPTION
### Description

This PR changes it so the features tagged as `Pro` trigger a Paywall Modal that offers the options to buy the Pro License, instead of the one that enables user to get the free license.

### How Has This Been Tested: 

Launched the app, removed the license, verified that after 5 minutes the correct modal (_Get your free license_) is shown. Verified that, upon clicking a pro feature button, the _Get Radon IDE Pro_ modal is shown, no matter whether No license or Free license is registered.

### How Has This Change Been Documented:

Not applicable.

