### PR TITLE
add json-ld and llms.txt for the docs site

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -13,7 +13,7 @@ const config = {
   title: "Radon – the Best IDE for React Native & Expo",
   favicon: "img/favicon.png",
 
-  url: "https://ide.swmansion.com",
+  url: "https://radon.swmansion.com",
 
   baseUrl: "/",
 

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -57,7 +57,7 @@ const config = {
       }),
     ],
   ],
-  plugins: ["./src/plugins/changelog"],
+  plugins: ["./src/plugins/changelog", "./src/plugins/swm-geo"],
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/packages/docs/src/plugins/swm-geo.js
+++ b/packages/docs/src/plugins/swm-geo.js
@@ -1,0 +1,162 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ORGANIZATION_ID = "https://swmansion.com/#organization";
+const SECTION_NAMES = { docs: "Documentation" };
+const ACRONYMS = { api: "API", ui: "UI" };
+
+const titleCase = (segment) =>
+  segment
+    .split(/[-_]/)
+    .map((word) => ACRONYMS[word] ?? word.replace(/^./, (c) => c.toUpperCase()))
+    .join(" ");
+
+const sectionOf = (relative) => {
+  const parts = relative.split("/").filter(Boolean);
+  if (SECTION_NAMES[parts[0]]) return SECTION_NAMES[parts[0]];
+  if (parts.length < 2) return "Pages";
+  return titleCase(parts[0]);
+};
+
+const decode = (value) =>
+  value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const metaOf = (html, name) =>
+  new RegExp(`<meta[^>]+name="${escapeRegExp(name)}"[^>]+content="([^"]*)"`, "i").exec(html)?.[1] ??
+  "";
+
+function describe(html, siteTitle) {
+  const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+  const title = decode(raw).replace(new RegExp(`\\s*\\|\\s*${escapeRegExp(siteTitle)}$`), "");
+  return { title, description: decode(metaOf(html, "description")) };
+}
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+function buildStructuredData(siteConfig) {
+  const { organizationName, projectName, tagline, title } = siteConfig;
+  const repository =
+    organizationName && projectName
+      ? `https://github.com/${organizationName}/${projectName}`
+      : undefined;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": ORGANIZATION_ID,
+        "name": "Software Mansion",
+        "url": "https://swmansion.com",
+        "sameAs": [
+          "https://github.com/software-mansion",
+          "https://www.linkedin.com/company/software-mansion/",
+          "https://twitter.com/swmansion",
+          "https://www.youtube.com/c/SoftwareMansion",
+        ],
+      },
+      {
+        "@type": "SoftwareSourceCode",
+        "name": title,
+        ...(tagline ? { description: tagline } : {}),
+        ...(repository ? { codeRepository: repository } : {}),
+        "author": { "@id": ORGANIZATION_ID },
+        "maintainer": { "@id": ORGANIZATION_ID },
+      },
+    ],
+  };
+}
+
+function buildLlmsTxt({ siteConfig, routesPaths, readPage }) {
+  const { baseUrl, title, tagline, url } = siteConfig;
+  const grouped = new Map();
+
+  for (const route of routesPaths) {
+    if (!route.startsWith(baseUrl) || route.endsWith("404.html")) continue;
+
+    const relative = route.slice(baseUrl.length);
+    const html = readPage(relative);
+    if (!html) continue;
+
+    const page = describe(html, title);
+    if (!page.title) continue;
+
+    const section = sectionOf(relative);
+    const line = `- [${page.title}](${url.replace(/\/$/, "")}${route})${page.description ? `: ${page.description}` : ""}`;
+
+    if (!grouped.has(section)) grouped.set(section, []);
+    grouped.get(section).push(line);
+  }
+
+  const lines = [`# ${title}`];
+  if (tagline) lines.push("", `> ${tagline}`);
+
+  // Documentation first, the rest alphabetically, loose pages last.
+  const order = [
+    ...(grouped.has("Documentation") ? ["Documentation"] : []),
+    ...[...grouped.keys()]
+      .filter((section) => section !== "Documentation" && section !== "Pages")
+      .sort(),
+    ...(grouped.has("Pages") ? ["Pages"] : []),
+  ];
+
+  for (const section of order) {
+    const entries = grouped.get(section);
+    if (!entries?.length) continue;
+    lines.push("", `## ${section}`, "", ...entries.sort());
+  }
+
+  lines.push(
+    "",
+    "## About",
+    "",
+    `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
+    ""
+  );
+
+  return lines.join("\n");
+}
+
+module.exports = function swmGeoPlugin(context) {
+  return {
+    name: "swm-geo",
+
+    injectHtmlTags() {
+      return {
+        headTags: [
+          {
+            tagName: "script",
+            attributes: { type: "application/ld+json" },
+            innerHTML: JSON.stringify(buildStructuredData(context.siteConfig)).replace(
+              /</g,
+              "\\u003c"
+            ),
+          },
+        ],
+      };
+    },
+
+    async postBuild({ siteConfig, routesPaths, outDir }) {
+      const readPage = (relative) => {
+        const file = path.join(outDir, relative, "index.html");
+        return fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+      };
+
+      await fs.promises.writeFile(
+        path.join(outDir, "llms.txt"),
+        buildLlmsTxt({ siteConfig, routesPaths, readPage }),
+        "utf8"
+      );
+    },
+  };
+};
+
+module.exports.buildLlmsTxt = buildLlmsTxt;
+module.exports.buildStructuredData = buildStructuredData;


### PR DESCRIPTION
radon.swmansion.com serves no llms.txt and no structured data.

- **json-ld** via a local plugin: `Organization` with the same `@id` as swmansion.com plus `SoftwareSourceCode` for radon, so the docs and the company site read as one entity rather than two unrelated ones
- **llms.txt** generated at build from the built pages — no new dependency

no robots.txt here on purpose: this site is its own origin and its robots would have to live at the root, which is a separate concern from this plugin.

**second commit, review separately:** `url` was `https://ide.swmansion.com`, which 301s to `radon.swmansion.com`. every absolute url docusaurus generates follows it, so `sitemap.xml` currently lists redirects instead of destinations — you can see it at https://radon.swmansion.com/sitemap.xml. drop the commit if the old host is meant to stay canonical.

check: `build/llms.txt` after a docs build, and the `application/ld+json` block in page source.