### PR TITLE
fix: add `scroll-padding-top`

### DIFF
--- a/packages/docs/src/components/Changelog/styles.module.css
+++ b/packages/docs/src/components/Changelog/styles.module.css
@@ -1,3 +1,13 @@
+html:has(.changelogContainer) {
+  scroll-padding-top: 7rem;
+}
+
+@media (min-width: 64rem) {
+  html:has(.changelogContainer) {
+    scroll-padding-top: 7.625rem;
+  }
+}
+
 .changelogContainer {
   padding: 32px;
   max-width: 1300px;

--- a/packages/docs/src/components/Changelog/styles.module.css
+++ b/packages/docs/src/components/Changelog/styles.module.css
@@ -1,5 +1,5 @@
 html:has(.changelogContainer) {
-  scroll-padding-top: 7rem;
+  scroll-padding-top: 6.5rem;
 }
 
 @media (min-width: 64rem) {

--- a/packages/docs/src/css/overrides.css
+++ b/packages/docs/src/css/overrides.css
@@ -6,6 +6,17 @@
   --swm-sidebar-actual-width: min(var(--doc-sidebar-width), 250px);
 }
 
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 2rem;
+}
+
+@media (min-width: 64rem) {
+  html {
+    scroll-padding-top: 2.5rem;
+  }
+}
+
 table {
   display: table;
   width: 100%;


### PR DESCRIPTION
This pull request adds `scroll-padding-top` to the `<html>` element so anchor-link jumps land below the sticky navbar instead of hiding the section heading underneath it and enables `scroll-behavior: smooth`.

### How has this been tested

Verified that the changes are applied locally.