### PR TITLE
fix: Apollo Client v4 detection fails

### DIFF
--- a/packages/vscode-extension/lib/babel_transformer.js
+++ b/packages/vscode-extension/lib/babel_transformer.js
@@ -187,6 +187,10 @@ function transformWrapper({ filename, src, ...rest }) {
       src = `module.exports = require("__RNIDE_lib__/JSXRuntime/react-native-78-79/${jsxRuntimeFileName}");`;
     }
   } else if (
+    // Apollo Client v4
+    isTransforming("node_modules/@apollo/client/core/index") ||
+    isTransforming("node_modules/@apollo/client/__cjs/core/index") ||
+    // Apollo Client v3
     isTransforming("node_modules/@apollo/client/index") ||
     isTransforming("node_modules/@apollo/client/main") ||
     isTransforming("node_modules/@apollo/client/apollo-client")


### PR DESCRIPTION
In version 4.0 the `@apollo/client`'s entry file changed from `index.js` to `core/index.js`.
We need to adjust the babel transform accordingly to detect the new entry file.

### How Has This Been Tested: 
(PR with test cases: https://github.com/software-mansion-labs/radon-ide-test-apps/pull/44)
- run `expo-52-prebuild-with-plugins` (which uses Apollo Client v3)
- verify apollo client plugin works
- run `expo-54-prebuild-with-plugins` (which uses Apollo Client v4)
- verify apollo client plugin works

### How Has This Change Been Documented:
Bugfix


