### PR TITLE
feat: change pro feature messaging in Paywall

### DIFF
--- a/packages/vscode-extension/src/webview/views/PaywallView.css
+++ b/packages/vscode-extension/src/webview/views/PaywallView.css
@@ -11,14 +11,23 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 100%;
+  min-height: fit-content;
 }
 
 .paywall-container {
   max-width: 400px;
   width: 100%;
   height: 100%;
+  min-height: fit-content;
+
   text-align: center;
   padding: 25px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .paywall-title {


### PR DESCRIPTION
### Description

This PR changes how we signal the Pro Features to the user via the paywall modal and removes pricing from the message itself.

Changes made:
- if the user does not have a license, upon modal activation (either by clicking a Pro feature or having extension open for 5 minutes) the paywall shown is as follows:
  - the Pro features are now shown first, then Free features
  - the text on the _Get Your Free License_ button has been changed to _Get Your License_

- if the user does have a license, the paywall now looks as follows:
  - the pricing information has been removed
  - the button text has been changed to "Start Free 14-days Pro Trial"

In both cases, styling changes have been made to make the buttons float to the bottom of the screen if there is sufficient space.

### How Has This Been Tested: 

- Launched the app, removed the license, verified that, upon clicking a pro feature button proper modal is shown.
- After that, activated the license and confirmed that upon clicking Pro feature the modal changes to the one described above

### How Has This Change Been Documented:

Not applicable.

