### PR TITLE
chore: bump minimal supported VSCode / Cursor versions

### DIFF
--- a/packages/docs/docs/getting-started/compatibility.md
+++ b/packages/docs/docs/getting-started/compatibility.md
@@ -14,7 +14,7 @@ In a such case, you can still Radon IDE but we also recommend [submitting an iss
 
 ## Supported editors
 
-Radon IDE works with [Visual Studio Code](https://code.visualstudio.com/) 1.86 or higher and [Cursor](https://www.cursor.com/) 0.32 or higher.
+Radon IDE works with [Visual Studio Code](https://code.visualstudio.com/) 1.90.0 or higher and [Cursor](https://www.cursor.com/) 0.40.0 or higher.
 
 ## Supported project setups
 


### PR DESCRIPTION
Bumps minimum supported VSCode and Cursor version in the documentation to match reality.
The minimum supported version for VSCode was verified via automatic testing, and the Cursor version was chosen to match it:

| Cursor Version | Base VS Code Version |
| :--- | :--- |
| **0.38.x** | **1.89.1** |
| **0.39.x** | **1.89.1** |
| **0.40.x** | **1.91.1** |
| **0.41.x** | **1.91.1** |
| **0.42.x** | **1.93.1** |
| **0.43.x** | **1.93.1** |
| **0.44.x** | **1.93.1** |