### PR TITLE
chore: early access to new features

### DIFF
--- a/packages/docs/src/components/Pricing/PricingCard/index.tsx
+++ b/packages/docs/src/components/Pricing/PricingCard/index.tsx
@@ -45,7 +45,7 @@ function PricingCard({ planData, isMonthly, href, onButtonClick, children }: Pri
         </div>
         {featuresSupport && (
           <div className={styles.cardFeatures}>
-            <p>Support</p>
+            <p>Support & Updates</p>
             <PricingFeaturesList featuresList={featuresSupport} />
           </div>
         )}

--- a/packages/docs/src/components/Pricing/pricingIndividualData.tsx
+++ b/packages/docs/src/components/Pricing/pricingIndividualData.tsx
@@ -44,6 +44,7 @@ export const pricingIndividualData: PricingPlanCardProps[] = [
       { label: "Storybook integration" },
       { label: "Maestro testing integration" },
       { label: "Radon AI assistant" },
+      { label: "Early access to new features" },
       { label: "Priority support via email" },
     ],
   },

--- a/packages/docs/src/components/Pricing/pricingOrganizationsData.tsx
+++ b/packages/docs/src/components/Pricing/pricingOrganizationsData.tsx
@@ -33,7 +33,10 @@ export const pricingOrganizationsData: PricingPlanCardProps[] = [
       { label: "Centralized team billing" },
       { label: "Insights Dashboard with usage stats" },
     ],
-    featuresSupport: [{ label: "Priority support via email" }],
+    featuresSupport: [
+      { label: "Early access to new features" },
+      { label: "Priority support via email" },
+    ],
   },
   {
     plan: "ENTERPRISE",


### PR DESCRIPTION
This PR reverts changes introduced in https://github.com/software-mansion/radon-ide/pull/1895 related to "Early access to new features". 

Explanation: Radon publishes nightly releases that allow to use features before they are released in stable channel.