### PR TITLE
ci: add close when stale github action

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,34 @@
+name: Check for stale issues
+on:
+  schedule:
+    - cron: '37 21 * * *'
+  issues:
+    types: [edited]
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+
+jobs:
+   main:
+    if: github.repository == 'software-mansion/radon-ide'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: 'software-mansion-labs/swmansion-bot'
+          ref: stable
+
+      - uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Actions
+        run: yarn install
+
+      - name: Close when stale
+        uses: ./close-when-stale
+        with:
+          close-when-stale-label: 'close when stale'
+          days-to-close: 14


### PR DESCRIPTION
This pull request adds `close-when-stale` action from [software-mansion-labs/swmansion-bot](https://github.com/software-mansion-labs/swmansion-bot).



